### PR TITLE
feat: implement sep-24 interactive withdraw endpoint

### DIFF
--- a/backend/src/api/controllers/sep24.controller.test.ts
+++ b/backend/src/api/controllers/sep24.controller.test.ts
@@ -1,0 +1,125 @@
+import { Request, Response } from 'express';
+import { depositInteractive, withdrawInteractive } from './sep24.controller';
+
+describe('SEP-24 Controller', () => {
+  let mockRequest: Partial<Request>;
+  let mockResponse: Partial<Response>;
+  let jsonMock: jest.Mock;
+  let statusMock: jest.Mock;
+
+  beforeEach(() => {
+    jsonMock = jest.fn();
+    statusMock = jest.fn().mockReturnValue({ json: jsonMock });
+    
+    mockRequest = {
+      body: {}
+    };
+    
+    mockResponse = {
+      json: jsonMock,
+      status: statusMock
+    };
+  });
+
+  describe('depositInteractive', () => {
+    it('should return error when asset_code is missing', () => {
+      mockRequest.body = {};
+
+      depositInteractive(mockRequest as Request, mockResponse as Response);
+
+      expect(statusMock).toHaveBeenCalledWith(400);
+      expect(jsonMock).toHaveBeenCalledWith({
+        error: 'asset_code is required'
+      });
+    });
+
+    it('should return error for unsupported asset', () => {
+      mockRequest.body = { asset_code: 'INVALID' };
+
+      depositInteractive(mockRequest as Request, mockResponse as Response);
+
+      expect(statusMock).toHaveBeenCalledWith(400);
+      expect(jsonMock).toHaveBeenCalledWith({
+        error: 'Asset INVALID is not supported. Supported assets: USDC, USD, BTC, ETH'
+      });
+    });
+
+    it('should return interactive response for valid deposit request', () => {
+      mockRequest.body = {
+        asset_code: 'USDC',
+        account: 'GTEST123',
+        amount: '100',
+        lang: 'en'
+      };
+
+      depositInteractive(mockRequest as Request, mockResponse as Response);
+
+      expect(jsonMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'interactive_customer_info_needed',
+          url: expect.stringContaining('/kyc-deposit'),
+          id: expect.any(String)
+        })
+      );
+    });
+  });
+
+  describe('withdrawInteractive', () => {
+    it('should return error when asset_code is missing', () => {
+      mockRequest.body = {};
+
+      withdrawInteractive(mockRequest as Request, mockResponse as Response);
+
+      expect(statusMock).toHaveBeenCalledWith(400);
+      expect(jsonMock).toHaveBeenCalledWith({
+        error: 'asset_code is required'
+      });
+    });
+
+    it('should return error for unsupported asset', () => {
+      mockRequest.body = { asset_code: 'INVALID' };
+
+      withdrawInteractive(mockRequest as Request, mockResponse as Response);
+
+      expect(statusMock).toHaveBeenCalledWith(400);
+      expect(jsonMock).toHaveBeenCalledWith({
+        error: 'Asset INVALID is not supported. Supported assets: USDC, USD, BTC, ETH'
+      });
+    });
+
+    it('should return interactive response for valid withdraw request', () => {
+      mockRequest.body = {
+        asset_code: 'USDC',
+        account: 'GTEST123',
+        amount: '100',
+        dest: 'bank_account',
+        dest_extra: 'routing_number',
+        lang: 'en'
+      };
+
+      withdrawInteractive(mockRequest as Request, mockResponse as Response);
+
+      expect(jsonMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'interactive_customer_info_needed',
+          url: expect.stringContaining('/kyc-withdraw'),
+          id: expect.any(String)
+        })
+      );
+    });
+
+    it('should include withdrawal-specific parameters in URL', () => {
+      mockRequest.body = {
+        asset_code: 'USDC',
+        dest: 'bank_account',
+        dest_extra: 'routing_123'
+      };
+
+      withdrawInteractive(mockRequest as Request, mockResponse as Response);
+
+      const response = jsonMock.mock.calls[0][0];
+      expect(response.url).toContain('dest=bank_account');
+      expect(response.url).toContain('dest_extra=routing_123');
+    });
+  });
+});

--- a/backend/src/api/controllers/sep24.controller.ts
+++ b/backend/src/api/controllers/sep24.controller.ts
@@ -1,0 +1,117 @@
+import { Request, Response } from 'express';
+import { randomUUID } from 'crypto';
+
+// Supported assets for SEP-24 transactions
+const SUPPORTED_ASSETS = ['USDC', 'USD', 'BTC', 'ETH'];
+
+interface DepositRequest {
+  asset_code: string;
+  account?: string;
+  amount?: string;
+  lang?: string;
+}
+
+interface WithdrawRequest {
+  asset_code: string;
+  account?: string;
+  amount?: string;
+  lang?: string;
+  dest?: string;
+  dest_extra?: string;
+}
+
+interface InteractiveResponse {
+  type: 'interactive_customer_info_needed';
+  url: string;
+  id: string;
+}
+
+/**
+ * POST /transactions/deposit/interactive
+ * SEP-24 Interactive Deposit Endpoint
+ * Returns a URL for the user to complete KYC/Deposit
+ */
+export const depositInteractive = (req: Request, res: Response): Response => {
+  const { asset_code, account, amount, lang = 'en' }: DepositRequest = req.body;
+
+  // Validate required fields
+  if (!asset_code) {
+    return res.status(400).json({
+      error: 'asset_code is required'
+    });
+  }
+
+  // Validate asset
+  if (!SUPPORTED_ASSETS.includes(asset_code.toUpperCase())) {
+    return res.status(400).json({
+      error: `Asset ${asset_code} is not supported. Supported assets: ${SUPPORTED_ASSETS.join(', ')}`
+    });
+  }
+
+  // Generate unique transaction ID
+  const transactionId = randomUUID();
+
+  // Build redirect URL with transaction parameters
+  const baseUrl = process.env.INTERACTIVE_URL || 'http://localhost:3000';
+  const redirectUrl = new URL('/kyc-deposit', baseUrl);
+  redirectUrl.searchParams.append('transaction_id', transactionId);
+  redirectUrl.searchParams.append('asset_code', asset_code);
+  if (account) redirectUrl.searchParams.append('account', account);
+  if (amount) redirectUrl.searchParams.append('amount', amount);
+  redirectUrl.searchParams.append('lang', lang);
+
+  // Return interactive response
+  const response: InteractiveResponse = {
+    type: 'interactive_customer_info_needed',
+    url: redirectUrl.toString(),
+    id: transactionId
+  };
+
+  return res.json(response);
+};
+
+/**
+ * POST /transactions/withdraw/interactive
+ * SEP-24 Interactive Withdraw Endpoint
+ * Returns a URL for the user to complete KYC/Withdrawal
+ */
+export const withdrawInteractive = (req: Request, res: Response): Response => {
+  const { asset_code, account, amount, lang = 'en', dest, dest_extra }: WithdrawRequest = req.body;
+
+  // Validate required fields
+  if (!asset_code) {
+    return res.status(400).json({
+      error: 'asset_code is required'
+    });
+  }
+
+  // Validate asset
+  if (!SUPPORTED_ASSETS.includes(asset_code.toUpperCase())) {
+    return res.status(400).json({
+      error: `Asset ${asset_code} is not supported. Supported assets: ${SUPPORTED_ASSETS.join(', ')}`
+    });
+  }
+
+  // Generate unique transaction ID
+  const transactionId = randomUUID();
+
+  // Build redirect URL with transaction parameters
+  const baseUrl = process.env.INTERACTIVE_URL || 'http://localhost:3000';
+  const redirectUrl = new URL('/kyc-withdraw', baseUrl);
+  redirectUrl.searchParams.append('transaction_id', transactionId);
+  redirectUrl.searchParams.append('asset_code', asset_code);
+  if (account) redirectUrl.searchParams.append('account', account);
+  if (amount) redirectUrl.searchParams.append('amount', amount);
+  if (dest) redirectUrl.searchParams.append('dest', dest);
+  if (dest_extra) redirectUrl.searchParams.append('dest_extra', dest_extra);
+  redirectUrl.searchParams.append('lang', lang);
+
+  // Return interactive response
+  const response: InteractiveResponse = {
+    type: 'interactive_customer_info_needed',
+    url: redirectUrl.toString(),
+    id: transactionId
+  };
+
+  return res.json(response);
+};

--- a/backend/src/api/routes/sep24.route.ts
+++ b/backend/src/api/routes/sep24.route.ts
@@ -1,66 +1,18 @@
-import { Router, Request, Response } from 'express';
-import { randomUUID } from 'crypto';
+import { Router } from 'express';
+import { depositInteractive, withdrawInteractive } from '../controllers/sep24.controller';
 
 const router = Router();
-
-// Supported assets for deposit
-const SUPPORTED_ASSETS = ['USDC', 'USD', 'BTC', 'ETH'];
-
-interface DepositRequest {
-  asset_code: string;
-  account?: string;
-  amount?: string;
-  lang?: string;
-}
-
-interface DepositResponse {
-  type: 'interactive_customer_info_needed';
-  url: string;
-  id: string;
-}
 
 /**
  * POST /transactions/deposit/interactive
  * SEP-24 Interactive Deposit Endpoint
- * Returns a URL for the user to complete KYC/Deposit
  */
-router.post('/transactions/deposit/interactive', (req: Request, res: Response) => {
-  const { asset_code, account, amount, lang = 'en' }: DepositRequest = req.body;
+router.post('/transactions/deposit/interactive', depositInteractive);
 
-  // Validate required fields
-  if (!asset_code) {
-    return res.status(400).json({
-      error: 'asset_code is required'
-    });
-  }
-
-  // Validate asset
-  if (!SUPPORTED_ASSETS.includes(asset_code.toUpperCase())) {
-    return res.status(400).json({
-      error: `Asset ${asset_code} is not supported. Supported assets: ${SUPPORTED_ASSETS.join(', ')}`
-    });
-  }
-
-  // Generate unique transaction ID
-  const transactionId = randomUUID();
-
-  // Build redirect URL with transaction parameters
-  const baseUrl = process.env.INTERACTIVE_URL || 'http://localhost:3000';
-  const redirectUrl = new URL('/kyc-deposit', baseUrl);
-  redirectUrl.searchParams.append('transaction_id', transactionId);
-  redirectUrl.searchParams.append('asset_code', asset_code);
-  if (account) redirectUrl.searchParams.append('account', account);
-  if (amount) redirectUrl.searchParams.append('amount', amount);
-  redirectUrl.searchParams.append('lang', lang);
-
-  // Return interactive response
-  const response: DepositResponse = {
-    type: 'interactive_customer_info_needed',
-    url: redirectUrl.toString(),
-    id: transactionId
-  };
-
-  res.json(response);
-});
+/**
+ * POST /transactions/withdraw/interactive
+ * SEP-24 Interactive Withdraw Endpoint
+ */
+router.post('/transactions/withdraw/interactive', withdrawInteractive);
 
 export default router;

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -3,6 +3,7 @@ import cors from 'cors';
 import dotenv from 'dotenv';
 import logger from './utils/logger';
 import transactionsRouter from './api/routes/transactions.route';
+import sep24Router from './api/routes/sep24.route';
 
 dotenv.config();
 


### PR DESCRIPTION
## feat: implement sep-24 interactive withdraw endpoint

### Changes
- Created `sep24.controller.ts` with `depositInteractive` and `withdrawInteractive` functions
- Refactored existing deposit logic from route to controller
- Added `/transactions/withdraw/interactive` endpoint for SEP-24 withdrawals
- Updated `sep24.route.ts` to use controller functions
- Added comprehensive unit tests for both endpoints
- Fixed missing import in `index.ts`

### Implementation Details
The withdraw endpoint follows the same pattern as deposit:
- Validates `asset_code` (required)
- Supports USDC, USD, BTC, ETH
- Generates unique transaction ID
- Returns interactive URL for KYC/withdrawal flow
- Includes withdrawal-specific parameters: `dest`, `dest_extra`

### Testing
Added tests covering:
- Missing required fields validation
- Unsupported asset validation
- Successful response generation
- URL parameter inclusion

close #7