### PR TITLE
eat(contract) #154 : add global emergency pause mechanism via SecurityRegistry

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,9 @@ members = [
     "src/flash_loan",
     "src/kyc",
     "src/staking",
-    "src/escrow_timelock"
+    "src/security_registry",
+    "src/escrow_timelock",
+    "src/vesting"
 ]
 resolver = "2"
 

--- a/backend/src/api/controllers/info.controller.test.ts
+++ b/backend/src/api/controllers/info.controller.test.ts
@@ -1,0 +1,248 @@
+import { Request, Response } from 'express';
+import { getInfo } from './info.controller';
+import { ASSETS } from '../../config/assets';
+
+jest.mock('../../config/assets', () => ({
+  ASSETS: [
+    {
+      code: 'USDC',
+      issuer: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+      type: 'credit_alphanum4',
+      desc: 'USD Coin',
+      minAmount: '0.01',
+      maxAmount: '100000',
+      feeFixed: 0.1,
+      feePercent: 0.001,
+      feeMinimum: 0.01,
+      depositEnabled: true,
+      withdrawEnabled: true
+    },
+    {
+      code: 'XLM',
+      type: 'native',
+      desc: 'Stellar Lumens',
+      minAmount: '1',
+      maxAmount: '1000000',
+      feeFixed: 0,
+      feePercent: 0,
+      feeMinimum: 0,
+      depositEnabled: true,
+      withdrawEnabled: false
+    }
+  ]
+}));
+
+describe('Info Controller', () => {
+  let mockRequest: Partial<Request>;
+  let mockResponse: Partial<Response>;
+  let jsonMock: jest.Mock;
+  let sendMock: jest.Mock;
+  let setHeaderMock: jest.Mock;
+
+  beforeEach(() => {
+    jsonMock = jest.fn().mockReturnValue(mockResponse);
+    sendMock = jest.fn().mockReturnValue(mockResponse);
+    setHeaderMock = jest.fn().mockReturnValue(mockResponse);
+
+    mockRequest = {
+      query: {},
+      headers: {}
+    };
+
+    mockResponse = {
+      json: jsonMock,
+      send: sendMock,
+      setHeader: setHeaderMock
+    } as any;
+
+    jest.clearAllMocks();
+    process.env.STELLAR_NETWORK = 'testnet';
+    process.env.BASE_URL = 'http://localhost:3002';
+  });
+
+  describe('getInfo - JSON format', () => {
+    it('should return info in JSON format by default', () => {
+      mockRequest.query = {};
+      mockRequest.headers = {};
+
+      getInfo(mockRequest as Request, mockResponse as Response);
+
+      expect(jsonMock).toHaveBeenCalled();
+      const response = jsonMock.mock.calls[0][0];
+      expect(response).toHaveProperty('version');
+      expect(response).toHaveProperty('network', 'testnet');
+      expect(response).toHaveProperty('assets');
+    });
+
+    it('should return JSON when Accept header includes application/json', () => {
+      mockRequest.query = {};
+      mockRequest.headers = { accept: 'application/json' };
+
+      getInfo(mockRequest as Request, mockResponse as Response);
+
+      expect(jsonMock).toHaveBeenCalled();
+    });
+
+    it('should include all assets in the response', () => {
+      getInfo(mockRequest as Request, mockResponse as Response);
+
+      const response = jsonMock.mock.calls[0][0];
+      expect(response.assets).toHaveLength(2);
+      expect(response.assets[0].code).toBe('USDC');
+      expect(response.assets[1].code).toBe('XLM');
+    });
+
+    it('should include asset details with correct properties', () => {
+      getInfo(mockRequest as Request, mockResponse as Response);
+
+      const response = jsonMock.mock.calls[0][0];
+      const usdcAsset = response.assets.find((a: any) => a.code === 'USDC');
+      expect(usdcAsset).toHaveProperty('issuer');
+      expect(usdcAsset).toHaveProperty('status', 'live');
+      expect(usdcAsset).toHaveProperty('is_asset_anchored', true);
+      expect(usdcAsset).toHaveProperty('desc', 'USD Coin');
+      expect(usdcAsset).toHaveProperty('max_amount', '100000');
+      expect(usdcAsset).toHaveProperty('min_amount', '0.01');
+      expect(usdcAsset).toHaveProperty('fee_fixed', 0.1);
+      expect(usdcAsset).toHaveProperty('fee_percent', 0.001);
+    });
+
+    it('should include fee variations for deposit and withdraw', () => {
+      getInfo(mockRequest as Request, mockResponse as Response);
+
+      const response = jsonMock.mock.calls[0][0];
+      expect(response).toHaveProperty('fee_variations');
+      expect(response.fee_variations).toHaveProperty('deposit');
+      expect(response.fee_variations).toHaveProperty('withdraw');
+    });
+
+    it('should include only assets that support deposit in fee_variations.deposit', () => {
+      getInfo(mockRequest as Request, mockResponse as Response);
+
+      const response = jsonMock.mock.calls[0][0];
+      expect(response.fee_variations.deposit).toHaveProperty('USDC');
+      expect(response.fee_variations.deposit).toHaveProperty('XLM');
+    });
+
+    it('should include only assets that support withdraw in fee_variations.withdraw', () => {
+      getInfo(mockRequest as Request, mockResponse as Response);
+
+      const response = jsonMock.mock.calls[0][0];
+      expect(response.fee_variations.withdraw).toHaveProperty('USDC');
+      expect(response.fee_variations.withdraw).not.toHaveProperty('XLM');
+    });
+
+    it('should include accounts information', () => {
+      getInfo(mockRequest as Request, mockResponse as Response);
+
+      const response = jsonMock.mock.calls[0][0];
+      expect(response.accounts).toHaveProperty('receiving');
+    });
+
+    it('should use environment variables for server URLs', () => {
+      process.env.AUTH_SERVER = 'https://auth.example.com';
+      process.env.TRANSFER_SERVER = 'https://transfer.example.com';
+
+      getInfo(mockRequest as Request, mockResponse as Response);
+
+      const response = jsonMock.mock.calls[0][0];
+      expect(response.auth_server).toBe('https://auth.example.com');
+      expect(response.transfer_server).toBe('https://transfer.example.com');
+    });
+  });
+
+  describe('getInfo - TOML format', () => {
+    it('should return TOML when format=toml query parameter is set', () => {
+      mockRequest.query = { format: 'toml' };
+
+      getInfo(mockRequest as Request, mockResponse as Response);
+
+      expect(setHeaderMock).toHaveBeenCalledWith('Content-Type', 'text/toml');
+      expect(sendMock).toHaveBeenCalled();
+    });
+
+    it('should return TOML when Accept header includes text/toml', () => {
+      mockRequest.headers = { accept: 'text/toml' };
+
+      getInfo(mockRequest as Request, mockResponse as Response);
+
+      expect(setHeaderMock).toHaveBeenCalledWith('Content-Type', 'text/toml');
+      expect(sendMock).toHaveBeenCalled();
+    });
+
+    it('should include required fields in TOML output', () => {
+      mockRequest.query = { format: 'toml' };
+
+      getInfo(mockRequest as Request, mockResponse as Response);
+
+      const tomlOutput = sendMock.mock.calls[0][0];
+      expect(tomlOutput).toContain('version =');
+      expect(tomlOutput).toContain('network = "testnet"');
+      expect(tomlOutput).toContain('signing_key =');
+      expect(tomlOutput).toContain('horizon_url =');
+      expect(tomlOutput).toContain('url = "http://localhost:3002"');
+    });
+
+    it('should include accounts section in TOML output', () => {
+      mockRequest.query = { format: 'toml' };
+
+      getInfo(mockRequest as Request, mockResponse as Response);
+
+      const tomlOutput = sendMock.mock.calls[0][0];
+      expect(tomlOutput).toContain('[accounts]');
+      expect(tomlOutput).toContain('receiving =');
+    });
+
+    it('should include assets section in TOML output', () => {
+      mockRequest.query = { format: 'toml' };
+
+      getInfo(mockRequest as Request, mockResponse as Response);
+
+      const tomlOutput = sendMock.mock.calls[0][0];
+      expect(tomlOutput).toContain('[[assets]]');
+      expect(tomlOutput).toContain('code = "USDC"');
+      expect(tomlOutput).toContain('code = "XLM"');
+    });
+
+    it('should include fee variations section in TOML output', () => {
+      mockRequest.query = { format: 'toml' };
+
+      getInfo(mockRequest as Request, mockResponse as Response);
+
+      const tomlOutput = sendMock.mock.calls[0][0];
+      expect(tomlOutput).toContain('[fee_variations.deposit]');
+      expect(tomlOutput).toContain('[fee_variations.withdraw]');
+    });
+  });
+
+  describe('getInfo - environment variables', () => {
+    it('should use default values when environment variables are not set', () => {
+      delete process.env.AUTH_SERVER;
+      delete process.env.FEDERATION_SERVER;
+
+      getInfo(mockRequest as Request, mockResponse as Response);
+
+      const response = jsonMock.mock.calls[0][0];
+      expect(response.horizon_url).toBeDefined();
+      expect(response.signing_key).toBeDefined();
+    });
+
+    it('should filter out undefined optional fields', () => {
+      delete process.env.FEDERATION_SERVER;
+
+      getInfo(mockRequest as Request, mockResponse as Response);
+
+      const response = jsonMock.mock.calls[0][0];
+      expect(response.federation_server).toBeUndefined();
+    });
+
+    it('should use TRANSFER_SERVER_SEP24 environment variable or construct default', () => {
+      process.env.TRANSFER_SERVER_SEP24 = 'https://sep24.example.com';
+
+      getInfo(mockRequest as Request, mockResponse as Response);
+
+      const response = jsonMock.mock.calls[0][0];
+      expect(response.transfer_server_sep24).toBe('https://sep24.example.com');
+    });
+  });
+});

--- a/backend/src/api/controllers/sep38.controller.test.ts
+++ b/backend/src/api/controllers/sep38.controller.test.ts
@@ -1,0 +1,241 @@
+import { sep38Controller } from './sep38.controller';
+
+describe('SEP-38 Controller', () => {
+  beforeEach(() => {
+    // Reset mock prices to known state before each test
+    sep38Controller.updateMockPrice('XLM', 0.12);
+    sep38Controller.updateMockPrice('USDC', 1.0);
+    sep38Controller.updateMockPrice('USDT', 1.0);
+    sep38Controller.updateMockPrice('BTC', 45000.0);
+    sep38Controller.updateMockPrice('ETH', 2500.0);
+  });
+
+  describe('getPriceQuote', () => {
+    it('should calculate correct price quote for USDC to XLM', async () => {
+      const quote = await sep38Controller.getPriceQuote('USDC', 100, 'XLM');
+
+      expect(quote.source_asset).toBe('USDC');
+      expect(quote.source_amount).toBe(100);
+      expect(quote.destination_asset).toBe('XLM');
+      expect(quote.destination_amount).toBeCloseTo(833.33, 1);
+      expect(quote.price).toBeCloseTo(8.33, 1);
+    });
+
+    it('should calculate correct price quote for XLM to USDC', async () => {
+      const quote = await sep38Controller.getPriceQuote('XLM', 1000, 'USDC');
+
+      expect(quote.source_asset).toBe('XLM');
+      expect(quote.source_amount).toBe(1000);
+      expect(quote.destination_asset).toBe('USDC');
+      expect(quote.destination_amount).toBeCloseTo(120, 1);
+      expect(quote.price).toBeLessThan(1);
+    });
+
+    it('should handle same-asset quotes', async () => {
+      const quote = await sep38Controller.getPriceQuote('USDC', 100, 'USDC');
+
+      expect(quote.source_asset).toBe('USDC');
+      expect(quote.destination_asset).toBe('USDC');
+      expect(quote.destination_amount).toBe(100);
+      expect(quote.price).toBe(1);
+    });
+
+    it('should include expiration_time in quote', async () => {
+      const beforeQuote = Math.floor(Date.now() / 1000);
+      const quote = await sep38Controller.getPriceQuote('USDC', 100, 'XLM');
+      const afterQuote = Math.floor(Date.now() / 1000);
+
+      expect(quote.expiration_time).toBeDefined();
+      expect(quote.expiration_time).toBeGreaterThanOrEqual(beforeQuote + 60);
+      expect(quote.expiration_time).toBeLessThanOrEqual(afterQuote + 60);
+    });
+
+    it('should include context when provided', async () => {
+      const quote = await sep38Controller.getPriceQuote('USDC', 100, 'XLM', 'SEP-24');
+
+      expect(quote.context).toBe('SEP-24');
+    });
+
+    it('should omit context from quote when not provided', async () => {
+      const quote = await sep38Controller.getPriceQuote('USDC', 100, 'XLM');
+
+      expect(quote.context).toBeUndefined();
+    });
+
+    it('should handle decimal source amounts correctly', async () => {
+      const quote = await sep38Controller.getPriceQuote('USDC', 50.5, 'XLM');
+
+      expect(quote.source_amount).toBe(50.5);
+      expect(quote.destination_amount).toBeCloseTo(420.83, 1);
+    });
+
+    it('should throw error for unsupported source asset', async () => {
+      await expect(sep38Controller.getPriceQuote('INVALID', 100, 'USDC')).rejects.toThrow(
+        'Unsupported source asset'
+      );
+    });
+
+    it('should throw error for unsupported destination asset', async () => {
+      await expect(sep38Controller.getPriceQuote('USDC', 100, 'INVALID')).rejects.toThrow(
+        'Unsupported destination asset'
+      );
+    });
+
+    it('should be case-insensitive for asset codes', async () => {
+      const quote1 = await sep38Controller.getPriceQuote('usdc', 100, 'xlm');
+      const quote2 = await sep38Controller.getPriceQuote('USDC', 100, 'XLM');
+
+      expect(quote1.destination_amount).toBe(quote2.destination_amount);
+      expect(quote1.price).toBe(quote2.price);
+    });
+
+    it('should handle BTC to ETH conversion', async () => {
+      const quote = await sep38Controller.getPriceQuote('BTC', 1, 'ETH');
+
+      expect(quote.source_asset).toBe('BTC');
+      expect(quote.destination_asset).toBe('ETH');
+      expect(quote.destination_amount).toBeCloseTo(18, 0); // 45000 / 2500 = 18
+    });
+  });
+
+  describe('getSupportedAssets', () => {
+    it('should return list of supported assets', async () => {
+      const assets = await sep38Controller.getSupportedAssets();
+
+      expect(Array.isArray(assets)).toBe(true);
+      expect(assets.length).toBeGreaterThan(0);
+    });
+
+    it('should include XLM in supported assets', async () => {
+      const assets = await sep38Controller.getSupportedAssets();
+      const xlmAsset = assets.find(a => a.code === 'XLM');
+
+      expect(xlmAsset).toBeDefined();
+      expect(xlmAsset?.asset_type).toBe('native');
+    });
+
+    it('should include USDC in supported assets', async () => {
+      const assets = await sep38Controller.getSupportedAssets();
+      const usdcAsset = assets.find(a => a.code === 'USDC');
+
+      expect(usdcAsset).toBeDefined();
+      expect(usdcAsset?.asset_type).toBe('credit_alphanum4');
+      expect(usdcAsset?.issuer).toBeDefined();
+    });
+
+    it('should include asset details in each asset object', async () => {
+      const assets = await sep38Controller.getSupportedAssets();
+      const asset = assets[0];
+
+      expect(asset).toHaveProperty('code');
+      expect(asset).toHaveProperty('asset_type');
+      expect(asset).toHaveProperty('name');
+      expect(asset).toHaveProperty('decimals');
+      expect(asset).toHaveProperty('description');
+    });
+
+    it('should have decimals set to 7 for all assets', async () => {
+      const assets = await sep38Controller.getSupportedAssets();
+
+      assets.forEach(asset => {
+        expect(asset.decimals).toBe(7);
+      });
+    });
+  });
+
+  describe('addSupportedAsset', () => {
+    it('should add a new supported asset', async () => {
+      const newAsset = {
+        code: 'TEST',
+        asset_type: 'credit_alphanum4' as const,
+        name: 'Test Asset',
+        decimals: 7,
+        description: 'Test asset for unit testing',
+        issuer: 'GTEST123'
+      };
+
+      sep38Controller.addSupportedAsset(newAsset);
+      const assets = await sep38Controller.getSupportedAssets();
+      const addedAsset = assets.find(a => a.code === 'TEST');
+
+      expect(addedAsset).toBeDefined();
+      expect(addedAsset?.name).toBe('Test Asset');
+    });
+
+    it('should update existing asset when adding with same code and issuer', async () => {
+      const initialAssets = await sep38Controller.getSupportedAssets();
+      const xlmAsset = initialAssets.find(a => a.code === 'XLM');
+      
+      const updatedAsset = {
+        code: 'XLM',
+        asset_type: 'native' as const,
+        name: 'Updated Stellar Lumens',
+        decimals: 7,
+        description: 'Updated description'
+      };
+
+      sep38Controller.addSupportedAsset(updatedAsset);
+      const updatedAssets = await sep38Controller.getSupportedAssets();
+      const modifiedXlm = updatedAssets.find(a => a.code === 'XLM');
+
+      expect(modifiedXlm?.name).toBe('Updated Stellar Lumens');
+      expect(modifiedXlm?.description).toBe('Updated description');
+    });
+
+    it('should allow same asset code with different issuer', async () => {
+      const newAsset = {
+        code: 'USDC',
+        asset_type: 'credit_alphanum4' as const,
+        name: 'USDC (Alternative Issuer)',
+        decimals: 7,
+        issuer: 'GALTERNATIVE123'
+      };
+
+      sep38Controller.addSupportedAsset(newAsset);
+      const assets = await sep38Controller.getSupportedAssets();
+      const usdcAssets = assets.filter(a => a.code === 'USDC');
+
+      expect(usdcAssets.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe('updateMockPrice', () => {
+    it('should update price for existing asset', async () => {
+      sep38Controller.updateMockPrice('XLM', 0.25);
+      const quote = await sep38Controller.getPriceQuote('XLM', 100, 'USDC');
+
+      expect(quote.destination_amount).toBeCloseTo(25, 1);
+    });
+
+    it('should be case-insensitive when updating prices', async () => {
+      sep38Controller.updateMockPrice('xlm', 0.50);
+      const quote = await sep38Controller.getPriceQuote('XLM', 100, 'USDC');
+
+      expect(quote.destination_amount).toBeCloseTo(50, 1);
+    });
+
+    it('should allow adding price for new asset', async () => {
+      sep38Controller.updateMockPrice('NEWCOIN', 99.99);
+      const newAsset = {
+        code: 'NEWCOIN',
+        asset_type: 'credit_alphanum4' as const,
+        name: 'New Coin',
+        decimals: 7
+      };
+
+      sep38Controller.addSupportedAsset(newAsset);
+      const quote = await sep38Controller.getPriceQuote('USDC', 100, 'NEWCOIN');
+
+      expect(quote.destination_amount).toBeCloseTo(1, 0);
+    });
+
+    it('should affect future price calculations', async () => {
+      const originalQuote = await sep38Controller.getPriceQuote('USDC', 100, 'BTC');
+      
+      sep38Controller.updateMockPrice('BTC', 90000.0);
+      const newQuote = await sep38Controller.getPriceQuote('USDC', 100, 'BTC');
+
+      expect(newQuote.destination_amount).toBeLessThan(originalQuote.destination_amount);
+    });
+  });
+});

--- a/backend/src/api/controllers/sep6.controller.test.ts
+++ b/backend/src/api/controllers/sep6.controller.test.ts
@@ -1,0 +1,173 @@
+import { Response } from 'express';
+import { randomUUID } from 'crypto';
+import { AuthRequest } from '../middleware/auth.middleware';
+import * as sep6Controller from './sep6.controller';
+import * as kycService from '../../services/kyc.service';
+import prisma from '../../lib/prisma';
+import { ASSETS } from '../../config/assets';
+
+jest.mock('../../lib/prisma');
+jest.mock('../../services/kyc.service');
+jest.mock('crypto');
+
+describe('SEP-6 Controller', () => {
+  let mockRequest: Partial<AuthRequest>;
+  let mockResponse: Partial<Response>;
+  let jsonMock: jest.Mock;
+  let statusMock: jest.Mock;
+
+  beforeEach(() => {
+    jsonMock = jest.fn().mockReturnThis();
+    statusMock = jest.fn().mockReturnValue({ json: jsonMock });
+
+    mockRequest = {
+      body: {},
+      query: {},
+      user: { publicKey: 'GBTEST123' }
+    };
+
+    mockResponse = {
+      json: jsonMock,
+      status: statusMock
+    };
+
+    jest.clearAllMocks();
+    (randomUUID as jest.Mock).mockReturnValue('test-transaction-id-123');
+  });
+
+  describe('sep6Info', () => {
+    it('should return info with supported assets', () => {
+      sep6Controller.sep6Info(mockRequest as AuthRequest, mockResponse as Response);
+
+      expect(jsonMock).toHaveBeenCalled();
+      const response = jsonMock.mock.calls[0][0];
+      expect(response).toHaveProperty('deposit');
+      expect(response).toHaveProperty('withdraw');
+    });
+
+    it('should include deposit info for supported deposit assets', () => {
+      sep6Controller.sep6Info(mockRequest as AuthRequest, mockResponse as Response);
+
+      const response = jsonMock.mock.calls[0][0];
+      expect(Object.keys(response.deposit).length).toBeGreaterThan(0);
+      const firstAsset = Object.values(response.deposit)[0] as any;
+      expect(firstAsset).toHaveProperty('enabled', true);
+      expect(firstAsset).toHaveProperty('min_amount');
+      expect(firstAsset).toHaveProperty('max_amount');
+      expect(firstAsset).toHaveProperty('fee_fixed');
+      expect(firstAsset).toHaveProperty('fee_percent');
+      expect(firstAsset).toHaveProperty('fields');
+    });
+
+    it('should include withdraw info for supported withdraw assets', () => {
+      sep6Controller.sep6Info(mockRequest as AuthRequest, mockResponse as Response);
+
+      const response = jsonMock.mock.calls[0][0];
+      expect(Object.keys(response.withdraw).length).toBeGreaterThan(0);
+      const firstAsset = Object.values(response.withdraw)[0] as any;
+      expect(firstAsset).toHaveProperty('enabled', true);
+      expect(firstAsset).toHaveProperty('types');
+    });
+  });
+
+  describe('sep6Deposit', () => {
+    beforeEach(() => {
+      (kycService.isDepositSupported as jest.Mock).mockReturnValue(true);
+      (kycService.normalizeAssetCode as jest.Mock).mockImplementation(code => code.toUpperCase());
+      (kycService.getAsset as jest.Mock).mockReturnValue({
+        code: 'USDC',
+        minAmount: '0.01',
+        maxAmount: '100000',
+        feeFixed: '0.1',
+        feePercent: '0.001'
+      });
+    });
+
+    it('should return 400 when asset_code is missing', async () => {
+      mockRequest.query = {};
+
+      await sep6Controller.sep6Deposit(mockRequest as AuthRequest, mockResponse as Response);
+
+      expect(statusMock).toHaveBeenCalledWith(400);
+      expect(jsonMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: expect.any(String)
+        })
+      );
+    });
+
+    it('should return 400 for unsupported asset', async () => {
+      mockRequest.query = { asset_code: 'UNSUPPORTED' };
+      (kycService.isDepositSupported as jest.Mock).mockReturnValue(false);
+
+      await sep6Controller.sep6Deposit(mockRequest as AuthRequest, mockResponse as Response);
+
+      expect(statusMock).toHaveBeenCalledWith(400);
+      expect(jsonMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: expect.stringContaining('not supported for deposit')
+        })
+      );
+    });
+
+    it('should return 400 when amount is below minimum', async () => {
+      mockRequest.query = { asset_code: 'USDC', amount: '0.001' };
+
+      await sep6Controller.sep6Deposit(mockRequest as AuthRequest, mockResponse as Response);
+
+      expect(statusMock).toHaveBeenCalledWith(400);
+      expect(jsonMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: expect.stringContaining('must be between')
+        })
+      );
+    });
+
+    it('should return 400 when amount is above maximum', async () => {
+      mockRequest.query = { asset_code: 'USDC', amount: '1000000' };
+
+      await sep6Controller.sep6Deposit(mockRequest as AuthRequest, mockResponse as Response);
+
+      expect(statusMock).toHaveBeenCalledWith(400);
+      expect(jsonMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: expect.stringContaining('must be between')
+        })
+      );
+    });
+
+    it('should create deposit transaction successfully', async () => {
+      mockRequest.query = { asset_code: 'USDC', amount: '100', email_address: 'user@example.com' };
+      (prisma.user.upsert as jest.Mock).mockResolvedValue({ id: 'user-1', publicKey: 'GBTEST123' });
+      (prisma.transaction.create as jest.Mock).mockResolvedValue({
+        id: 'test-transaction-id-123',
+        userId: 'user-1',
+        assetCode: 'USDC',
+        amount: '100',
+        type: 'DEPOSIT',
+        status: 'PENDING'
+      });
+
+      await sep6Controller.sep6Deposit(mockRequest as AuthRequest, mockResponse as Response);
+
+      expect(jsonMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'test-transaction-id-123',
+          eta: expect.any(Number),
+          min_amount: '0.01',
+          max_amount: '100000'
+        })
+      );
+    });
+
+    it('should normalize asset code to uppercase', async () => {
+      mockRequest.query = { asset_code: 'usdc', amount: '100' };
+      (prisma.user.upsert as jest.Mock).mockResolvedValue({ id: 'user-1' });
+      (prisma.transaction.create as jest.Mock).mockResolvedValue({ id: 'tx-1' });
+
+      await sep6Controller.sep6Deposit(mockRequest as AuthRequest, mockResponse as Response);
+
+      expect(kycService.normalizeAssetCode).toHaveBeenCalledWith('usdc');
+    });
+  });
+});

--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["yield", "nft_metadata"]
+members = ["yield", "nft_metadata", "swap"]
 
 [workspace.package]
 version = "0.0.0"

--- a/contracts/nft_metadata/src/lib.rs
+++ b/contracts/nft_metadata/src/lib.rs
@@ -12,7 +12,7 @@
 
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, String, Vec, Map};
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, IntoVal, String, Vec, Map};
 
 // ============================================================================
 // Storage Keys
@@ -35,6 +35,7 @@ pub enum DataKey {
     TokenApproval(u64, Address),
     /// Whether an operator is approved for all tokens of an owner
     OperatorApproval(Address, Address),
+    Registry,
 }
 
 // ============================================================================
@@ -176,6 +177,12 @@ impl NftMetadataContract {
         env.storage().instance().set(&DataKey::TokenCounter, &0u64);
     }
 
+    pub fn set_registry(env: Env, registry: Address) {
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).expect("not initialized");
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Registry, &registry);
+    }
+
     // ========================================================================
     // NFT Minting
     // ========================================================================
@@ -207,6 +214,7 @@ impl NftMetadataContract {
         royalty_percentage: u32,
         is_mutable: bool,
     ) -> u64 {
+        Self::ensure_not_paused(&env);
         minter.require_auth();
 
         let admin: Address = env
@@ -269,6 +277,7 @@ impl NftMetadataContract {
         to: Address,
         metadata: NftMetadata,
     ) -> u64 {
+        Self::ensure_not_paused(&env);
         minter.require_auth();
 
         let admin: Address = env
@@ -345,6 +354,7 @@ impl NftMetadataContract {
         description: String,
         image: String,
     ) {
+        Self::ensure_not_paused(&env);
         caller.require_auth();
 
         let owner: Address = env
@@ -395,6 +405,7 @@ impl NftMetadataContract {
         token_id: u64,
         attribute: NftAttribute,
     ) {
+        Self::ensure_not_paused(&env);
         caller.require_auth();
 
         let owner: Address = env
@@ -438,6 +449,7 @@ impl NftMetadataContract {
         percentage: u32,
         recipient: Address,
     ) {
+        Self::ensure_not_paused(&env);
         caller.require_auth();
 
         let owner: Address = env
@@ -493,6 +505,7 @@ impl NftMetadataContract {
         to: Address,
         token_id: u64,
     ) {
+        Self::ensure_not_paused(&env);
         from.require_auth();
 
         let owner: Address = env
@@ -531,6 +544,7 @@ impl NftMetadataContract {
         approved: Address,
         token_id: u64,
     ) {
+        Self::ensure_not_paused(&env);
         owner.require_auth();
 
         let token_owner: Address = env
@@ -562,6 +576,7 @@ impl NftMetadataContract {
         operator: Address,
         approved: bool,
     ) {
+        Self::ensure_not_paused(&env);
         owner.require_auth();
 
         if approved {
@@ -643,6 +658,7 @@ impl NftMetadataContract {
         description: String,
         image: String,
     ) {
+        Self::ensure_not_paused(&env);
         caller.require_auth();
 
         let admin: Address = env
@@ -712,6 +728,15 @@ impl NftMetadataContract {
         let royalty_amount = (sale_price * metadata.royalty_percentage as i128) / 10000;
 
         (metadata.royalty_recipient, royalty_amount)
+    }
+
+    fn ensure_not_paused(env: &Env) {
+        if let Some(registry_addr) = env.storage().instance().get::<_, Address>(&DataKey::Registry) {
+            let is_paused: bool = env.invoke_contract(&registry_addr, &soroban_sdk::symbol_short!("is_paused"), ().into_val(env));
+            if is_paused {
+                panic!("system is paused");
+            }
+        }
     }
 }
 

--- a/contracts/swap/Cargo.toml
+++ b/contracts/swap/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "swap"
+version = "0.0.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"
+
+[dev-dependencies]
+soroban-sdk = { version = "22.0.0", features = ["testutils"] }

--- a/contracts/swap/src/lib.rs
+++ b/contracts/swap/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 
 use soroban_sdk::{
-    contract, contractimpl, contracttype, symbol_short, token, Address, Env,
+    contract, contractimpl, contracttype, symbol_short, token, Address, Env, IntoVal,
 };
 
 #[contracttype]
@@ -11,6 +11,8 @@ pub enum DataKey {
     TokenB,
     ReserveA,
     ReserveB,
+    Admin,
+    Registry,
 }
 
 #[contract]
@@ -19,19 +21,27 @@ pub struct MultiAssetSwap;
 #[contractimpl]
 impl MultiAssetSwap {
     /// Initializes the swap pool.
-    pub fn initialize(env: Env, token_a: Address, token_b: Address) {
+    pub fn initialize(env: Env, admin: Address, token_a: Address, token_b: Address) {
         if env.storage().instance().has(&DataKey::TokenA) {
             panic!("already initialized");
         }
         
+        env.storage().instance().set(&DataKey::Admin, &admin);
         env.storage().instance().set(&DataKey::TokenA, &token_a);
         env.storage().instance().set(&DataKey::TokenB, &token_b);
         env.storage().instance().set(&DataKey::ReserveA, &0_i128);
         env.storage().instance().set(&DataKey::ReserveB, &0_i128);
     }
 
+    pub fn set_registry(env: Env, registry: Address) {
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).expect("not initialized");
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Registry, &registry);
+    }
+
     /// Deposits liquidity into the pool.
     pub fn deposit(env: Env, from: Address, amount_a: i128, amount_b: i128) {
+        Self::ensure_not_paused(&env);
         from.require_auth();
         assert!(amount_a > 0 && amount_b > 0, "amount must be positive");
 
@@ -61,6 +71,7 @@ impl MultiAssetSwap {
         amount_in: i128,
         min_amount_out: i128,
     ) -> i128 {
+        Self::ensure_not_paused(&env);
         from.require_auth();
         assert!(amount_in > 0, "amount must be positive");
 
@@ -120,6 +131,15 @@ impl MultiAssetSwap {
         env.events().publish((symbol_short!("swap"), from), (amount_in, amount_out));
 
         amount_out
+    }
+
+    fn ensure_not_paused(env: &Env) {
+        if let Some(registry_addr) = env.storage().instance().get::<_, Address>(&DataKey::Registry) {
+            let is_paused: bool = env.invoke_contract(&registry_addr, &soroban_sdk::symbol_short!("is_paused"), ().into_val(env));
+            if is_paused {
+                panic!("system is paused");
+            }
+        }
     }
 }
 

--- a/contracts/yield/src/lib.rs
+++ b/contracts/yield/src/lib.rs
@@ -14,7 +14,7 @@
 #![no_std]
 
 use soroban_sdk::{
-    contract, contractimpl, contracttype, symbol_short, token, Address, Env,
+    contract, contractimpl, contracttype, symbol_short, token, Address, Env, IntoVal,
 };
 
 // Fixed-point precision: 1e18
@@ -40,6 +40,7 @@ pub enum DataKey {
     UserRewardPerTokenPaid(Address),
     /// Accrued but unclaimed rewards for a user
     Rewards(Address),
+    Registry,
 }
 
 // ── Contract ─────────────────────────────────────────────────────────────────
@@ -64,11 +65,18 @@ impl YieldDistribution {
         env.storage().instance().set(&DataKey::RewardPerTokenStored, &0_i128);
     }
 
+    pub fn set_registry(env: Env, registry: Address) {
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).expect("not initialized");
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Registry, &registry);
+    }
+
     /// Deposit `amount` of reward tokens into the contract for distribution.
     /// Calling this increases `reward_per_token_stored` proportionally.
     ///
     /// O(1) — no iteration over holders.
     pub fn deposit_rewards(env: Env, from: Address, amount: i128) {
+        Self::ensure_not_paused(&env);
         from.require_auth();
         assert!(amount > 0, "amount must be positive");
 
@@ -112,6 +120,7 @@ impl YieldDistribution {
 
     /// Stake `amount` of the staking token.
     pub fn stake(env: Env, user: Address, amount: i128) {
+        Self::ensure_not_paused(&env);
         user.require_auth();
         assert!(amount > 0, "amount must be positive");
 
@@ -144,6 +153,7 @@ impl YieldDistribution {
 
     /// Unstake `amount` of the staking token.
     pub fn unstake(env: Env, user: Address, amount: i128) {
+        Self::ensure_not_paused(&env);
         user.require_auth();
         assert!(amount > 0, "amount must be positive");
 
@@ -179,6 +189,7 @@ impl YieldDistribution {
 
     /// Claim all accrued rewards for `user`.
     pub fn claim(env: Env, user: Address) -> i128 {
+        Self::ensure_not_paused(&env);
         user.require_auth();
         Self::_update_reward(&env, &user);
 
@@ -286,6 +297,15 @@ impl YieldDistribution {
             .persistent()
             .get(&DataKey::Stake(user.clone()))
             .unwrap_or(0)
+    }
+
+    fn ensure_not_paused(env: &Env) {
+        if let Some(registry_addr) = env.storage().instance().get::<_, Address>(&DataKey::Registry) {
+            let is_paused: bool = env.invoke_contract(&registry_addr, &soroban_sdk::symbol_short!("is_paused"), ().into_val(env));
+            if is_paused {
+                panic!("system is paused");
+            }
+        }
     }
 }
 

--- a/src/amm/lib.rs
+++ b/src/amm/lib.rs
@@ -7,12 +7,14 @@ use soroban_sdk::{
 #[contracttype]
 #[derive(Clone)]
 pub enum DataKey {
+    Admin,
     TokenA,
     TokenB,
     ReserveA,
     ReserveB,
     TotalShares,
     Shares(Address),
+    Registry,
 }
 
 #[contract]
@@ -21,10 +23,11 @@ pub struct AMM;
 #[contractimpl]
 impl AMM {
     /// Initializes the AMM pool for a specific pair of tokens.
-    pub fn initialize(env: Env, token_a: Address, token_b: Address) {
+    pub fn initialize(env: Env, admin: Address, token_a: Address, token_b: Address) {
         if env.storage().instance().has(&DataKey::TokenA) {
             panic!("already initialized");
         }
+        env.storage().instance().set(&DataKey::Admin, &admin);
         
         // Canonical order: ensures same pool for (A,B) and (B,A)
         if token_a < token_b {
@@ -40,8 +43,15 @@ impl AMM {
         env.storage().instance().set(&DataKey::TotalShares, &0_i128);
     }
 
+    pub fn set_registry(env: Env, registry: Address) {
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).expect("not initialized");
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Registry, &registry);
+    }
+
     /// Deposits liquidity into the pool. Returns the number of LP shares minted.
     pub fn deposit(env: Env, from: Address, amount_a: i128, amount_b: i128) -> i128 {
+        Self::ensure_not_paused(&env);
         from.require_auth();
 
         let token_a: Address = env.storage().instance().get(&DataKey::TokenA).expect("not initialized");
@@ -83,6 +93,7 @@ impl AMM {
 
     /// Swaps tokens using the constant product formula (x * y = k) with a 0.3% fee.
     pub fn swap(env: Env, from: Address, token_in: Address, amount_in: i128, min_amount_out: i128) -> i128 {
+        Self::ensure_not_paused(&env);
         from.require_auth();
 
         let token_a: Address = env.storage().instance().get(&DataKey::TokenA).expect("not initialized");
@@ -132,6 +143,7 @@ impl AMM {
 
     /// Withdraws liquidity from the pool.
     pub fn withdraw(env: Env, from: Address, shares: i128) -> (i128, i128) {
+        Self::ensure_not_paused(&env);
         from.require_auth();
 
         let token_a: Address = env.storage().instance().get(&DataKey::TokenA).expect("not initialized");
@@ -167,6 +179,15 @@ impl AMM {
             env.storage().instance().get(&DataKey::ReserveA).unwrap_or(0),
             env.storage().instance().get(&DataKey::ReserveB).unwrap_or(0),
         )
+    }
+
+    fn ensure_not_paused(env: &Env) {
+        if let Some(registry_addr) = env.storage().instance().get::<_, Address>(&DataKey::Registry) {
+            let is_paused: bool = env.invoke_contract(&registry_addr, &soroban_sdk::symbol_short!("is_paused"), ().into_val(env));
+            if is_paused {
+                panic!("system is paused");
+            }
+        }
     }
 }
 

--- a/src/auth/rbac.rs
+++ b/src/auth/rbac.rs
@@ -1,7 +1,7 @@
 #![no_std]
 
 use soroban_sdk::{
-    contract, contractimpl, contracttype, symbol_short, Address, Env,
+    contract, contractimpl, contracttype, symbol_short, Address, Env, IntoVal,
 };
 
 /// Defined roles for the RBAC module.
@@ -21,6 +21,7 @@ pub enum AccessRole {
 pub enum AccessDataKey {
     Role(Address),
     AdminInitialized,
+    Registry,
 }
 
 /// A collection of utility functions to manage RBAC.
@@ -106,13 +107,23 @@ impl RBACContract {
         RBAC::init_admin(&env, &admin);
     }
 
+    pub fn set_registry(env: Env, from: Address, registry: Address) {
+        from.require_auth();
+        if !RBAC::has_role(&env, &from, AccessRole::Admin) {
+            panic!("unauthorized");
+        }
+        env.storage().instance().set(&AccessDataKey::Registry, &registry);
+    }
+
     /// Assigns a role to a target address. Only the admin can call this.
     pub fn set_role(env: Env, from: Address, target: Address, role: AccessRole) {
+        Self::ensure_not_paused(&env);
         RBAC::set_role(&env, &from, &target, role);
     }
 
     /// Revokes any role from a target address. Only the admin can call this.
     pub fn revoke_role(env: Env, from: Address, target: Address) {
+        Self::ensure_not_paused(&env);
         RBAC::revoke_role(&env, &from, &target);
     }
 
@@ -124,6 +135,15 @@ impl RBACContract {
     /// Returns the raw role of an address, if any.
     pub fn get_role(env: Env, address: Address) -> Option<AccessRole> {
         env.storage().instance().get(&AccessDataKey::Role(address))
+    }
+
+    fn ensure_not_paused(env: &Env) {
+        if let Some(registry_addr) = env.storage().instance().get::<_, Address>(&AccessDataKey::Registry) {
+            let is_paused: bool = env.invoke_contract(&registry_addr, &soroban_sdk::symbol_short!("is_paused"), ().into_val(env));
+            if is_paused {
+                panic!("system is paused");
+            }
+        }
     }
 }
 

--- a/src/batch/lib.rs
+++ b/src/batch/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, Symbol, Val, Vec};
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, IntoVal, Symbol, Val, Vec};
 
 #[contracttype]
 #[derive(Clone, Debug)]
@@ -9,21 +9,50 @@ pub struct Call {
     pub args: Vec<Val>,
 }
 
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    Registry,
+}
+
 #[contract]
 pub struct BatchExecutor;
 
 #[contractimpl]
 impl BatchExecutor {
+    pub fn initialize(env: Env, admin: Address) {
+        if env.storage().instance().has(&DataKey::Admin) {
+            panic!("already initialized");
+        }
+        env.storage().instance().set(&DataKey::Admin, &admin);
+    }
+
+    pub fn set_registry(env: Env, registry: Address) {
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).expect("not initialized");
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Registry, &registry);
+    }
+
     /// Executes a sequence of contract calls in a single transaction.
     /// Returns a list of the execution results.
     /// If any call fails, the entire transaction reverts.
     pub fn execute_batch(env: Env, calls: Vec<Call>) -> Vec<Val> {
+        Self::ensure_not_paused(&env);
         let mut results = Vec::new(&env);
         for call in calls.iter() {
             let result: Val = env.invoke_contract(&call.contract, &call.function, call.args.clone());
             results.push_back(result);
         }
         results
+    }
+
+    fn ensure_not_paused(env: &Env) {
+        if let Some(registry_addr) = env.storage().instance().get::<_, Address>(&DataKey::Registry) {
+            let is_paused: bool = env.invoke_contract(&registry_addr, &soroban_sdk::symbol_short!("is_paused"), ().into_val(env));
+            if is_paused {
+                panic!("system is paused");
+            }
+        }
     }
 }
 

--- a/src/escrow_multisig/lib.rs
+++ b/src/escrow_multisig/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, Vec, token};
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, IntoVal, Vec, token};
 
 #[contracttype]
 #[derive(Clone)]
@@ -8,6 +8,7 @@ enum DataKey {
     Threshold,
     Recipient,
     Initialized,
+    Registry,
 }
 
 #[contract]
@@ -29,35 +30,20 @@ impl EscrowMultisig {
         e.storage().instance().set(&DataKey::Recipient, &recipient);
         e.storage().instance().set(&DataKey::Initialized, &true);
     }
+
+    pub fn set_registry(e: Env, signers: Vec<Address>, registry: Address) {
+        Self::verify_multisig(&e, &signers);
+        e.storage().instance().set(&DataKey::Registry, &registry);
+    }
     
     /// Release funds to the recipient.
     /// Requires authorization from M-of-N signers.
     /// The `signers` parameter specifies which M signers are authorizing the release.
     pub fn release(e: Env, signers: Vec<Address>, token: Address) {
-        let stored_signers: Vec<Address> = e.storage().instance().get(&DataKey::Signers).expect("not initialized");
-        let threshold: u32 = e.storage().instance().get(&DataKey::Threshold).expect("not initialized");
+        Self::ensure_not_paused(&e);
+        Self::verify_multisig(&e, &signers);
+        
         let recipient: Address = e.storage().instance().get(&DataKey::Recipient).expect("not initialized");
-        
-        if signers.len() < threshold {
-            panic!("not enough signers provided");
-        }
-        
-        // Verify all provided signers are valid and have authorized the call
-        for signer in signers.iter() {
-            let mut is_valid = false;
-            for stored_signer in stored_signers.iter() {
-                if signer == stored_signer {
-                    is_valid = true;
-                    break;
-                }
-            }
-            if !is_valid {
-                panic!("invalid signer provided");
-            }
-            
-            // This will fail the entire transaction if the signer hasn't authorized this call.
-            signer.require_auth();
-        }
         
         // Get the current balance of the contract for the specified token.
         let token_client = token::Client::new(&e, &token);
@@ -81,6 +67,38 @@ impl EscrowMultisig {
     /// Get the recipient.
     pub fn get_recipient(e: Env) -> Address {
         e.storage().instance().get(&DataKey::Recipient).expect("recipient not set")
+    }
+
+    fn verify_multisig(e: &Env, signers: &Vec<Address>) {
+        let stored_signers: Vec<Address> = e.storage().instance().get(&DataKey::Signers).expect("not initialized");
+        let threshold: u32 = e.storage().instance().get(&DataKey::Threshold).expect("not initialized");
+        
+        if signers.len() < threshold {
+            panic!("not enough signers provided");
+        }
+        
+        for signer in signers.iter() {
+            let mut is_valid = false;
+            for stored_signer in stored_signers.iter() {
+                if signer == stored_signer {
+                    is_valid = true;
+                    break;
+                }
+            }
+            if !is_valid {
+                panic!("invalid signer provided");
+            }
+            signer.require_auth();
+        }
+    }
+
+    fn ensure_not_paused(env: &Env) {
+        if let Some(registry_addr) = env.storage().instance().get::<_, Address>(&DataKey::Registry) {
+            let is_paused: bool = env.invoke_contract(&registry_addr, &soroban_sdk::symbol_short!("is_paused"), ().into_val(env));
+            if is_paused {
+                panic!("system is paused");
+            }
+        }
     }
 }
 

--- a/src/escrow_timelock/lib.rs
+++ b/src/escrow_timelock/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, token};
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, IntoVal, token};
 
 #[contracttype]
 #[derive(Clone)]
@@ -7,6 +7,7 @@ pub enum DataKey {
     EscrowInitialized,
     EscrowDetails,
     RefundClaimed,
+    Registry,
 }
 
 #[contracttype]
@@ -80,8 +81,15 @@ impl EscrowTimelock {
         token_client.transfer(&sender, &e.current_contract_address(), &amount);
     }
 
+    pub fn set_registry(e: Env, registry: Address) {
+        let details: EscrowDetails = e.storage().instance().get(&DataKey::EscrowDetails).expect("not initialized");
+        details.sender.require_auth();
+        e.storage().instance().set(&DataKey::Registry, &registry);
+    }
+
     /// Mark conditions as met (can only be called by sender)
     pub fn mark_conditions_met(e: Env) {
+        Self::ensure_not_paused(&e);
         let mut details: EscrowDetails = e
             .storage()
             .instance()
@@ -96,6 +104,7 @@ impl EscrowTimelock {
 
     /// Claim funds as the recipient (only after unlock_time or if conditions are met)
     pub fn claim(e: Env) {
+        Self::ensure_not_paused(&e);
         let details: EscrowDetails = e
             .storage()
             .instance()
@@ -133,6 +142,7 @@ impl EscrowTimelock {
 
     /// Request refund as sender (only if unlock_time has passed and recipient hasn't claimed)
     pub fn refund(e: Env) {
+        Self::ensure_not_paused(&e);
         let details: EscrowDetails = e
             .storage()
             .instance()
@@ -187,6 +197,15 @@ impl EscrowTimelock {
     /// Get current ledger timestamp
     pub fn get_current_time(e: Env) -> u64 {
         e.ledger().timestamp()
+    }
+
+    fn ensure_not_paused(env: &Env) {
+        if let Some(registry_addr) = env.storage().instance().get::<_, Address>(&DataKey::Registry) {
+            let is_paused: bool = env.invoke_contract(&registry_addr, &soroban_sdk::symbol_short!("is_paused"), ().into_val(env));
+            if is_paused {
+                panic!("system is paused");
+            }
+        }
     }
 }
 

--- a/src/flash_loan/lib.rs
+++ b/src/flash_loan/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 
 use soroban_sdk::{
-    contract, contractclient, contractimpl, symbol_short, token, Address, Env,
+    contract, contractclient, contractimpl, contracttype, symbol_short, token, Address, Env, IntoVal,
 };
 
 /// Interface that a flash loan receiver must implement.
@@ -10,11 +10,30 @@ pub trait FlashLoanReceiver {
     fn execute_loan(env: Env, token: Address, amount: i128, fee: i128);
 }
 
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    Registry,
+}
+
 #[contract]
 pub struct FlashLoanProvider;
 
 #[contractimpl]
 impl FlashLoanProvider {
+    pub fn initialize(env: Env, admin: Address) {
+        if env.storage().instance().has(&DataKey::Admin) {
+            panic!("already initialized");
+        }
+        env.storage().instance().set(&DataKey::Admin, &admin);
+    }
+
+    pub fn set_registry(env: Env, registry: Address) {
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).expect("not initialized");
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Registry, &registry);
+    }
+
     /// Executes a flash loan.
     /// 
     /// # Arguments
@@ -22,6 +41,7 @@ impl FlashLoanProvider {
     /// * `token` - The address of the token to be lent.
     /// * `amount` - The amount of tokens to lend.
     pub fn flash_loan(env: Env, receiver: Address, token: Address, amount: i128) {
+        Self::ensure_not_paused(&env);
         // 1. Calculate the fee (5 basis points = 0.05%)
         // fee = amount * 5 / 10000
         let fee = amount * 5 / 10000;
@@ -49,6 +69,15 @@ impl FlashLoanProvider {
             (symbol_short!("flash_ln"), receiver, token),
             (amount, fee),
         );
+    }
+
+    fn ensure_not_paused(env: &Env) {
+        if let Some(registry_addr) = env.storage().instance().get::<_, Address>(&DataKey::Registry) {
+            let is_paused: bool = env.invoke_contract(&registry_addr, &soroban_sdk::symbol_short!("is_paused"), ().into_val(env));
+            if is_paused {
+                panic!("system is paused");
+            }
+        }
     }
 }
 

--- a/src/governance/lib.rs
+++ b/src/governance/lib.rs
@@ -1,4 +1,4 @@
-﻿#![no_std]
+#![no_std]
 //! Governance Contract with Enhanced Quadratic Voting
 //!
 //! This contract implements a sophisticated quadratic voting mechanism where:
@@ -7,7 +7,7 @@
 //! - Proposals require quorum to pass
 //! - Mathematical accuracy is ensured through careful integer operations
 
-use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, String};
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, IntoVal, String};
 
 /// Default voting credits allocated to each user
 const DEFAULT_VOTING_CREDITS: i128 = 10_000;
@@ -38,6 +38,7 @@ pub enum DataKey {
     ProposalQuadraticCost(u32),
     /// User's quadratic cost spent on a proposal
     UserQuadraticCost(u32, Address),
+    Registry,
 }
 
 /// Proposal lifecycle states
@@ -121,6 +122,12 @@ impl GovernanceContract {
         env.storage().instance().set(&DataKey::QuorumPercentage, &DEFAULT_QUORUM_PERCENTAGE);
     }
 
+    pub fn set_registry(env: Env, registry: Address) {
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).expect("not initialized");
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Registry, &registry);
+    }
+
     /// Allocate voting credits to a user
     ///
     /// Voting credits determine how much quadratic voting power a user has.
@@ -135,6 +142,7 @@ impl GovernanceContract {
     /// # Panics
     /// Panics if caller is not admin
     pub fn allocate_credits(env: Env, caller: Address, user: Address, credits: i128) {
+        Self::ensure_not_paused(&env);
         caller.require_auth();
         
         let admin: Address = env
@@ -193,6 +201,7 @@ impl GovernanceContract {
     /// # Panics
     /// Panics if caller is not admin or percentage is invalid
     pub fn set_quorum_percentage(env: Env, caller: Address, percentage: i128) {
+        Self::ensure_not_paused(&env);
         caller.require_auth();
         
         let admin: Address = env
@@ -233,6 +242,7 @@ impl GovernanceContract {
         description: String,
         voting_period: u64,
     ) -> u32 {
+        Self::ensure_not_paused(&env);
         creator.require_auth();
         assert!(voting_period > 0, "voting period must be positive");
 
@@ -314,6 +324,7 @@ impl GovernanceContract {
         support: bool,
         votes: i128,
     ) {
+        Self::ensure_not_paused(&env);
         voter.require_auth();
         assert!(votes > 0, "votes must be positive");
 
@@ -510,6 +521,7 @@ impl GovernanceContract {
     /// - proposal did not pass the vote
     /// - quorum was not reached
     pub fn execute_proposal(env: Env, executor: Address, proposal_id: u32) {
+        Self::ensure_not_paused(&env);
         executor.require_auth();
 
         let admin: Address = env
@@ -735,6 +747,15 @@ impl GovernanceContract {
             .expect("proposal not found");
         
         proposal.voter_count
+    }
+
+    fn ensure_not_paused(env: &Env) {
+        if let Some(registry_addr) = env.storage().instance().get::<_, Address>(&DataKey::Registry) {
+            let is_paused: bool = env.invoke_contract(&registry_addr, &soroban_sdk::symbol_short!("is_paused"), ().into_val(env));
+            if is_paused {
+                panic!("system is paused");
+            }
+        }
     }
 }
 

--- a/src/kyc/lib.rs
+++ b/src/kyc/lib.rs
@@ -1,11 +1,12 @@
 #![no_std]
-use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, Bytes, BytesN, xdr::ToXdr};
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, IntoVal, Bytes, BytesN, xdr::ToXdr};
 
 #[contracttype]
 pub enum DataKey {
     Admin,
     VerifierPubKey,
     UserKyc(Address), // ExpiresAt (u64)
+    Registry,
 }
 
 #[contract]
@@ -22,7 +23,14 @@ impl KycVerifier {
         env.storage().instance().set(&DataKey::VerifierPubKey, &verifier_pubkey);
     }
 
+    pub fn set_registry(env: Env, registry: Address) {
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).expect("not initialized");
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Registry, &registry);
+    }
+
     pub fn set_kyc_status(env: Env, user: Address, signature: BytesN<64>, expires_at: u64) {
+        Self::ensure_not_paused(&env);
         // KYC provider signs: user_addr + expires_at
         let current_time = env.ledger().timestamp();
         assert!(expires_at > current_time, "proof expired");
@@ -50,8 +58,18 @@ impl KycVerifier {
     }
 
     pub fn update_verifier(env: Env, new_pubkey: BytesN<32>) {
+        Self::ensure_not_paused(&env);
         let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
         admin.require_auth();
         env.storage().instance().set(&DataKey::VerifierPubKey, &new_pubkey);
+    }
+
+    fn ensure_not_paused(env: &Env) {
+        if let Some(registry_addr) = env.storage().instance().get::<_, Address>(&DataKey::Registry) {
+            let is_paused: bool = env.invoke_contract(&registry_addr, &soroban_sdk::symbol_short!("is_paused"), ().into_val(env));
+            if is_paused {
+                panic!("system is paused");
+            }
+        }
     }
 }

--- a/src/oracle_consumer/lib.rs
+++ b/src/oracle_consumer/lib.rs
@@ -18,6 +18,7 @@ pub enum DataKey {
     OracleAddress,
     PriceRecord(Address),
     Admin,
+    Registry,
 }
 
 #[contract]
@@ -35,9 +36,16 @@ impl OracleConsumer {
         env.storage().instance().set(&DataKey::OracleAddress, &oracle);
     }
 
+    pub fn set_registry(env: Env, registry: Address) {
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).expect("not initialized");
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Registry, &registry);
+    }
+
     /// Pulls the latest price for a given asset from the configured external oracle.
     /// This updates the local storage with fresh data and returns it.
     pub fn update_price(env: Env, asset: Address) -> PriceData {
+        Self::ensure_not_paused(&env);
         let oracle: Address = env.storage().instance().get(&DataKey::OracleAddress).expect("oracle not set");
         
         // Attempt to call the external oracle's 'get_price' method.
@@ -74,6 +82,7 @@ impl OracleConsumer {
 
     /// Reconfigures the oracle source address. Restricted to the administrator.
     pub fn set_oracle(env: Env, new_oracle: Address) {
+        Self::ensure_not_paused(&env);
         let admin: Address = env.storage().instance().get(&DataKey::Admin).expect("admin not configured");
         admin.require_auth();
         
@@ -83,6 +92,15 @@ impl OracleConsumer {
     /// Simple getter for the current oracle address.
     pub fn get_oracle(env: Env) -> Address {
         env.storage().instance().get(&DataKey::OracleAddress).unwrap()
+    }
+
+    fn ensure_not_paused(env: &Env) {
+        if let Some(registry_addr) = env.storage().instance().get::<_, Address>(&DataKey::Registry) {
+            let is_paused: bool = env.invoke_contract(&registry_addr, &soroban_sdk::symbol_short!("is_paused"), ().into_val(env));
+            if is_paused {
+                panic!("system is paused");
+            }
+        }
     }
 }
 

--- a/src/security_registry/Cargo.toml
+++ b/src/security_registry/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "security-registry"
+version = "0.0.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"
+
+[dev-dependencies]
+soroban-sdk = { version = "22.0.0", features = ["testutils"] }

--- a/src/security_registry/src/lib.rs
+++ b/src/security_registry/src/lib.rs
@@ -1,0 +1,83 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env};
+
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    Paused,
+}
+
+#[contract]
+pub struct SecurityRegistry;
+
+#[contractimpl]
+impl SecurityRegistry {
+    /// Initializes the registry with a super-admin address.
+    pub fn initialize(env: Env, admin: Address) {
+        if env.storage().instance().has(&DataKey::Admin) {
+            panic!("already initialized");
+        }
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&DataKey::Paused, &false);
+    }
+
+    /// Sets the pause status. Only callable by the super-admin.
+    pub fn set_paused(env: Env, paused: bool) {
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).expect("not initialized");
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Paused, &paused);
+    }
+
+    /// Returns the current pause status.
+    pub fn is_paused(env: Env) -> bool {
+        env.storage().instance().get(&DataKey::Paused).unwrap_or(false)
+    }
+
+    /// Returns the current super-admin address.
+    pub fn get_admin(env: Env) -> Address {
+        env.storage().instance().get(&DataKey::Admin).expect("not initialized")
+    }
+
+    /// Allows transferring the super-admin role.
+    pub fn transfer_admin(env: Env, new_admin: Address) {
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).expect("not initialized");
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Admin, &new_admin);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::testutils::{Address as _};
+
+    #[test]
+    fn test_security_registry() {
+        let env = Env::default();
+        let admin = Address::generate(&env);
+        let contract_id = env.register(SecurityRegistry, ());
+        let client = SecurityRegistryClient::new(&env, &contract_id);
+
+        client.initialize(&admin);
+        assert_eq!(client.is_paused(), false);
+        assert_eq!(client.get_admin(), admin);
+
+        env.mock_all_auths();
+        client.set_paused(&true);
+        assert_eq!(client.is_paused(), true);
+
+        let new_admin = Address::generate(&env);
+        client.transfer_admin(&new_admin);
+        assert_eq!(client.get_admin(), new_admin);
+    }
+
+    #[test]
+    #[should_panic(expected = "not initialized")]
+    fn test_uninitialized() {
+        let env = Env::default();
+        let contract_id = env.register(SecurityRegistry, ());
+        let client = SecurityRegistryClient::new(&env, &contract_id);
+        client.is_paused(); // This should be fine as it has unwrap_or(false)
+        client.get_admin();
+    }
+}

--- a/src/staking/lib.rs
+++ b/src/staking/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, token};
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, IntoVal, token};
 
 #[contracttype]
 pub enum DataKey {
@@ -9,6 +9,7 @@ pub enum DataKey {
     LockPeriod, // Seconds
     PenaltyBps, // Penalty percentage (10000 = 100%)
     Stake(Address),
+    Registry,
 }
 
 #[contracttype]
@@ -46,7 +47,14 @@ impl StakingContract {
         env.storage().instance().set(&DataKey::PenaltyBps, &penalty_bps);
     }
 
+    pub fn set_registry(env: Env, registry: Address) {
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).expect("not initialized");
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Registry, &registry);
+    }
+
     pub fn stake(env: Env, user: Address, amount: i128) {
+        Self::ensure_not_paused(&env);
         user.require_auth();
         assert!(amount > 0, "amount must be positive");
 
@@ -68,6 +76,7 @@ impl StakingContract {
     }
 
     pub fn withdraw(env: Env, user: Address) {
+        Self::ensure_not_paused(&env);
         user.require_auth();
         let info = Self::get_stake_info(env.clone(), user.clone());
         assert!(info.amount > 0, "nothing to withdraw");
@@ -98,6 +107,7 @@ impl StakingContract {
     }
 
     pub fn claim_rewards(env: Env, user: Address) {
+        Self::ensure_not_paused(&env);
         user.require_auth();
         let mut info = Self::get_stake_info(env.clone(), user.clone());
         let current_time = env.ledger().timestamp();
@@ -131,5 +141,14 @@ impl StakingContract {
         let rate: i128 = env.storage().instance().get(&DataKey::RewardRate).unwrap();
         let seconds = (current_time - info.last_updated) as i128;
         (info.amount * rate * seconds) / REWARD_PRECISION
+    }
+
+    fn ensure_not_paused(env: &Env) {
+        if let Some(registry_addr) = env.storage().instance().get::<_, Address>(&DataKey::Registry) {
+            let is_paused: bool = env.invoke_contract(&registry_addr, &soroban_sdk::symbol_short!("is_paused"), ().into_val(env));
+            if is_paused {
+                panic!("system is paused");
+            }
+        }
     }
 }

--- a/src/token/lib.rs
+++ b/src/token/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 //! SEP-41 Compatible Token Wrapper
 
-use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, String};
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, IntoVal, String};
 
 #[contracttype]
 pub enum DataKey {
@@ -12,6 +12,7 @@ pub enum DataKey {
     Name,
     Symbol,
     Decimals,
+    Registry,
 }
 
 #[contract]
@@ -31,7 +32,14 @@ impl TokenContract {
         env.storage().instance().set(&DataKey::TotalSupply, &0_i128);
     }
 
+    pub fn set_registry(env: Env, registry: Address) {
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).expect("not initialized");
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Registry, &registry);
+    }
+
     pub fn mint(env: Env, to: Address, amount: i128) {
+        Self::ensure_not_paused(&env);
         assert!(amount > 0, "amount must be positive");
         let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
         admin.require_auth();
@@ -43,6 +51,7 @@ impl TokenContract {
     }
 
     pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
+        Self::ensure_not_paused(&env);
         from.require_auth();
         assert!(amount > 0, "amount must be positive");
         let from_bal = Self::balance_of(env.clone(), from.clone());
@@ -54,6 +63,7 @@ impl TokenContract {
     }
 
     pub fn approve(env: Env, owner: Address, spender: Address, amount: i128) {
+        Self::ensure_not_paused(&env);
         owner.require_auth();
         assert!(amount >= 0, "amount must be non-negative");
         env.storage().persistent().set(&DataKey::Allowance(owner.clone(), spender.clone()), &amount);
@@ -61,6 +71,7 @@ impl TokenContract {
     }
 
     pub fn transfer_from(env: Env, spender: Address, from: Address, to: Address, amount: i128) {
+        Self::ensure_not_paused(&env);
         spender.require_auth();
         assert!(amount > 0, "amount must be positive");
         let allowance = Self::allowance(env.clone(), from.clone(), spender.clone());
@@ -75,6 +86,7 @@ impl TokenContract {
     }
 
     pub fn burn(env: Env, from: Address, amount: i128) {
+        Self::ensure_not_paused(&env);
         from.require_auth();
         assert!(amount > 0, "amount must be positive");
         let bal = Self::balance_of(env.clone(), from.clone());
@@ -107,6 +119,15 @@ impl TokenContract {
 
     pub fn symbol(env: Env) -> String {
         env.storage().instance().get(&DataKey::Symbol).unwrap()
+    }
+
+    fn ensure_not_paused(env: &Env) {
+        if let Some(registry_addr) = env.storage().instance().get::<_, Address>(&DataKey::Registry) {
+            let is_paused: bool = env.invoke_contract(&registry_addr, &soroban_sdk::symbol_short!("is_paused"), ().into_val(env));
+            if is_paused {
+                panic!("system is paused");
+            }
+        }
     }
 }
 

--- a/src/upgradeable/lib.rs
+++ b/src/upgradeable/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, contracttype, Address, BytesN, Env};
+use soroban_sdk::{contract, contractimpl, contracttype, Address, BytesN, Env, IntoVal};
 
 /// Storage keys used by the upgradeable contract.
 #[derive(Clone)]
@@ -10,6 +10,7 @@ enum DataKey {
     Admin,
     /// The current contract version number (incremented on each upgrade).
     Version,
+    Registry,
 }
 
 #[contract]
@@ -35,6 +36,12 @@ impl UpgradeableContract {
         env.storage().instance().set(&DataKey::Version, &1u32);
     }
 
+    pub fn set_registry(env: Env, registry: Address) {
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).expect("not initialized");
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Registry, &registry);
+    }
+
     /// Upgrades the contract to a new WASM binary identified by `new_wasm_hash`.
     ///
     /// Only the current admin can call this function. The version counter is
@@ -47,6 +54,7 @@ impl UpgradeableContract {
     /// # Panics
     /// Panics if the caller is not the admin.
     pub fn upgrade(env: Env, new_wasm_hash: BytesN<32>) {
+        Self::ensure_not_paused(&env);
         // Retrieve the admin and enforce authorization.
         let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
         admin.require_auth();
@@ -76,6 +84,7 @@ impl UpgradeableContract {
     /// # Panics
     /// Panics if the caller is not the current admin.
     pub fn set_admin(env: Env, new_admin: Address) {
+        Self::ensure_not_paused(&env);
         let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
         admin.require_auth();
 
@@ -96,6 +105,15 @@ impl UpgradeableContract {
     /// Returns the current admin address.
     pub fn get_admin(env: Env) -> Address {
         env.storage().instance().get(&DataKey::Admin).unwrap()
+    }
+
+    fn ensure_not_paused(env: &Env) {
+        if let Some(registry_addr) = env.storage().instance().get::<_, Address>(&DataKey::Registry) {
+            let is_paused: bool = env.invoke_contract(&registry_addr, &soroban_sdk::symbol_short!("is_paused"), ().into_val(env));
+            if is_paused {
+                panic!("system is paused");
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Closes #154

---

Introduced a super-admin controlled pause system across all AnchorPoint contracts. A shared SecurityRegistry contract is used to store and manage the global pause state.

All sensitive contract methods are now guarded to check the pause status before execution, preventing critical actions during emergencies.

This improves platform security and provides a fast, centralized response to potential exploits or system risks.