### PR TITLE
feat: implement NFT metadata contract and scaffolding for swap and yield contracts

### DIFF
--- a/contracts/nft_metadata/src/lib.rs
+++ b/contracts/nft_metadata/src/lib.rs
@@ -113,17 +113,67 @@ pub struct CollectionMetadata {
 
 /// Event types for NFT operations
 #[contracttype]
-pub enum NftEvent {
-    /// Emitted when an NFT is minted
-    Minted { token_id: u64, to: Address },
-    /// Emitted when an NFT is transferred
-    Transferred { token_id: u64, from: Address, to: Address },
-    /// Emitted when metadata is updated
-    MetadataUpdated { token_id: u64 },
-    /// Emitted when approval is granted
-    Approved { token_id: u64, owner: Address, approved: Address },
-    /// Emitted when operator approval is set
-    OperatorApprovalSet { owner: Address, operator: Address, approved: bool },
+#[derive(Clone, Debug, PartialEq)]
+pub struct InitializedEvent {
+    pub admin: Address,
+    pub collection: CollectionMetadata,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct MintedEvent {
+    pub to: Address,
+    pub metadata: NftMetadata,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct TransferredEvent {
+    pub from: Address,
+    pub to: Address,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct MetadataUpdatedEvent {
+    pub name: String,
+    pub description: String,
+    pub image: String,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct AttributeAddedEvent {
+    pub attribute: NftAttribute,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct RoyaltySetEvent {
+    pub percentage: u32,
+    pub recipient: Address,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct ApprovedEvent {
+    pub owner: Address,
+    pub approved: Address,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct OperatorApprovalSetEvent {
+    pub operator: Address,
+    pub approved: bool,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct CollectionUpdatedEvent {
+    pub name: String,
+    pub description: String,
+    pub image: String,
 }
 
 // ============================================================================
@@ -174,6 +224,11 @@ impl NftMetadataContract {
         env.storage().instance().set(&DataKey::Admin, &admin);
         env.storage().instance().set(&DataKey::CollectionMetadata, &collection);
         env.storage().instance().set(&DataKey::TokenCounter, &0u64);
+        
+        env.events().publish(
+            (symbol_short!("NftMeta"), symbol_short!("Init"), symbol_short!("v1"), ()),
+            InitializedEvent { admin, collection },
+        );
     }
 
     // ========================================================================
@@ -246,8 +301,8 @@ impl NftMetadataContract {
         env.storage().instance().set(&DataKey::TokenCounter, &token_id);
 
         env.events().publish(
-            (symbol_short!("mint"), token_id),
-            to,
+            (symbol_short!("NftMeta"), symbol_short!("Minted"), symbol_short!("v1"), token_id),
+            MintedEvent { to: to.clone(), metadata: metadata.clone() },
         );
 
         token_id
@@ -296,8 +351,8 @@ impl NftMetadataContract {
         env.storage().instance().set(&DataKey::TokenCounter, &token_id);
 
         env.events().publish(
-            (symbol_short!("mint"), token_id),
-            to,
+            (symbol_short!("NftMeta"), symbol_short!("Minted"), symbol_short!("v1"), token_id),
+            MintedEvent { to: to.clone(), metadata: final_metadata.clone() },
         );
 
         token_id
@@ -377,8 +432,8 @@ impl NftMetadataContract {
         env.storage().instance().set(&DataKey::NftMetadata(token_id), &metadata);
 
         env.events().publish(
-            (symbol_short!("updated"), token_id),
-            caller,
+            (symbol_short!("NftMeta"), symbol_short!("MetaUpd"), symbol_short!("v1"), token_id),
+            MetadataUpdatedEvent { name, description, image },
         );
     }
 
@@ -418,8 +473,8 @@ impl NftMetadataContract {
         env.storage().instance().set(&DataKey::NftMetadata(token_id), &metadata);
 
         env.events().publish(
-            (symbol_short!("attr_add"), token_id),
-            caller,
+            (symbol_short!("NftMeta"), symbol_short!("AttrAdd"), symbol_short!("v1"), token_id),
+            AttributeAddedEvent { attribute },
         );
     }
 
@@ -456,9 +511,13 @@ impl NftMetadataContract {
             .expect("token not found");
 
         metadata.royalty_percentage = percentage;
-        metadata.royalty_recipient = recipient;
+        metadata.royalty_recipient = recipient.clone();
 
         env.storage().instance().set(&DataKey::NftMetadata(token_id), &metadata);
+        env.events().publish(
+            (symbol_short!("NftMeta"), symbol_short!("RyltySet"), symbol_short!("v1"), token_id),
+            RoyaltySetEvent { percentage, recipient },
+        );
     }
 
     // ========================================================================
@@ -509,8 +568,8 @@ impl NftMetadataContract {
         env.storage().instance().remove(&DataKey::TokenApproval(token_id, from.clone()));
 
         env.events().publish(
-            (symbol_short!("transfer"), token_id),
-            (from, to),
+            (symbol_short!("NftMeta"), symbol_short!("Transfer"), symbol_short!("v1"), token_id),
+            TransferredEvent { from, to },
         );
     }
 
@@ -544,8 +603,8 @@ impl NftMetadataContract {
         env.storage().instance().set(&DataKey::TokenApproval(token_id, owner.clone()), &approved);
 
         env.events().publish(
-            (symbol_short!("approved"), token_id),
-            (owner, approved),
+            (symbol_short!("NftMeta"), symbol_short!("Approved"), symbol_short!("v1"), token_id),
+            ApprovedEvent { owner, approved },
         );
     }
 
@@ -571,8 +630,8 @@ impl NftMetadataContract {
         }
 
         env.events().publish(
-            (symbol_short!("approval_all"), owner.clone()),
-            (operator, approved),
+            (symbol_short!("NftMeta"), symbol_short!("OpAppSet"), symbol_short!("v1"), owner.clone()),
+            OperatorApprovalSetEvent { operator, approved },
         );
     }
 
@@ -661,9 +720,13 @@ impl NftMetadataContract {
 
         collection.name = name;
         collection.description = description;
-        collection.image = image;
+        collection.image = image.clone();
 
         env.storage().instance().set(&DataKey::CollectionMetadata, &collection);
+        env.events().publish(
+            (symbol_short!("NftMeta"), symbol_short!("CollUpd"), symbol_short!("v1"), ()),
+            CollectionUpdatedEvent { name, description, image },
+        );
     }
 
     /// Get total supply of tokens

--- a/contracts/swap/lib.rs
+++ b/contracts/swap/lib.rs
@@ -5,6 +5,28 @@ use soroban_sdk::{
 };
 
 #[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct InitializedEvent {
+    pub token_a: Address,
+    pub token_b: Address,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct DepositEvent {
+    pub amount_a: i128,
+    pub amount_b: i128,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct SwapEvent {
+    pub token_in: Address,
+    pub amount_in: i128,
+    pub amount_out: i128,
+}
+
+#[contracttype]
 #[derive(Clone)]
 pub enum DataKey {
     TokenA,
@@ -28,6 +50,10 @@ impl MultiAssetSwap {
         env.storage().instance().set(&DataKey::TokenB, &token_b);
         env.storage().instance().set(&DataKey::ReserveA, &0_i128);
         env.storage().instance().set(&DataKey::ReserveB, &0_i128);
+        env.events().publish(
+            (symbol_short!("Swap"), symbol_short!("Init"), symbol_short!("v1"), ()),
+            InitializedEvent { token_a, token_b },
+        );
     }
 
     /// Deposits liquidity into the pool.
@@ -49,7 +75,10 @@ impl MultiAssetSwap {
         env.storage().instance().set(&DataKey::ReserveA, &(reserve_a + amount_a));
         env.storage().instance().set(&DataKey::ReserveB, &(reserve_b + amount_b));
 
-        env.events().publish((symbol_short!("deposit"), from), (amount_a, amount_b));
+        env.events().publish(
+            (symbol_short!("Swap"), symbol_short!("Deposit"), symbol_short!("v1"), from),
+            DepositEvent { amount_a, amount_b },
+        );
     }
 
     /// Swaps tokens using the constant product formula (with a 0.3% fee).
@@ -117,7 +146,10 @@ impl MultiAssetSwap {
         // Transfer token_out to user
         token::Client::new(&env, &token_out).transfer(&contract_addr, &from, &amount_out);
 
-        env.events().publish((symbol_short!("swap"), from), (amount_in, amount_out));
+        env.events().publish(
+            (symbol_short!("Swap"), symbol_short!("Swapped"), symbol_short!("v1"), from),
+            SwapEvent { token_in, amount_in, amount_out },
+        );
 
         amount_out
     }

--- a/contracts/yield/src/lib.rs
+++ b/contracts/yield/src/lib.rs
@@ -20,6 +20,40 @@ use soroban_sdk::{
 // Fixed-point precision: 1e18
 const PRECISION: i128 = 1_000_000_000_000_000_000;
 
+// ── Events ───────────────────────────────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct InitializedEvent {
+    pub admin: Address,
+    pub stake_token: Address,
+    pub reward_token: Address,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct DepositRewardsEvent {
+    pub amount: i128,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct StakedEvent {
+    pub amount: i128,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct UnstakedEvent {
+    pub amount: i128,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct ClaimedEvent {
+    pub amount: i128,
+}
+
 // ── Storage keys ─────────────────────────────────────────────────────────────
 
 #[contracttype]
@@ -62,6 +96,10 @@ impl YieldDistribution {
         env.storage().instance().set(&DataKey::RewardToken, &reward_token);
         env.storage().instance().set(&DataKey::TotalStaked, &0_i128);
         env.storage().instance().set(&DataKey::RewardPerTokenStored, &0_i128);
+        env.events().publish(
+            (symbol_short!("Yield"), symbol_short!("Init"), symbol_short!("v1"), ()),
+            InitializedEvent { admin, stake_token, reward_token },
+        );
     }
 
     /// Deposit `amount` of reward tokens into the contract for distribution.
@@ -103,8 +141,8 @@ impl YieldDistribution {
         }
 
         env.events().publish(
-            (symbol_short!("dep_rwd"), from),
-            amount,
+            (symbol_short!("Yield"), symbol_short!("DepRwd"), symbol_short!("v1"), from),
+            DepositRewardsEvent { amount },
         );
     }
 
@@ -139,7 +177,10 @@ impl YieldDistribution {
             .instance()
             .set(&DataKey::TotalStaked, &(total + amount));
 
-        env.events().publish((symbol_short!("staked"), user), amount);
+        env.events().publish(
+            (symbol_short!("Yield"), symbol_short!("Staked"), symbol_short!("v1"), user),
+            StakedEvent { amount },
+        );
     }
 
     /// Unstake `amount` of the staking token.
@@ -172,7 +213,10 @@ impl YieldDistribution {
             &amount,
         );
 
-        env.events().publish((symbol_short!("unstaked"), user), amount);
+        env.events().publish(
+            (symbol_short!("Yield"), symbol_short!("Unstaked"), symbol_short!("v1"), user),
+            UnstakedEvent { amount },
+        );
     }
 
     // ── Claiming ──────────────────────────────────────────────────────────
@@ -201,8 +245,10 @@ impl YieldDistribution {
                 &reward,
             );
 
-            env.events()
-                .publish((symbol_short!("claimed"), user), reward);
+            env.events().publish(
+                (symbol_short!("Yield"), symbol_short!("Claimed"), symbol_short!("v1"), user),
+                ClaimedEvent { amount: reward },
+            );
         }
 
         reward


### PR DESCRIPTION
This PR refactors all emitted events across the AnchorPoint smart contracts (Yield, Swap, and NFT Metadata) to adhere to a strict, standardized 4-topic indexed schema (Contract, EventName, Version, PrimaryID). To improve indexer reliability and reduce payload size, we transitioned from ad-hoc tuple payloads to strongly-typed event structs. Crucially, this update ensures that all state-mutating actions emit sufficient context—such as including the token_in address for swaps and the complete metadata payloads for NFT mints—allowing clients and off-chain indexers to fully reconstruct the contract state without needing to replay the underlying transactions.
closes #151 