### PR TITLE
feat: add graceful-shutdown

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -13,6 +13,7 @@
     "bench:sep38": "cross-env BENCH_ONLY=sep38_price_get ts-node -P tsconfig.perf.json perf/bench.ts",
     "bench:sep6:deposit": "cross-env BENCH_ONLY=sep6_deposit ts-node -P tsconfig.perf.json perf/bench.ts",
     "bench:sep6:withdraw": "cross-env BENCH_ONLY=sep6_withdraw ts-node -P tsconfig.perf.json perf/bench.ts",
+    "bench:sep10": "artillery run perf/sep10.yml",
     "test": "jest",
     "test:coverage": "jest --coverage",
     "lint": "eslint \"src/**/*.ts\"",

--- a/backend/perf/sep10-processor.js
+++ b/backend/perf/sep10-processor.js
@@ -1,0 +1,13 @@
+const StellarSdk = require('@stellar/stellar-sdk');
+
+function generateAccount(userContext, events, done) {
+  // Generate a random keypair for each virtual user
+  const keypair = StellarSdk.Keypair.random();
+  userContext.vars.account = keypair.publicKey();
+  userContext.vars.secret = keypair.secret();
+  return done();
+}
+
+module.exports = {
+  generateAccount,
+};

--- a/backend/perf/sep10.yml
+++ b/backend/perf/sep10.yml
@@ -1,0 +1,27 @@
+config:
+  target: "http://localhost:3002/api"
+  phases:
+    - duration: 20
+      arrivalRate: 5
+      rampTo: 50
+      name: "Ramp up load"
+    - duration: 60
+      arrivalRate: 50
+      name: "Sustained load"
+  payload:
+    # Use a dummy CSV or generate random accounts in a JS file, but for SEP-10 challenge,
+    # we can just use a static account or generate a random one using Artillery functions.
+  processor: "./sep10-processor.js"
+
+scenarios:
+  - name: "SEP-10 Challenge"
+    flow:
+      - function: "generateAccount"
+      - post:
+          url: "/auth"
+          json:
+            account: "{{ account }}"
+            home_domain: "localhost"
+          capture:
+            - json: "$.transaction"
+              as: "challengeTransaction"

--- a/backend/src/api/routes/admin.route.ts
+++ b/backend/src/api/routes/admin.route.ts
@@ -203,4 +203,82 @@ router.post('/password-reset/confirm', async (req: Request, res: Response) => {
   }
 });
 
+const adminTransactionsQuerySchema = z.object({
+  page: z.string().optional().transform(v => parseInt(v || '1', 10)).pipe(z.number().min(1)),
+  limit: z.string().optional().transform(v => parseInt(v || '10', 10)).pipe(z.number().min(1).max(100)),
+});
+
+/**
+ * @swagger
+ * /admin/transactions:
+ *   get:
+ *     summary: Get all transactions with pagination (Admin only)
+ *     tags: [Admin]
+ *     parameters:
+ *       - in: query
+ *         name: page
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *           default: 1
+ *         description: Page number
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *           maximum: 100
+ *           default: 10
+ *         description: Items per page
+ *     responses:
+ *       200:
+ *         description: A paginated list of transactions
+ *       400:
+ *         description: Invalid query parameters
+ *       500:
+ *         description: Internal server error
+ */
+router.get('/transactions', async (req: Request, res: Response) => {
+  const parsed = adminTransactionsQuerySchema.safeParse(req.query);
+  if (!parsed.success) {
+    return res.status(400).json({
+      status: 'error',
+      message: parsed.error.issues[0]?.message ?? 'Invalid query parameters',
+    });
+  }
+
+  const { page, limit } = parsed.data;
+  const skip = (page - 1) * limit;
+
+  try {
+    const [transactions, total] = await Promise.all([
+      import('../../lib/prisma').then(m => m.default.transaction.findMany({
+        orderBy: { createdAt: 'desc' },
+        take: limit,
+        skip,
+      })),
+      import('../../lib/prisma').then(m => m.default.transaction.count()),
+    ]);
+
+    return res.json({
+      status: 'success',
+      data: {
+        transactions,
+        pagination: {
+          total,
+          page,
+          limit,
+          totalPages: Math.ceil(total / limit),
+        },
+      },
+    });
+  } catch (error: any) {
+    logger.error('Failed to fetch admin transactions', { message: error?.message });
+    return res.status(500).json({
+      status: 'error',
+      message: 'Unable to fetch transactions',
+    });
+  }
+});
+
 export default router;

--- a/backend/src/config/queue.ts
+++ b/backend/src/config/queue.ts
@@ -123,6 +123,7 @@ export const QUEUE_NAMES = {
   CONTRACT_INTERACTIONS: 'contract-interactions',
   SETTLEMENTS: 'settlements',
   NOTIFICATIONS: 'notifications',
+  DEAD_LETTER_QUEUE: 'dead-letter-queue',
 } as const;
 
 export type QueueName = typeof QUEUE_NAMES[keyof typeof QUEUE_NAMES];

--- a/backend/src/workers/contract-queue.worker.ts
+++ b/backend/src/workers/contract-queue.worker.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env ts-node
 
-import { Worker, Job } from 'bullmq';
+import { Worker, Job, Queue } from 'bullmq';
 import * as StellarSdk from '@stellar/stellar-sdk';
 import logger from '../utils/logger';
 import { defaultWorkerOptions, QUEUE_NAMES, retryStrategies } from '../config/queue';
@@ -14,6 +14,9 @@ import sorobanErrorService from '../services/soroban-error.service';
 
 // Stellar server instance
 const server = new StellarSdk.Horizon.Server('https://horizon-testnet.stellar.org');
+
+// Dead Letter Queue instance
+const dlq = new Queue(QUEUE_NAMES.DEAD_LETTER_QUEUE, { connection: defaultWorkerOptions.connection });
 
 /**
  * Process a contract call job
@@ -402,9 +405,26 @@ function startWorker() {
     logger.info(`✅ Job ${job.id} completed successfully`);
   });
 
-  worker.on('failed', (job: Job | undefined, error: Error) => {
+  worker.on('failed', async (job: Job | undefined, error: Error) => {
     if (job) {
       logger.error(`❌ Job ${job.id} failed after ${job.attemptsMade} attempts:`, error.message);
+      
+      const maxAttempts = job.opts.attempts || 1;
+      if (job.attemptsMade >= maxAttempts) {
+        logger.info(`Moving job ${job.id} to Dead Letter Queue...`);
+        try {
+          await dlq.add(job.name, {
+            originalJob: job.data,
+            error: error.message,
+            stack: error.stack,
+            failedAt: new Date(),
+            attemptsMade: job.attemptsMade
+          });
+          logger.info(`Successfully moved job ${job.id} to DLQ.`);
+        } catch (dlqError) {
+          logger.error(`Failed to move job ${job.id} to DLQ:`, dlqError);
+        }
+      }
     }
   });
 
@@ -421,17 +441,32 @@ function startWorker() {
   logger.info(`   Concurrency: ${defaultWorkerOptions.concurrency}`);
 
   // Graceful shutdown
-  process.on('SIGTERM', async () => {
-    logger.info('SIGTERM received, closing worker...');
-    await worker.close();
-    process.exit(0);
-  });
+  let isShuttingDown = false;
+  const gracefulShutdown = async (signal: string) => {
+    if (isShuttingDown) return;
+    isShuttingDown = true;
+    
+    logger.info(`${signal} received, closing worker gracefully...`);
+    try {
+      // Close the worker, which waits for active jobs to finish
+      await worker.close();
+      
+      // Close the DLQ connection
+      await dlq.close();
+      
+      // Disconnect from Redis
+      await worker.disconnect();
+      
+      logger.info('Worker closed and disconnected successfully');
+      process.exit(0);
+    } catch (error) {
+      logger.error('Error during worker shutdown:', error);
+      process.exit(1);
+    }
+  };
 
-  process.on('SIGINT', async () => {
-    logger.info('SIGINT received, closing worker...');
-    await worker.close();
-    process.exit(0);
-  });
+  process.on('SIGTERM', () => gracefulShutdown('SIGTERM'));
+  process.on('SIGINT', () => gracefulShutdown('SIGINT'));
 
   return worker;
 }


### PR DESCRIPTION
## Here is a summary of the implementations:

- Graceful Shutdown for BullMQ Workers:

Refactored backend/src/workers/contract-queue.worker.ts to include a proper stateful graceful shutdown loop.
It intercepts SIGTERM and SIGINT, waits for any active long-running contract interactions to conclude using await worker.close(), and safely closes off any queues and disconnects the underlying Redis connection using worker.disconnect().

- Implement pagination on admin transactions API:

Implemented the GET /admin/transactions endpoint in backend/src/api/routes/admin.route.ts.
Provided Swagger API documentation for the endpoint.
Added validation with zod for parsing and checking pagination queries (page and limit).
Sourced all system transactions using Prisma without applying user filters to expose global data to the admin endpoints safely.

- Dead Letter Queue (DLQ) for Failed Contract Jobs:

Appended a dedicated DEAD_LETTER_QUEUE name format internally in backend/src/config/queue.ts.
Updated the generic BullMQ error listener inside backend/src/workers/contract-queue.worker.ts to hook into when jobs fail up to their maximum retry allowance (job.opts.attempts).
It securely traps these permanently failed contract execution jobs and moves them to the DLQ Redis queue saving their stack trace, failure time, and parameter data for manual recovery operations later.

- Load testing SEP-10 endpoint with Artillery:

Initialized an automated bench:sep10 npm script inside package.json.
Setup an Artillery test specification file inside backend/perf/sep10.yml configured to simulate traffic against the POST /auth endpoint over sustained phases.
Wrote a custom backend/perf/sep10-processor.js generator hooking into the Stellar SDK to dynamically spin up new random cryptographic keypairs for simulating multi-user load testing.


close #384 
close #386 
close #387 
close #388 