### PR TITLE
feat: add per-pool AMM pause controls

### DIFF
--- a/src/amm/lib.rs
+++ b/src/amm/lib.rs
@@ -5,12 +5,14 @@ use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, E
 #[contracttype]
 #[derive(Clone)]
 pub enum DataKey {
+    Admin,
     TokenA,
     TokenB,
     ReserveA,
     ReserveB,
     TotalShares,
     Shares(Address),
+    Paused,
 }
 
 #[contract]
@@ -19,10 +21,13 @@ pub struct AMM;
 #[contractimpl]
 impl AMM {
     /// Initializes the AMM pool for a specific pair of tokens.
-    pub fn initialize(env: Env, token_a: Address, token_b: Address) {
+    pub fn initialize(env: Env, admin: Address, token_a: Address, token_b: Address) {
         if env.storage().instance().has(&DataKey::TokenA) {
             panic!("already initialized");
         }
+
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Admin, &admin);
 
         // Canonical order: ensures same pool for (A,B) and (B,A)
         if token_a < token_b {
@@ -36,11 +41,33 @@ impl AMM {
         env.storage().instance().set(&DataKey::ReserveA, &0_i128);
         env.storage().instance().set(&DataKey::ReserveB, &0_i128);
         env.storage().instance().set(&DataKey::TotalShares, &0_i128);
+        env.storage().instance().set(&DataKey::Paused, &false);
+    }
+
+    /// Pauses this AMM pool. Other AMM pool contract instances remain unaffected.
+    pub fn pause_pool(env: Env, admin: Address) {
+        Self::require_admin(&env, &admin);
+        env.storage().instance().set(&DataKey::Paused, &true);
+
+        let (token_a, token_b) = Self::read_pool_tokens(&env);
+        env.events()
+            .publish((symbol_short!("pause"), admin), (token_a, token_b));
+    }
+
+    /// Unpauses this AMM pool after maintenance or incident response is complete.
+    pub fn unpause_pool(env: Env, admin: Address) {
+        Self::require_admin(&env, &admin);
+        env.storage().instance().set(&DataKey::Paused, &false);
+
+        let (token_a, token_b) = Self::read_pool_tokens(&env);
+        env.events()
+            .publish((symbol_short!("unpause"), admin), (token_a, token_b));
     }
 
     /// Deposits liquidity into the pool. Returns the number of LP shares minted.
     pub fn deposit(env: Env, from: Address, amount_a: i128, amount_b: i128) -> i128 {
         from.require_auth();
+        Self::check_not_paused(&env);
 
         let token_a: Address = env
             .storage()
@@ -74,8 +101,14 @@ impl AMM {
             sqrt(amount_a.checked_mul(amount_b).expect("deposit overflow"))
         } else {
             // Proportional liquidity: min(amount_a/reserve_a, amount_b/reserve_b) * total_shares
-            let shares_a = amount_a.checked_mul(total_shares).expect("deposit overflow") / reserve_a;
-            let shares_b = amount_b.checked_mul(total_shares).expect("deposit overflow") / reserve_b;
+            let shares_a = amount_a
+                .checked_mul(total_shares)
+                .expect("deposit overflow")
+                / reserve_a;
+            let shares_b = amount_b
+                .checked_mul(total_shares)
+                .expect("deposit overflow")
+                / reserve_b;
             if shares_a < shares_b {
                 shares_a
             } else {
@@ -104,28 +137,32 @@ impl AMM {
         );
 
         // Update state
-        env.storage()
-            .instance()
-            .set(&DataKey::ReserveA, &reserve_a.checked_add(amount_a).expect("reserve overflow"));
-        env.storage()
-            .instance()
-            .set(&DataKey::ReserveB, &reserve_b.checked_add(amount_b).expect("reserve overflow"));
-        env.storage()
-            .instance()
-            .set(&DataKey::TotalShares, &total_shares.checked_add(shares).expect("shares overflow"));
+        env.storage().instance().set(
+            &DataKey::ReserveA,
+            &reserve_a.checked_add(amount_a).expect("reserve overflow"),
+        );
+        env.storage().instance().set(
+            &DataKey::ReserveB,
+            &reserve_b.checked_add(amount_b).expect("reserve overflow"),
+        );
+        env.storage().instance().set(
+            &DataKey::TotalShares,
+            &total_shares.checked_add(shares).expect("shares overflow"),
+        );
 
         let old_shares: i128 = env
             .storage()
             .persistent()
             .get(&DataKey::Shares(from.clone()))
             .unwrap_or(0);
-        env.storage()
-            .persistent()
-            .set(&DataKey::Shares(from.clone()), &old_shares.checked_add(shares).expect("shares overflow"));
+        env.storage().persistent().set(
+            &DataKey::Shares(from.clone()),
+            &old_shares.checked_add(shares).expect("shares overflow"),
+        );
 
         // Topic: event name only; from + amounts in data.
         env.events().publish(
-            symbol_short!("deposit"),
+            (symbol_short!("deposit"),),
             (from, amount_a, amount_b, shares),
         );
         shares
@@ -140,6 +177,7 @@ impl AMM {
         min_amount_out: i128,
     ) -> i128 {
         from.require_auth();
+        Self::check_not_paused(&env);
 
         let token_a: Address = env
             .storage()
@@ -173,8 +211,14 @@ impl AMM {
 
         // Constant product formula with 0.3% fee: dy = (reserve_out * dx * 997) / (reserve_in * 1000 + dx * 997)
         let amount_in_with_fee = amount_in.checked_mul(997).expect("swap overflow");
-        let numerator = amount_in_with_fee.checked_mul(reserve_out).expect("swap overflow");
-        let denominator = reserve_in.checked_mul(1000).expect("swap overflow").checked_add(amount_in_with_fee).expect("swap overflow");
+        let numerator = amount_in_with_fee
+            .checked_mul(reserve_out)
+            .expect("swap overflow");
+        let denominator = reserve_in
+            .checked_mul(1000)
+            .expect("swap overflow")
+            .checked_add(amount_in_with_fee)
+            .expect("swap overflow");
         let amount_out = numerator / denominator;
 
         if amount_out < min_amount_out {
@@ -184,10 +228,14 @@ impl AMM {
         // Update state
         if token_in == token_a {
             reserve_a = reserve_a.checked_add(amount_in).expect("reserve overflow");
-            reserve_b = reserve_b.checked_sub(amount_out).expect("reserve underflow");
+            reserve_b = reserve_b
+                .checked_sub(amount_out)
+                .expect("reserve underflow");
         } else {
             reserve_b = reserve_b.checked_add(amount_in).expect("reserve overflow");
-            reserve_a = reserve_a.checked_sub(amount_out).expect("reserve underflow");
+            reserve_a = reserve_a
+                .checked_sub(amount_out)
+                .expect("reserve underflow");
         }
 
         env.storage().instance().set(&DataKey::ReserveA, &reserve_a);
@@ -204,13 +252,14 @@ impl AMM {
 
         // Topic: event name only; from + amounts in data.
         env.events()
-            .publish(symbol_short!("swap"), (from, amount_in, amount_out));
+            .publish((symbol_short!("swap"),), (from, amount_in, amount_out));
         amount_out
     }
 
     /// Withdraws liquidity from the pool.
     pub fn withdraw(env: Env, from: Address, shares: i128) -> (i128, i128) {
         from.require_auth();
+        Self::check_not_paused(&env);
 
         let token_a: Address = env
             .storage()
@@ -239,18 +288,22 @@ impl AMM {
         let amount_b = shares.checked_mul(reserve_b).expect("withdraw overflow") / total_shares;
 
         // Update state
-        env.storage()
-            .instance()
-            .set(&DataKey::ReserveA, &reserve_a.checked_sub(amount_a).expect("reserve underflow"));
-        env.storage()
-            .instance()
-            .set(&DataKey::ReserveB, &reserve_b.checked_sub(amount_b).expect("reserve underflow"));
-        env.storage()
-            .instance()
-            .set(&DataKey::TotalShares, &total_shares.checked_sub(shares).expect("shares underflow"));
-        env.storage()
-            .persistent()
-            .set(&DataKey::Shares(from.clone()), &user_shares.checked_sub(shares).expect("shares underflow"));
+        env.storage().instance().set(
+            &DataKey::ReserveA,
+            &reserve_a.checked_sub(amount_a).expect("reserve underflow"),
+        );
+        env.storage().instance().set(
+            &DataKey::ReserveB,
+            &reserve_b.checked_sub(amount_b).expect("reserve underflow"),
+        );
+        env.storage().instance().set(
+            &DataKey::TotalShares,
+            &total_shares.checked_sub(shares).expect("shares underflow"),
+        );
+        env.storage().persistent().set(
+            &DataKey::Shares(from.clone()),
+            &user_shares.checked_sub(shares).expect("shares underflow"),
+        );
 
         // Transfer tokens back to user
         transfer(
@@ -270,7 +323,7 @@ impl AMM {
 
         // Topic: event name only; from + amounts in data.
         env.events().publish(
-            symbol_short!("withdraw"),
+            (symbol_short!("withdraw"),),
             (from, amount_a, amount_b, shares),
         );
         (amount_a, amount_b)
@@ -301,6 +354,54 @@ impl AMM {
             .instance()
             .get(&DataKey::TotalShares)
             .unwrap_or(0)
+    }
+
+    /// Returns the administrator authorized to pause and unpause this pool.
+    pub fn get_admin(env: Env) -> Address {
+        env.storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("not initialized")
+    }
+
+    /// Returns whether this specific AMM pool is paused.
+    pub fn is_paused(env: Env) -> bool {
+        Self::read_paused(&env)
+    }
+
+    fn require_admin(env: &Env, admin: &Address) {
+        admin.require_auth();
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("not initialized");
+        assert!(admin == &stored_admin, "unauthorized");
+    }
+
+    fn check_not_paused(env: &Env) {
+        assert!(!Self::read_paused(env), "pool is paused");
+    }
+
+    fn read_paused(env: &Env) -> bool {
+        env.storage()
+            .instance()
+            .get(&DataKey::Paused)
+            .unwrap_or(false)
+    }
+
+    fn read_pool_tokens(env: &Env) -> (Address, Address) {
+        let token_a: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::TokenA)
+            .expect("not initialized");
+        let token_b: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::TokenB)
+            .expect("not initialized");
+        (token_a, token_b)
     }
 }
 
@@ -335,26 +436,112 @@ mod tests {
     use super::*;
     use soroban_sdk::testutils::Address as _;
 
-    #[test]
-    fn test_initialization() {
+    fn setup() -> (Env, AMMClient<'static>, Address, Address, Address) {
         let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
         let token_a = Address::generate(&env);
         let token_b = Address::generate(&env);
 
         let contract_id = env.register(AMM, ());
         let client = AMMClient::new(&env, &contract_id);
 
-        client.initialize(&token_a, &token_b);
+        client.initialize(&admin, &token_a, &token_b);
+        (env, client, admin, token_a, token_b)
+    }
+
+    #[test]
+    fn test_initialization() {
+        let (_env, client, admin, _token_a, _token_b) = setup();
+
         let (r_a, r_b) = client.get_reserves();
         assert_eq!(r_a, 0);
         assert_eq!(r_b, 0);
+        assert_eq!(client.get_admin(), admin);
+        assert!(!client.is_paused());
+    }
+
+    #[test]
+    fn test_admin_can_pause_and_unpause_pool() {
+        let (_env, client, admin, _token_a, _token_b) = setup();
+
+        client.pause_pool(&admin);
+        assert!(client.is_paused());
+
+        client.unpause_pool(&admin);
+        assert!(!client.is_paused());
+    }
+
+    #[test]
+    #[should_panic(expected = "unauthorized")]
+    fn test_non_admin_cannot_pause_pool() {
+        let (env, client, _admin, _token_a, _token_b) = setup();
+        let non_admin = Address::generate(&env);
+
+        client.pause_pool(&non_admin);
+    }
+
+    #[test]
+    fn test_pausing_one_pool_does_not_pause_other_pool() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin_a = Address::generate(&env);
+        let admin_b = Address::generate(&env);
+        let token_a = Address::generate(&env);
+        let token_b = Address::generate(&env);
+        let token_c = Address::generate(&env);
+        let token_d = Address::generate(&env);
+
+        let pool_a_id = env.register(AMM, ());
+        let pool_b_id = env.register(AMM, ());
+        let pool_a = AMMClient::new(&env, &pool_a_id);
+        let pool_b = AMMClient::new(&env, &pool_b_id);
+
+        pool_a.initialize(&admin_a, &token_a, &token_b);
+        pool_b.initialize(&admin_b, &token_c, &token_d);
+
+        pool_a.pause_pool(&admin_a);
+
+        assert!(pool_a.is_paused());
+        assert!(!pool_b.is_paused());
+    }
+
+    #[test]
+    #[should_panic(expected = "pool is paused")]
+    fn test_deposit_rejects_when_pool_is_paused() {
+        let (env, client, admin, _token_a, _token_b) = setup();
+        let user = Address::generate(&env);
+
+        client.pause_pool(&admin);
+        client.deposit(&user, &100, &100);
+    }
+
+    #[test]
+    #[should_panic(expected = "pool is paused")]
+    fn test_swap_rejects_when_pool_is_paused() {
+        let (env, client, admin, token_a, _token_b) = setup();
+        let user = Address::generate(&env);
+
+        client.pause_pool(&admin);
+        client.swap(&user, &token_a, &100, &1);
+    }
+
+    #[test]
+    #[should_panic(expected = "pool is paused")]
+    fn test_withdraw_rejects_when_pool_is_paused() {
+        let (env, client, admin, _token_a, _token_b) = setup();
+        let user = Address::generate(&env);
+
+        client.pause_pool(&admin);
+        client.withdraw(&user, &1);
     }
 }
 
 #[cfg(test)]
 mod fuzz_tests {
     use super::*;
-    use soroban_sdk::testutils::Address as _;
 
     const FEE_NUMERATOR: i128 = 997;
     const FEE_DENOMINATOR: i128 = 1000;
@@ -366,7 +553,12 @@ mod fuzz_tests {
         numerator / denominator
     }
 
-    fn apply_swap(reserve_a: i128, reserve_b: i128, amount_in: i128, from_a: bool) -> (i128, i128, i128) {
+    fn apply_swap(
+        reserve_a: i128,
+        reserve_b: i128,
+        amount_in: i128,
+        from_a: bool,
+    ) -> (i128, i128, i128) {
         if from_a {
             let amount_out = swap_formula(reserve_a, reserve_b, amount_in);
             (reserve_a + amount_in, reserve_b - amount_out, amount_out)
@@ -384,7 +576,10 @@ mod fuzz_tests {
             let amount_in: i128 = rand_simple(1, reserve_a / 10);
 
             let amount_out = swap_formula(reserve_a, reserve_b, amount_in);
-            assert!(amount_out < reserve_b, "Swap output should never exceed available reserves");
+            assert!(
+                amount_out < reserve_b,
+                "Swap output should never exceed available reserves"
+            );
             assert!(amount_out >= 0, "Swap output should never be negative");
         }
     }
@@ -401,14 +596,16 @@ mod fuzz_tests {
             }
 
             let k_before = r_a * r_b;
-            let amount_out = swap_formula(r_a, r_b, amount_in);
             let (new_r_a, new_r_b, _) = apply_swap(r_a, r_b, amount_in, true);
             let k_after = new_r_a * new_r_b;
 
             assert!(k_after >= k_before, "K should never decrease");
             // Allow generous margin for integer arithmetic edge cases
             let max_increase = k_before / 50; // 2%
-            assert!(k_after - k_before <= max_increase || k_before == 0, "K increase bounded");
+            assert!(
+                k_after - k_before <= max_increase || k_before == 0,
+                "K increase bounded"
+            );
         }
     }
 
@@ -425,8 +622,14 @@ mod fuzz_tests {
                 assert!(new_r_b >= 0, "Reserve B should never be negative");
 
                 let (new_r_a2, new_r_b2, _) = apply_swap(reserve_a, reserve_b, amount_in, false);
-                assert!(new_r_a2 >= 0, "Reserve A should never be negative (swap from B)");
-                assert!(new_r_b2 >= 0, "Reserve B should never be negative (swap from B)");
+                assert!(
+                    new_r_a2 >= 0,
+                    "Reserve A should never be negative (swap from B)"
+                );
+                assert!(
+                    new_r_b2 >= 0,
+                    "Reserve B should never be negative (swap from B)"
+                );
             }
         }
     }
@@ -453,8 +656,8 @@ mod fuzz_tests {
     #[test]
     fn test_invariant_multiple_swaps_maintain_positive_reserves() {
         for _ in 0..100 {
-            let mut r_a: i128 = rand_simple(50000, 500000);
-            let mut r_b: i128 = rand_simple(50000, 500000);
+            let r_a: i128 = rand_simple(50000, 500000);
+            let r_b: i128 = rand_simple(50000, 500000);
             let swaps = rand_simple(1, 50) as u32;
 
             for i in 0..swaps {
@@ -490,7 +693,10 @@ mod fuzz_tests {
             let k_increase = new_k - k;
             let fee_revenue_bps = (k_increase * 1000) / k;
 
-            assert!(fee_revenue_bps >= 0, "Pool should always capture positive fees");
+            assert!(
+                fee_revenue_bps >= 0,
+                "Pool should always capture positive fees"
+            );
             assert!(fee_revenue_bps <= 4, "Fee revenue should be bounded");
         }
     }
@@ -513,7 +719,10 @@ mod fuzz_tests {
         let a: i128 = 1_000_000_000_000_i128;
         let b: i128 = 1_000_000_000_000_i128;
         let product = a * b;
-        assert!(product > 0, "Product of positive numbers should be positive");
+        assert!(
+            product > 0,
+            "Product of positive numbers should be positive"
+        );
     }
 
     #[test]
@@ -531,8 +740,14 @@ mod fuzz_tests {
             let ratio_b = (amount_b * 1000) / reserve_b;
             let share_ratio = (shares * 1000) / total_shares;
 
-            assert!((ratio_a - share_ratio).abs() <= 1, "Withdrawal should be proportional for token A");
-            assert!((ratio_b - share_ratio).abs() <= 1, "Withdrawal should be proportional for token B");
+            assert!(
+                (ratio_a - share_ratio).abs() <= 1,
+                "Withdrawal should be proportional for token A"
+            );
+            assert!(
+                (ratio_b - share_ratio).abs() <= 1,
+                "Withdrawal should be proportional for token B"
+            );
         }
     }
 
@@ -551,7 +766,11 @@ mod fuzz_tests {
 
             let shares_a = (amount_a * total_shares) / r_a;
             let shares_b = (amount_b * total_shares) / r_b;
-            let min_shares = if shares_a < shares_b { shares_a } else { shares_b };
+            let min_shares = if shares_a < shares_b {
+                shares_a
+            } else {
+                shares_b
+            };
 
             assert!(min_shares >= 0, "Shares should never be negative");
         }

--- a/src/benchmarks/src/lib.rs
+++ b/src/benchmarks/src/lib.rs
@@ -2,7 +2,7 @@
 
 #[cfg(test)]
 mod tests {
-    use soroban_amm::{AMMClient, AMM};
+    use anchorpoint_amm::{AMMClient, AMM};
     use soroban_sdk::{testutils::Address as _, Address, Env, String};
     use soroban_token::{TokenContract, TokenContractClient};
 
@@ -15,6 +15,7 @@ mod tests {
         let env = Env::default();
         env.mock_all_auths();
 
+        let admin = Address::generate(&env);
         let token_a = Address::generate(&env);
         let token_b = Address::generate(&env);
 
@@ -24,7 +25,7 @@ mod tests {
         let start_cpu = env.budget().cpu_instruction_cost();
         let start_mem = env.budget().memory_bytes_cost();
 
-        amm_client.initialize(&token_a, &token_b);
+        amm_client.initialize(&admin, &token_a, &token_b);
 
         let cpu_used = env.budget().cpu_instruction_cost() - start_cpu;
         let mem_used = env.budget().memory_bytes_cost() - start_mem;


### PR DESCRIPTION
closes #269 

##Summary of Changes
Added admin-controlled pause_pool and unpause_pool functions to the AMM contract.
Stored pause state per AMM contract instance so one paused pool does not affect other pools.
Added pause guards to deposit, swap, and withdraw.
Added read helpers for is_paused and get_admin.
Updated AMM benchmark initialization to pass the new admin argument.
Added tests for admin authorization, paused operation rejection, and independent pool pause state.

##Reason for Changes
Administrators need the ability to pause a specific AMM pool for maintenance or security response without disrupting other active pools.

