### PR TITLE
chore(ci): improve Prisma migration reliability for CI/CD pipelines

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -14,38 +14,72 @@ jobs:
   validate:
     name: Validate Migration Integrity
     runs-on: ubuntu-latest
-    
+
     defaults:
       run:
         working-directory: backend
 
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
           cache-dependency-path: 'backend/package-lock.json'
-          
+
       - name: Install dependencies
         run: npm install
-        
+
+      # Generate the Prisma client before any migration steps so that all
+      # downstream commands (migrate deploy, migrate diff, ts-node scripts)
+      # have the correct client bindings available.
+      - name: Generate Prisma client
+        env:
+          DATABASE_URL: "file:./ci-verify.db"
+        run: npx prisma generate
+
+      # Fast environment check — fails immediately with a clear message if
+      # DATABASE_URL is missing or malformed, rather than surfacing a cryptic
+      # Prisma error several steps later.
+      - name: Validate migration environment
+        env:
+          DATABASE_URL: "file:./ci-verify.db"
+        run: node scripts/validate-migration-env.js
+
       - name: Verify Migrations Against Temporary Database
         env:
           DATABASE_URL: "file:./ci-verify.db"
         run: npm run migrate:verify
-        
+
       - name: Run Migration Integrity Checker
         env:
           DATABASE_URL: "file:./ci.db"
           SHADOW_DATABASE_URL: "file:./shadow.db"
         run: node scripts/check-migrations.js
-        
+
+      # Emit migration status as an artefact so reviewers can see which
+      # migrations are applied without re-running CI.
+      - name: Report migration status
+        if: always()
+        env:
+          DATABASE_URL: "file:./ci.db"
+        run: |
+          echo "## Migration Status" > migration-status.md
+          npx prisma migrate status >> migration-status.md 2>&1 || true
+
+      - name: Upload migration status report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: migration-status
+          path: backend/migration-status.md
+          retention-days: 7
+
       - name: Run Lint
         run: npm run lint
-        
+
       - name: Run Tests
         env:
           DATABASE_URL: "file:./test.db"

--- a/backend/package.json
+++ b/backend/package.json
@@ -25,7 +25,9 @@
     "migrate:verify": "ts-node scripts/verify-migrations.ts",
     "migrate:check": "ts-node scripts/migration-integrity-checker.ts",
     "migrate:rollback": "ts-node scripts/generate-rollback.ts",
-    "migrate:status": "prisma migrate status"
+    "migrate:status": "prisma migrate status",
+    "migrate:validate-env": "node scripts/validate-migration-env.js",
+    "migrate:bootstrap": "bash scripts/bootstrap-db.sh"
   },
   "dependencies": {
     "@aws-sdk/client-kms": "^3.500.0",

--- a/backend/scripts/bootstrap-db.sh
+++ b/backend/scripts/bootstrap-db.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# bootstrap-db.sh
+#
+# One-shot local development database setup.
+# Idempotent: safe to run repeatedly.
+#
+# Usage:
+#   ./scripts/bootstrap-db.sh               # uses .env file
+#   DATABASE_URL=file:./dev.db ./scripts/bootstrap-db.sh
+#
+# What this does:
+#   1. Validates the migration environment (DATABASE_URL etc.)
+#   2. Generates the Prisma client
+#   3. Applies all pending migrations deterministically (migrate deploy)
+#   4. Runs a quick schema-drift check
+#   5. Prints migration status
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BACKEND_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+cd "${BACKEND_DIR}"
+
+# ── Load .env if present ──────────────────────────────────────────────────────
+if [[ -f ".env" ]]; then
+  set -a
+  # shellcheck disable=SC1091
+  source .env
+  set +a
+  echo "ℹ️  Loaded .env"
+fi
+
+DATABASE_URL="${DATABASE_URL:-file:./prisma/dev.db}"
+export DATABASE_URL
+
+echo ""
+echo "🔧  AnchorPoint — Local Database Bootstrap"
+echo "    DATABASE_URL: ${DATABASE_URL}"
+echo ""
+
+# ── Step 1: validate environment ──────────────────────────────────────────────
+echo "Step 1/4 — Validating environment"
+node scripts/validate-migration-env.js
+
+# ── Step 2: generate Prisma client ───────────────────────────────────────────
+echo ""
+echo "Step 2/4 — Generating Prisma client"
+npx prisma generate
+
+# ── Step 3: apply migrations ──────────────────────────────────────────────────
+echo ""
+echo "Step 3/4 — Applying migrations"
+npx prisma migrate deploy
+
+# ── Step 4: drift + status check ─────────────────────────────────────────────
+echo ""
+echo "Step 4/4 — Checking schema drift and migration status"
+npx prisma migrate status
+
+echo ""
+echo "✅  Database bootstrap complete.  You can start the server with: npm run dev"

--- a/backend/scripts/check-migrations.js
+++ b/backend/scripts/check-migrations.js
@@ -1,16 +1,34 @@
 #!/usr/bin/env node
+/**
+ * check-migrations.js
+ *
+ * CI/CD migration integrity checker for AnchorPoint.
+ *
+ * Goals
+ * ─────
+ * 1. Generate the Prisma client so downstream commands have the right bindings.
+ * 2. Prevent destructive schema changes from reaching production undetected.
+ * 3. Simulate rollbacks via a shadow database to ensure idempotency.
+ * 4. Detect schema drift between the committed migration history and the
+ *    current schema.prisma definition.
+ *
+ * Environment variables
+ * ─────────────────────
+ * DATABASE_URL        – target database (required)
+ * SHADOW_DATABASE_URL – shadow DB used for migration simulation
+ *                       (defaults to file:./shadow.db)
+ *
+ * Exit codes
+ * ──────────
+ * 0 – all checks passed
+ * 1 – one or more checks failed (fatal)
+ */
+
+'use strict';
+
 const { execSync } = require('child_process');
 const path = require('path');
 const fs = require('fs');
-
-/**
- * Prisma Migration Integrity Checker
- * 
- * Goals:
- * 1. Prevent destructive changes to production databases (via prisma migrate diff).
- * 2. Simulate rollbacks to ensure idempotency.
- * 3. Check for schema drifts.
- */
 
 const PRISMA_BINARY = 'npx prisma';
 const SCHEMA_PATH = path.join(__dirname, '../prisma/schema.prisma');
@@ -96,20 +114,45 @@ function checkDrift() {
     }
 }
 
+/**
+ * Generate the Prisma client before any migration commands.
+ * This is a no-op if the client is already up to date, but prevents
+ * confusing "PrismaClient not found" errors in fresh CI environments.
+ */
+function generateClient() {
+    console.log('--- Generating Prisma client ---');
+    try {
+        execSync(`${PRISMA_BINARY} generate`, { stdio: 'inherit' });
+        console.log('✅ Prisma client generated.');
+    } catch (error) {
+        console.error('❌ Failed to generate Prisma client.');
+        process.exit(1);
+    }
+}
+
 async function main() {
     console.log('🚀 Starting Database Migration Integrity Check');
-    
-    // Ensure we are in the backend directory
+
+    // Ensure we are in the backend directory so relative paths resolve correctly
     process.chdir(path.join(__dirname, '..'));
 
+    // Validate environment before doing anything else (subprocess so it can exit independently)
     try {
+        execSync('node scripts/validate-migration-env.js', { stdio: 'inherit' });
+    } catch (_) {
+        console.error('❌ Environment validation failed. Aborting migration check.');
+        process.exit(1);
+    }
+
+    try {
+        generateClient();
         checkDrift();
         checkDestructiveChanges();
         simulateMigration();
-        
+
         console.log('\n✨ All migration integrity checks passed!');
     } catch (error) {
-        console.error('\n💥 Migration integrity check failed.');
+        console.error('\n💥 Migration integrity check failed:', error && error.message ? error.message : error);
         process.exit(1);
     }
 }

--- a/backend/scripts/validate-migration-env.js
+++ b/backend/scripts/validate-migration-env.js
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+/**
+ * validate-migration-env.js
+ *
+ * Validates that all required environment variables are present and well-formed
+ * before any Prisma migration command runs.  Failing fast here prevents
+ * confusing Prisma errors that surface far from the actual root cause.
+ *
+ * Usage:
+ *   node scripts/validate-migration-env.js           # exits 1 on failure
+ *   node scripts/validate-migration-env.js --warn    # exits 0 but prints warnings
+ */
+
+'use strict';
+
+const warnOnly = process.argv.includes('--warn');
+
+const issues = [];
+
+// ── Required ─────────────────────────────────────────────────────────────────
+
+const DATABASE_URL = process.env.DATABASE_URL;
+
+if (!DATABASE_URL) {
+  issues.push('DATABASE_URL is not set');
+} else if (!/^(file:|postgresql:|postgres:|mysql:|sqlserver:|mongodb\+srv:)/.test(DATABASE_URL)) {
+  issues.push(`DATABASE_URL has an unrecognised scheme: "${DATABASE_URL.split(':')[0]}:"`);
+}
+
+// ── SQLite-specific checks ────────────────────────────────────────────────────
+
+if (DATABASE_URL && DATABASE_URL.startsWith('file:')) {
+  const path = require('path');
+  const fs   = require('fs');
+
+  // Resolve the DB file relative to the backend root (one level up from scripts/)
+  const backendRoot = path.resolve(__dirname, '..');
+  const dbRelative  = DATABASE_URL.replace(/^file:/, '');
+  const dbAbsolute  = path.isAbsolute(dbRelative)
+    ? dbRelative
+    : path.join(backendRoot, dbRelative);
+
+  const dbDir = path.dirname(dbAbsolute);
+  if (!fs.existsSync(dbDir)) {
+    issues.push(`DATABASE_URL directory does not exist: ${dbDir}`);
+  }
+}
+
+// ── Shadow DB (required for migrate dev; optional for deploy / CI) ────────────
+
+const SHADOW_DATABASE_URL = process.env.SHADOW_DATABASE_URL;
+if (process.env.REQUIRE_SHADOW_DB === 'true' && !SHADOW_DATABASE_URL) {
+  issues.push('SHADOW_DATABASE_URL is required when REQUIRE_SHADOW_DB=true');
+}
+
+// ── Report ────────────────────────────────────────────────────────────────────
+
+if (issues.length === 0) {
+  console.log('✅  Migration environment validation passed');
+  console.log(`    DATABASE_URL scheme : ${(DATABASE_URL || '').split(':')[0]}:`);
+  if (SHADOW_DATABASE_URL) {
+    console.log(`    SHADOW_DATABASE_URL : set`);
+  }
+  process.exit(0);
+}
+
+const label = warnOnly ? '⚠️  WARNING' : '❌  ERROR';
+console.error(`\n${label}: Migration environment validation failed\n`);
+issues.forEach(i => console.error(`  • ${i}`));
+console.error('');
+
+if (warnOnly) {
+  process.exit(0);
+} else {
+  process.exit(1);
+}

--- a/backend/scripts/validate-migration-env.test.js
+++ b/backend/scripts/validate-migration-env.test.js
@@ -1,0 +1,68 @@
+/**
+ * Tests for validate-migration-env.js
+ *
+ * Runs the script as a child process so that process.exit() calls are isolated
+ * to the subprocess and do not terminate the test runner.
+ */
+
+'use strict';
+
+const { spawnSync } = require('child_process');
+const path = require('path');
+
+const SCRIPT = path.join(__dirname, 'validate-migration-env.js');
+
+function run(env = {}) {
+  return spawnSync(process.execPath, [SCRIPT], {
+    env: { ...process.env, ...env },
+    encoding: 'utf-8',
+  });
+}
+
+describe('validate-migration-env', () => {
+  it('exits 0 when DATABASE_URL is a valid SQLite path', () => {
+    const result = run({ DATABASE_URL: 'file:./prisma/dev.db' });
+    expect(result.status).toBe(0);
+  });
+
+  it('exits 0 when DATABASE_URL is a postgresql URL', () => {
+    const result = run({ DATABASE_URL: 'postgresql://user:pass@localhost:5432/db' });
+    expect(result.status).toBe(0);
+  });
+
+  it('exits 1 when DATABASE_URL is missing', () => {
+    const { DATABASE_URL: _omit, ...envWithout } = process.env;
+    const result = spawnSync(process.execPath, [SCRIPT], {
+      env: envWithout,
+      encoding: 'utf-8',
+    });
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('DATABASE_URL is not set');
+  });
+
+  it('exits 1 when DATABASE_URL has an unrecognised scheme', () => {
+    const result = run({ DATABASE_URL: 'ftp://example.com/db' });
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('unrecognised scheme');
+  });
+
+  it('exits 0 with --warn flag even when DATABASE_URL is missing', () => {
+    const { DATABASE_URL: _omit, ...envWithout } = process.env;
+    const result = spawnSync(process.execPath, [SCRIPT, '--warn'], {
+      env: envWithout,
+      encoding: 'utf-8',
+    });
+    expect(result.status).toBe(0);
+    expect(result.stderr).toContain('WARNING');
+  });
+
+  it('exits 1 when REQUIRE_SHADOW_DB=true and SHADOW_DATABASE_URL is absent', () => {
+    const { SHADOW_DATABASE_URL: _omit, ...envWithout } = process.env;
+    const result = spawnSync(process.execPath, [SCRIPT], {
+      env: { ...envWithout, DATABASE_URL: 'file:./dev.db', REQUIRE_SHADOW_DB: 'true' },
+      encoding: 'utf-8',
+    });
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('SHADOW_DATABASE_URL');
+  });
+});


### PR DESCRIPTION
## Summary

Improves Prisma migration reliability for CI/CD pipelines as specified in issue #360.

- Adds `scripts/validate-migration-env.js`: validates `DATABASE_URL` presence and scheme, SQLite directory existence, optional shadow DB, with `--warn` mode
- Adds `scripts/bootstrap-db.sh`: idempotent local dev bootstrap (load .env ? validate ? generate ? migrate deploy ? status)
- Updates `scripts/check-migrations.js`: adds `generateClient()` step, calls env validator as subprocess, improved error handling
- Updates `.github/workflows/backend.yml`: adds Prisma generate, env validation, migration status report, and artifact upload steps
- Adds `migrate:validate-env` and `migrate:bootstrap` npm scripts

## Test plan

- [x] Validates DATABASE_URL presence, scheme, and SQLite dir existence
- [x] Exits 0 in --warn mode even when validation fails
- [x] Exits 1 when DATABASE_URL is missing without --warn
- [x] CI workflow generates Prisma client before running migrations
- [x] Migration status artifact uploaded for 7 days

Fixes #360