### PR TITLE
fix: handle KYC webhook payload parsing for Persona and Shufti

### DIFF
--- a/backend/src/services/kyc-provider.service.test.ts
+++ b/backend/src/services/kyc-provider.service.test.ts
@@ -40,7 +40,28 @@ describe('KYC provider service', () => {
     expect(provider.verifyWebhookSignature('{}', 'bad')).toBe(false);
   });
 
-  it('persona parser extracts providerRef/account/status shape', () => {
+  it('mock parser extracts providerRef/account/status shape', () => {
+    const provider = createKycProvider('mock');
+    const parsed = provider.parseWebhook({
+      account: 'GACC',
+      providerRef: 'mock_1',
+      status: 'accepted',
+    });
+
+    expect(parsed).toEqual({
+      providerRef: 'mock_1',
+      account: 'GACC',
+      status: KycStatus.ACCEPTED,
+    });
+  });
+
+  it('mock parser rejects payloads without customer identifiers', () => {
+    const provider = createKycProvider('mock');
+    expect(provider.parseWebhook({ status: 'accepted' })).toBeNull();
+    expect(provider.parseWebhook(null)).toBeNull();
+  });
+
+  it('persona parser extracts direct inquiry response shape', () => {
     const provider = createKycProvider('persona');
     const parsed = provider.parseWebhook({
       data: {
@@ -55,6 +76,114 @@ describe('KYC provider service', () => {
     expect(parsed).toEqual({
       providerRef: 'inq_1',
       account: 'GACC',
+      status: KycStatus.ACCEPTED,
+    });
+  });
+
+  it('persona parser extracts nested webhook event payload shape', () => {
+    const provider = createKycProvider('persona');
+    const parsed = provider.parseWebhook({
+      data: {
+        type: 'event',
+        id: 'evt_1',
+        attributes: {
+          name: 'inquiry.approved',
+          payload: {
+            data: {
+              type: 'inquiry',
+              id: 'inq_webhook_1',
+              attributes: {
+                'reference-id': 'GWEBHOOK',
+                status: 'approved',
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(parsed).toEqual({
+      providerRef: 'inq_webhook_1',
+      account: 'GWEBHOOK',
+      status: KycStatus.ACCEPTED,
+    });
+  });
+
+  it('persona parser maps declined event names to rejected status', () => {
+    const provider = createKycProvider('persona');
+    const parsed = provider.parseWebhook({
+      data: {
+        type: 'event',
+        id: 'evt_2',
+        attributes: {
+          name: 'inquiry.declined',
+          payload: {
+            data: {
+              id: 'inq_2',
+              attributes: {
+                'reference-id': 'GDECLINED',
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(parsed).toEqual({
+      providerRef: 'inq_2',
+      account: 'GDECLINED',
+      status: KycStatus.REJECTED,
+    });
+  });
+
+  it('shufti parser maps verification events to normalized status', () => {
+    const provider = createKycProvider('shufti');
+
+    expect(
+      provider.parseWebhook({
+        reference: 'shufti_ref_1',
+        event: 'verification.approved',
+      })
+    ).toEqual({
+      providerRef: 'shufti_ref_1',
+      account: 'shufti_ref_1',
+      status: KycStatus.ACCEPTED,
+    });
+
+    expect(
+      provider.parseWebhook({
+        reference: 'shufti_ref_2',
+        event: 'verification.declined',
+      })
+    ).toEqual({
+      providerRef: 'shufti_ref_2',
+      account: 'shufti_ref_2',
+      status: KycStatus.REJECTED,
+    });
+
+    expect(
+      provider.parseWebhook({
+        reference: 'shufti_ref_3',
+        event: 'request.pending',
+      })
+    ).toEqual({
+      providerRef: 'shufti_ref_3',
+      account: 'shufti_ref_3',
+      status: KycStatus.PENDING,
+    });
+  });
+
+  it('shufti parser prefers verification_status when present', () => {
+    const provider = createKycProvider('shufti');
+    const parsed = provider.parseWebhook({
+      reference: 'shufti_ref_4',
+      event: 'verification.status.changed',
+      verification_status: 'verified',
+    });
+
+    expect(parsed).toEqual({
+      providerRef: 'shufti_ref_4',
+      account: 'shufti_ref_4',
       status: KycStatus.ACCEPTED,
     });
   });

--- a/backend/src/services/kyc-provider.service.ts
+++ b/backend/src/services/kyc-provider.service.ts
@@ -43,8 +43,28 @@ export interface IKycProvider {
   parseWebhook(payload: unknown): KycWebhookResult | null;
 }
 
-const normalizeStatus = (rawStatus: string): KycStatus => {
+const getString = (
+  obj: Record<string, unknown> | undefined,
+  ...keys: string[]
+): string | undefined => {
+  if (!obj) return undefined;
+  for (const key of keys) {
+    const value = obj[key];
+    if (typeof value === 'string' && value.length > 0) return value;
+  }
+  return undefined;
+};
+
+const extractStatusToken = (rawStatus: string): string => {
   const value = rawStatus.toLowerCase();
+  if (value.includes('.')) {
+    return value.split('.').pop() ?? value;
+  }
+  return value.replace(/_/g, '-');
+};
+
+const normalizeStatus = (rawStatus: string): KycStatus => {
+  const value = extractStatusToken(rawStatus);
   if (['approved', 'accepted', 'completed', 'verified', 'clear'].includes(value)) {
     return KycStatus.ACCEPTED;
   }
@@ -55,6 +75,9 @@ const normalizeStatus = (rawStatus: string): KycStatus => {
 
   return KycStatus.PENDING;
 };
+
+const asRecord = (value: unknown): Record<string, unknown> | undefined =>
+  value && typeof value === 'object' ? (value as Record<string, unknown>) : undefined;
 
 const timingSafeMatch = (expected: string, actual: string): boolean => {
   const expectedBuffer = Buffer.from(expected);
@@ -90,13 +113,19 @@ class MockKycProvider implements IKycProvider {
   }
 
   parseWebhook(payload: unknown): KycWebhookResult | null {
-    if (!payload || typeof payload !== 'object') return null;
-    const body = payload as Record<string, unknown>;
-    const account = typeof body.account === 'string' ? body.account : undefined;
-    const providerRef = typeof body.providerRef === 'string' ? body.providerRef : undefined;
-    const status = typeof body.status === 'string' ? normalizeStatus(body.status) : KycStatus.PENDING;
+    const body = asRecord(payload);
+    if (!body) return null;
 
-    return { account, providerRef, status };
+    const account = getString(body, 'account');
+    const providerRef = getString(body, 'providerRef');
+    if (!account && !providerRef) return null;
+
+    const status = getString(body, 'status');
+    return {
+      account,
+      providerRef,
+      status: status ? normalizeStatus(status) : KycStatus.PENDING,
+    };
   }
 }
 
@@ -163,22 +192,31 @@ class PersonaKycProvider implements IKycProvider {
   }
 
   parseWebhook(payload: unknown): KycWebhookResult | null {
-    if (!payload || typeof payload !== 'object') return null;
-    const body = payload as Record<string, unknown>;
-    const data = body.data as Record<string, unknown> | undefined;
-    const attributes = data?.attributes as Record<string, unknown> | undefined;
+    const body = asRecord(payload);
+    const data = asRecord(body?.data);
+    if (!data) return null;
 
-    if (!data || typeof data !== 'object') return null;
+    const attributes = asRecord(data.attributes);
+    const eventPayload = asRecord(attributes?.payload);
+    const inquiry = asRecord(eventPayload?.data);
+    const inquiryAttributes = asRecord(inquiry?.attributes);
 
-    const providerRef = typeof data.id === 'string' ? data.id : undefined;
+    const providerRef = getString(inquiry, 'id') ?? getString(data, 'id');
     const account =
-      typeof attributes?.referenceId === 'string' ? attributes.referenceId : undefined;
-    const status =
-      typeof attributes?.status === 'string'
-        ? normalizeStatus(attributes.status)
-        : KycStatus.PENDING;
+      getString(inquiryAttributes, 'reference-id', 'referenceId') ??
+      getString(attributes, 'reference-id', 'referenceId');
+    if (!providerRef && !account) return null;
 
-    return { providerRef, account, status };
+    const statusSource =
+      getString(inquiryAttributes, 'status') ??
+      getString(attributes, 'name') ??
+      getString(attributes, 'status');
+
+    return {
+      providerRef,
+      account,
+      status: statusSource ? normalizeStatus(statusSource) : KycStatus.PENDING,
+    };
   }
 }
 
@@ -253,22 +291,19 @@ class ShuftiKycProvider implements IKycProvider {
   }
 
   parseWebhook(payload: unknown): KycWebhookResult | null {
-    if (!payload || typeof payload !== 'object') return null;
-    const body = payload as Record<string, unknown>;
+    const body = asRecord(payload);
+    if (!body) return null;
 
-    const providerRef = typeof body.reference === 'string' ? body.reference : undefined;
-    const account = typeof body.reference === 'string' ? body.reference : undefined;
-    const statusSource =
-      typeof body.verification_status === 'string'
-        ? body.verification_status
-        : typeof body.event === 'string'
-          ? body.event
-          : 'pending';
+    const providerRef = getString(body, 'reference');
+    const account = providerRef;
+    if (!providerRef && !account) return null;
+
+    const statusSource = getString(body, 'verification_status', 'event');
 
     return {
       providerRef,
       account,
-      status: normalizeStatus(statusSource),
+      status: statusSource ? normalizeStatus(statusSource) : KycStatus.PENDING,
     };
   }
 }


### PR DESCRIPTION
## Summary
Implements robust KYC webhook payload parsing for mock, Persona, and Shufti providers so SEP-12 webhook updates correctly identify customers and normalize provider-specific status values.

## Purpose / Motivation
Persona and Shufti send webhook payloads in formats that differ from their submission API responses. The previous parser only handled a simplified Persona inquiry shape and did not map dotted event names (for example `inquiry.approved`, `verification.declined`) to internal KYC statuses. This caused webhook-driven status updates to remain stuck in `PENDING` or fail to resolve the target customer.

## Changes Made
- Added shared helpers to safely read nested payload fields and normalize provider event/status tokens.
- Updated Persona parsing to support both direct inquiry responses and nested webhook event payloads (`attributes.payload.data`).
- Updated Shufti parsing to map callback `event` and `verification_status` fields to normalized statuses.
- Added validation so webhook payloads without a resolvable `providerRef` or `account` are rejected early.
- Expanded unit tests for mock, Persona, and Shufti webhook payload shapes and edge cases.

## How to Test
1. Run backend unit tests:
   ```bash
   cd backend
   npm test -- --testPathPattern=kyc-provider
   ```
   Expected: all KYC provider webhook parsing tests pass.

2. Mock provider webhook (development):
   - `POST /sep12/webhook`
   - Header: `x-kyc-signature: mock-valid-signature`
   - Body:
     ```json
     {
       providerRef: mock_abc,
       account: GACC...,
       status: accepted
     }
     ```
   Expected: matching KYC customer status updates to `ACCEPTED`.

3. Persona-style webhook payload:
   - Send nested event payload with `data.attributes.payload.data.id` and `reference-id`.
   Expected: customer resolved by inquiry id or reference id; status mapped from inquiry status or event name.

4. Shufti-style webhook payload:
   - Send `{ reference: ..., event: verification.approved }`.
   Expected: customer resolved by reference; status mapped to `ACCEPTED`.

## Breaking Changes
None.

## Related Issues
Closes ceejaylaboratory/AnchorPoint#376