### PR TITLE
fix: implement SEP-12 customer PUT endpoint

### DIFF
--- a/backend/src/api/controllers/sep12.controller.test.ts
+++ b/backend/src/api/controllers/sep12.controller.test.ts
@@ -1,5 +1,7 @@
 import type { Request, Response } from 'express';
 
+const VALID_ACCOUNT = 'GD5DJQDKEBTHBQC7LKLDSLRGEA3KMRMFOKMJUEKSFZLWQ5E2PJDJYZNF';
+
 const prismaMock = {
   user: {
     findUnique: jest.fn(),
@@ -45,6 +47,16 @@ jest.mock('../../services/crypto.service', () => ({
   cryptoService: cryptoMock,
 }));
 
+jest.mock('../../utils/logger', () => ({
+  __esModule: true,
+  default: {
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
 import { sep12Controller } from './sep12.controller';
 
 const makeRes = (): Response => {
@@ -60,49 +72,197 @@ describe('Sep12Controller', () => {
     jest.clearAllMocks();
   });
 
-  it('submits customer to provider and persists provider metadata', async () => {
-    const req = {
-      body: {
-        account: 'GACC',
-        first_name: 'Jane',
-        last_name: 'Doe',
-        email_address: 'jane@example.com',
-      },
-      files: undefined,
-    } as unknown as Request;
-    const res = makeRes();
+  describe('putCustomer', () => {
+    it('returns 400 when account is missing', async () => {
+      const req = {
+        body: { first_name: 'Jane' },
+        user: { publicKey: VALID_ACCOUNT },
+      } as unknown as Request;
+      const res = makeRes();
 
-    prismaMock.user.findUnique.mockResolvedValue({ id: 'u1', publicKey: 'GACC' });
-    prismaMock.kycCustomer.upsert.mockResolvedValue({ id: 'k1' });
-    providerMock.submitCustomer.mockResolvedValue({
-      success: true,
-      status: 'PENDING',
-      providerRef: 'mock_123',
+      await sep12Controller.putCustomer(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({ error: 'account is required' });
     });
 
-    await sep12Controller.putCustomer(req, res);
+    it('returns 400 for an invalid Stellar account', async () => {
+      const req = {
+        body: { account: 'not-a-stellar-key' },
+        user: { publicKey: 'not-a-stellar-key' },
+      } as unknown as Request;
+      const res = makeRes();
 
-    expect(providerMock.submitCustomer).toHaveBeenCalledWith(
-      {
-        account: 'GACC',
-        firstName: 'Jane',
-        lastName: 'Doe',
-        email: 'jane@example.com',
-        extraFields: {},
-      },
-      {}
-    );
+      await sep12Controller.putCustomer(req, res);
 
-    expect(prismaMock.kycCustomer.update).toHaveBeenCalledWith({
-      where: { id: 'k1' },
-      data: {
-        provider: 'mock',
-        providerRef: 'mock_123',
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({ error: 'Invalid Stellar account' });
+    });
+
+    it('returns 403 when authenticated account does not match request account', async () => {
+      const req = {
+        body: { account: VALID_ACCOUNT },
+        user: { publicKey: 'GBZXN7PIRZGNMHGA7MUUUF4GW3F55GQRQ5UKMJTDEFEKTGW4RHFDQLNZ' },
+      } as unknown as Request;
+      const res = makeRes();
+
+      await sep12Controller.putCustomer(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(res.json).toHaveBeenCalledWith({
+        error: 'Authenticated account does not match request account',
+      });
+    });
+
+    it('creates a user when one does not exist and submits to provider', async () => {
+      const req = {
+        body: {
+          account: VALID_ACCOUNT,
+          first_name: 'Jane',
+          last_name: 'Doe',
+          email_address: 'jane@example.com',
+        },
+        user: { publicKey: VALID_ACCOUNT },
+        files: undefined,
+      } as unknown as Request;
+      const res = makeRes();
+
+      prismaMock.user.findUnique.mockResolvedValue(null);
+      prismaMock.user.create.mockResolvedValue({ id: 'u1', publicKey: VALID_ACCOUNT });
+      prismaMock.kycCustomer.upsert.mockResolvedValue({ id: 'k1' });
+      providerMock.submitCustomer.mockResolvedValue({
+        success: true,
         status: 'PENDING',
-      },
+        providerRef: 'mock_123',
+      });
+
+      await sep12Controller.putCustomer(req, res);
+
+      expect(prismaMock.user.create).toHaveBeenCalledWith({
+        data: { publicKey: VALID_ACCOUNT },
+      });
+      expect(providerMock.submitCustomer).toHaveBeenCalledWith(
+        {
+          account: VALID_ACCOUNT,
+          firstName: 'Jane',
+          lastName: 'Doe',
+          email: 'jane@example.com',
+          extraFields: {},
+        },
+        {}
+      );
+      expect(prismaMock.kycCustomer.update).toHaveBeenCalledWith({
+        where: { id: 'k1' },
+        data: {
+          provider: 'mock',
+          providerRef: 'mock_123',
+          status: 'PENDING',
+        },
+      });
+      expect(res.status).toHaveBeenCalledWith(202);
+      expect(res.json).toHaveBeenCalledWith({
+        id: VALID_ACCOUNT,
+        status: 'PROCESSING',
+      });
     });
 
-    expect(res.status).toHaveBeenCalledWith(202);
+    it('submits customer to provider and persists provider metadata', async () => {
+      const req = {
+        body: {
+          account: VALID_ACCOUNT,
+          first_name: 'Jane',
+          last_name: 'Doe',
+          email_address: 'jane@example.com',
+        },
+        user: { publicKey: VALID_ACCOUNT },
+        files: undefined,
+      } as unknown as Request;
+      const res = makeRes();
+
+      prismaMock.user.findUnique.mockResolvedValue({ id: 'u1', publicKey: VALID_ACCOUNT });
+      prismaMock.kycCustomer.upsert.mockResolvedValue({ id: 'k1' });
+      providerMock.submitCustomer.mockResolvedValue({
+        success: true,
+        status: 'PENDING',
+        providerRef: 'mock_123',
+      });
+
+      await sep12Controller.putCustomer(req, res);
+
+      expect(providerMock.submitCustomer).toHaveBeenCalledWith(
+        {
+          account: VALID_ACCOUNT,
+          firstName: 'Jane',
+          lastName: 'Doe',
+          email: 'jane@example.com',
+          extraFields: {},
+        },
+        {}
+      );
+
+      expect(prismaMock.kycCustomer.update).toHaveBeenCalledWith({
+        where: { id: 'k1' },
+        data: {
+          provider: 'mock',
+          providerRef: 'mock_123',
+          status: 'PENDING',
+        },
+      });
+
+      expect(res.status).toHaveBeenCalledWith(202);
+      expect(res.json).toHaveBeenCalledWith({
+        id: VALID_ACCOUNT,
+        status: 'PROCESSING',
+      });
+    });
+
+    it('includes uploaded document paths when files are present', async () => {
+      const req = {
+        body: { account: VALID_ACCOUNT, first_name: 'Jane' },
+        user: { publicKey: VALID_ACCOUNT },
+        files: {
+          id_photo_front: [{ path: '/uploads/kyc/id-front.jpg' }],
+        },
+      } as unknown as Request;
+      const res = makeRes();
+
+      prismaMock.user.findUnique.mockResolvedValue({ id: 'u1', publicKey: VALID_ACCOUNT });
+      prismaMock.kycCustomer.upsert.mockResolvedValue({ id: 'k1' });
+      providerMock.submitCustomer.mockResolvedValue({
+        success: true,
+        status: 'PENDING',
+        providerRef: 'mock_456',
+      });
+
+      await sep12Controller.putCustomer(req, res);
+
+      expect(providerMock.submitCustomer).toHaveBeenCalledWith(
+        expect.objectContaining({ account: VALID_ACCOUNT, firstName: 'Jane' }),
+        { id_photo_front: '/uploads/kyc/id-front.jpg' }
+      );
+      expect(res.status).toHaveBeenCalledWith(202);
+    });
+
+    it('returns 202 with PROCESSING when provider submission fails', async () => {
+      const req = {
+        body: { account: VALID_ACCOUNT, first_name: 'Jane' },
+        user: { publicKey: VALID_ACCOUNT },
+      } as unknown as Request;
+      const res = makeRes();
+
+      prismaMock.user.findUnique.mockResolvedValue({ id: 'u1', publicKey: VALID_ACCOUNT });
+      prismaMock.kycCustomer.upsert.mockResolvedValue({ id: 'k1' });
+      providerMock.submitCustomer.mockRejectedValue(new Error('Provider unavailable'));
+
+      await sep12Controller.putCustomer(req, res);
+
+      expect(prismaMock.kycCustomer.update).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(202);
+      expect(res.json).toHaveBeenCalledWith({
+        id: VALID_ACCOUNT,
+        status: 'PROCESSING',
+      });
+    });
   });
 
   it('updates customer KYC status via webhook providerRef lookup', async () => {

--- a/backend/src/api/controllers/sep12.controller.ts
+++ b/backend/src/api/controllers/sep12.controller.ts
@@ -1,11 +1,18 @@
-import { Request, Response } from 'express';
+import { Response } from 'express';
+import { StrKey } from '@stellar/stellar-sdk';
 import prisma from '../../lib/prisma';
 import { cryptoService } from '../../services/crypto.service';
 import { kycProvider, KycStatus } from '../../services/kyc-provider.service';
 import { KYCStatus } from '@prisma/client';
+import { AuthRequest } from '../middleware/auth.middleware';
+import logger from '../../utils/logger';
+
+type UploadedFiles = { [fieldname: string]: Array<{ path: string }> };
+
+const pack = (enc?: { encryptedData: string; iv: string } | null) =>
+  enc ? `${enc.iv}|${enc.encryptedData}` : null;
 
 export class Sep12Controller {
-
   private toDbStatus(status: KycStatus): KYCStatus {
     switch (status) {
       case KycStatus.ACCEPTED:
@@ -16,62 +23,76 @@ export class Sep12Controller {
         return KYCStatus.PENDING;
     }
   }
-  
-  async putCustomer(req: Request, res: Response) {
+
+  private toSep12Status(status: KycStatus): string {
+    switch (status) {
+      case KycStatus.ACCEPTED:
+        return 'ACCEPTED';
+      case KycStatus.REJECTED:
+        return 'REJECTED';
+      default:
+        return 'PROCESSING';
+    }
+  }
+
+  /**
+   * PUT /sep12/customer
+   * Accepts customer KYC fields (JSON, form-urlencoded, or multipart) and
+   * forwards the submission to the configured KYC provider.
+   */
+  async putCustomer(req: AuthRequest, res: Response) {
     try {
-      const { account, memo, memo_type, first_name, last_name, email_address, ...otherFields } = req.body;
+      const {
+        account,
+        memo: _memo,
+        memo_type: _memoType,
+        first_name,
+        last_name,
+        email_address,
+        ...otherFields
+      } = req.body as Record<string, string>;
 
       if (!account) {
         return res.status(400).json({ error: 'account is required' });
       }
 
-      // In a real app, verify that the account is authenticated (SEP-10).
-      // Find or create User based on account
+      if (!StrKey.isValidEd25519PublicKey(account)) {
+        return res.status(400).json({ error: 'Invalid Stellar account' });
+      }
+
+      if (req.user!.publicKey !== account) {
+        return res.status(403).json({ error: 'Authenticated account does not match request account' });
+      }
+
       let user = await prisma.user.findUnique({ where: { publicKey: account } });
       if (!user) {
         user = await prisma.user.create({ data: { publicKey: account } });
       }
 
-      // Handle File Uploads (Multer puts files in req.files)
-      const uploadedFiles = (req as any).files as
-        | { [fieldname: string]: Array<{ path: string }> }
-        | undefined;
+      const uploadedFiles = (req as AuthRequest & { files?: UploadedFiles }).files;
       const documents: Record<string, string> = {};
       if (uploadedFiles) {
-        Object.keys(uploadedFiles).forEach((field) => {
+        for (const field of Object.keys(uploadedFiles)) {
           documents[field] = uploadedFiles[field][0].path;
-        });
+        }
       }
 
-      // Encrypt PII data
-      const extraFieldsJson = JSON.stringify(otherFields);
-      const encryptedFirstName = first_name ? cryptoService.encrypt(first_name) : null;
-      const encryptedLastName = last_name ? cryptoService.encrypt(last_name) : null;
-      const encryptedEmail = email_address ? cryptoService.encrypt(email_address) : null;
-      const encryptedExtra = Object.keys(otherFields).length > 0 ? cryptoService.encrypt(extraFieldsJson) : null;
+      const extraPayload: Record<string, unknown> = { ...otherFields };
+      if (Object.keys(documents).length > 0) {
+        extraPayload.documents = documents;
+      }
 
-      // We need a single IV for the record, or we can just use the first one and store it, 
-      // but cryptoService returns an IV per encryption. 
-      // A better approach for the schema is to store the combined encrypted string which includes the IV in our format.
-      // Wait, our CryptoService `encrypt` returns `{ encryptedData, iv }`.
-      // Let's store the raw IV from one of them if we had a single IV, but our encrypt function generates a random IV each time.
-      // We can just serialize the object `{ data, iv }` into the DB string, or update the DB to just store the concatenated string.
-      // Actually, since we added `encryptionIV` to the schema, let's use a single IV for all fields by modifying the crypto flow,
-      // or we can just ignore `encryptionIV` column and store the IVs inside a JSON if needed.
-      // Let's just use a generated IV for the whole record to be safe, but our `encrypt` method doesn't take IV as input.
-      // I will just concatenate IV:Data:AuthTag inside the string for simplicity, or just use the first generated IV to fill the schema column.
-
-      // Let's adjust to store JSON in DB for the encrypted fields since they need IV.
-      const pack = (enc?: { encryptedData: string, iv: string } | null) => enc ? `${enc.iv}|${enc.encryptedData}` : null;
-
-      const dbData: any = {
+      const dbData = {
         userId: user.id,
-        firstName: pack(encryptedFirstName),
-        lastName: pack(encryptedLastName),
-        email: pack(encryptedEmail),
-        extraFields: pack(encryptedExtra),
-        documents: documents,
-        status: KYCStatus.PENDING
+        firstName: pack(first_name ? cryptoService.encrypt(first_name) : null),
+        lastName: pack(last_name ? cryptoService.encrypt(last_name) : null),
+        email: pack(email_address ? cryptoService.encrypt(email_address) : null),
+        extraFields: pack(
+          Object.keys(extraPayload).length > 0
+            ? cryptoService.encrypt(JSON.stringify(extraPayload))
+            : null
+        ),
+        status: KYCStatus.PENDING,
       };
 
       const kycCustomer = await prisma.kycCustomer.upsert({
@@ -80,7 +101,6 @@ export class Sep12Controller {
         create: dbData,
       });
 
-      // Submit to 3rd party Provider
       const customerData = {
         account,
         firstName: first_name,
@@ -88,30 +108,45 @@ export class Sep12Controller {
         email: email_address,
         extraFields: otherFields,
       };
-      const providerRes = await kycProvider.submitCustomer(customerData, documents);
 
-      await prisma.kycCustomer.update({
-        where: { id: kycCustomer.id },
-        data: {
-          provider: kycProvider.providerName,
-          providerRef: providerRes.providerRef,
-          status: this.toDbStatus(providerRes.status),
-        },
+      let providerStatus = KycStatus.PENDING;
+      try {
+        const providerRes = await kycProvider.submitCustomer(customerData, documents);
+        providerStatus = providerRes.status;
+
+        await prisma.kycCustomer.update({
+          where: { id: kycCustomer.id },
+          data: {
+            provider: kycProvider.providerName,
+            providerRef: providerRes.providerRef,
+            status: this.toDbStatus(providerRes.status),
+          },
+        });
+      } catch (providerError) {
+        logger.error('SEP-12 customer provider submission failed', {
+          error: providerError instanceof Error ? providerError.message : 'Unknown error',
+          account,
+        });
+      }
+
+      logger.info('SEP-12 customer submitted', {
+        account,
+        status: this.toSep12Status(providerStatus),
       });
 
-      res.status(202).json({
+      return res.status(202).json({
         id: user.publicKey,
-        status: providerRes.status,
-        provider: kycProvider.providerName,
+        status: this.toSep12Status(providerStatus),
       });
-
     } catch (error) {
-      console.error(error);
-      res.status(500).json({ error: 'Internal Server Error' });
+      logger.error('SEP-12 customer PUT failed', {
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+      return res.status(500).json({ error: 'Internal Server Error' });
     }
   }
 
-  async getCustomer(req: Request, res: Response) {
+  async getCustomer(req: AuthRequest, res: Response) {
     try {
       const account = req.query.account as string;
       if (!account) return res.status(400).json({ error: 'account is required' });
@@ -121,33 +156,44 @@ export class Sep12Controller {
         return res.status(404).json({ error: 'Customer not found' });
       }
 
-      const unpack = (packed?: string | null) => {
-        if (!packed) return null;
-        const [iv, data] = packed.split('|');
-        return cryptoService.decrypt(data, iv);
-      };
-
       const customer = user.kycCustomer;
-      const responsePayload: any = {
+      const responsePayload: Record<string, unknown> = {
         id: user.publicKey,
         status: customer.status,
       };
 
       if (customer.status === KYCStatus.ACCEPTED) {
         responsePayload.provided_fields = {};
-        if (customer.firstName) responsePayload.provided_fields.first_name = { description: "First Name", status: "ACCEPTED" };
-        if (customer.lastName) responsePayload.provided_fields.last_name = { description: "Last Name", status: "ACCEPTED" };
-        if (customer.email) responsePayload.provided_fields.email_address = { description: "Email", status: "ACCEPTED" };
+        if (customer.firstName) {
+          (responsePayload.provided_fields as Record<string, unknown>).first_name = {
+            description: 'First Name',
+            status: 'ACCEPTED',
+          };
+        }
+        if (customer.lastName) {
+          (responsePayload.provided_fields as Record<string, unknown>).last_name = {
+            description: 'Last Name',
+            status: 'ACCEPTED',
+          };
+        }
+        if (customer.email) {
+          (responsePayload.provided_fields as Record<string, unknown>).email_address = {
+            description: 'Email',
+            status: 'ACCEPTED',
+          };
+        }
       }
 
       res.json(responsePayload);
     } catch (error) {
-      console.error(error);
+      logger.error('SEP-12 customer GET failed', {
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
       res.status(500).json({ error: 'Internal Server Error' });
     }
   }
 
-  async deleteCustomer(req: Request, res: Response) {
+  async deleteCustomer(req: AuthRequest, res: Response) {
     try {
       const account = req.params.account;
       if (!account) return res.status(400).json({ error: 'account is required' });
@@ -158,12 +204,14 @@ export class Sep12Controller {
       }
       res.status(200).send();
     } catch (error) {
-      console.error(error);
+      logger.error('SEP-12 customer DELETE failed', {
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
       res.status(404).json({ error: 'Customer not found' });
     }
   }
 
-  async handleWebhook(req: Request, res: Response) {
+  async handleWebhook(req: AuthRequest, res: Response) {
     try {
       const signature = req.headers['x-kyc-signature'] as string | undefined;
       const payloadString = JSON.stringify(req.body);
@@ -200,12 +248,14 @@ export class Sep12Controller {
 
       await prisma.kycCustomer.update({
         where: { id: targetCustomer.id },
-        data: { status: this.toDbStatus(event.status) }
+        data: { status: this.toDbStatus(event.status) },
       });
 
       res.status(200).send('OK');
     } catch (error) {
-      console.error(error);
+      logger.error('SEP-12 webhook handling failed', {
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
       res.status(500).json({ error: 'Internal Server Error' });
     }
   }

--- a/backend/src/api/routes/sep12.route.ts
+++ b/backend/src/api/routes/sep12.route.ts
@@ -3,6 +3,7 @@ import multer from 'multer';
 import fs from 'fs';
 import path from 'path';
 import { sep12Controller } from '../controllers/sep12.controller';
+import { authMiddleware } from '../middleware/auth.middleware';
 
 const router = Router();
 
@@ -32,7 +33,7 @@ const upload = multer({ storage: storage });
  *     summary: Upload customer information and documents
  *     tags: [SEP-12]
  */
-router.put('/customer', upload.any(), sep12Controller.putCustomer);
+router.put('/customer', authMiddleware, upload.any(), sep12Controller.putCustomer);
 
 /**
  * @swagger

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -7,6 +7,7 @@ import logger from './utils/logger';
 import transactionsRouter from './api/routes/transactions.route';
 import adminRouter from './api/routes/admin.route';
 import sep24Router from './api/routes/sep24.route';
+import sep12Router from './api/routes/sep12.route';
 import sep6Router from './api/routes/sep6.route';
 import sep38Router from './api/routes/sep38.route';
 import sep40Router from './api/routes/sep40.route';
@@ -39,6 +40,7 @@ const PORT = config.PORT;
 
 app.use(cors());
 app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
 
 /**
  * @swagger
@@ -139,6 +141,9 @@ app.use('/sep40', sep40Router);
 
 // SEP-1 Info endpoint
 app.use('/info', infoRouter);
+
+// SEP-12 KYC routes
+app.use('/sep12', sep12Router);
 
 // SEP-24 routes
 app.use('/sep24', sep24Router);

--- a/backend/src/services/kyc-provider.service.ts
+++ b/backend/src/services/kyc-provider.service.ts
@@ -67,7 +67,10 @@ const timingSafeMatch = (expected: string, actual: string): boolean => {
 class MockKycProvider implements IKycProvider {
   readonly providerName = 'mock';
 
-  async submitCustomer(data: KycSubmissionInput): Promise<KycSubmissionResult> {
+  async submitCustomer(
+    data: KycSubmissionInput,
+    _documents: Record<string, string> = {}
+  ): Promise<KycSubmissionResult> {
     if (data.email && data.email.includes('reject')) {
       return {
         success: true,


### PR DESCRIPTION
## Summary
Implements the SEP-12 `PUT /sep12/customer` endpoint for submitting customer KYC data, including route registration, SEP-10 authentication, encrypted PII persistence, and KYC provider submission.

## Purpose / Motivation
AnchorPoint had SEP-12 controller and route code that was never mounted on the Express app, and the PUT handler referenced a non-existent Prisma field, lacked authentication, and did not follow project logging or validation conventions. This change makes the endpoint reachable and production-ready for testnet deployment.

## Changes Made
- Mount `/sep12` routes in the backend entrypoint and enable `urlencoded` body parsing for SEP-12 form submissions.
- Require SEP-10 JWT auth on `PUT /sep12/customer` and verify the authenticated account matches the request `account`.
- Validate Stellar public keys, encrypt PII at rest, store document references inside encrypted `extraFields`, and submit to the configured KYC provider.
- Map provider status to SEP-12 response values (`PROCESSING`, `ACCEPTED`, `REJECTED`) and return HTTP 202 on success.
- Add structured logging via the shared logger (no PII or secrets logged).
- Expand unit tests for validation, auth mismatch, user creation, file uploads, and provider failure handling.

## How to Test
1. Start the backend with `KYC_PROVIDER=mock` and a valid `JWT_SECRET`.
2. Obtain a SEP-10 JWT for a test Stellar account via `POST /auth`.
3. Send `PUT /sep12/customer` with `Authorization: Bearer <token>` and JSON body:
   ```json
   {
     "account": "<same account as JWT>",
     "first_name": "Jane",
     "last_name": "Doe",
     "email_address": "jane@example.com"
   }
   ```
4. Expect HTTP **202** with `{ "id": "<account>", "status": "PROCESSING" }`.
5. Send the same request with a mismatched `account` — expect HTTP **403**.
6. Omit `account` — expect HTTP **400**.
7. Run unit tests: `cd backend && npm test -- sep12.controller.test.ts`

## Breaking Changes
- None. The endpoint was previously unreachable; clients must now supply a valid SEP-10 JWT as documented in the Postman collection.

## Related Issues
Closes ceejaylaboratory/AnchorPoint#375

## Checklist
- [x] Code builds successfully
- [x] Tests added/updated
- [x] No console errors
- [x] Documentation updated (if needed)
