### PR TITLE
fix: add automated key rotation cron worker

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -47,6 +47,12 @@ AWS_REGION=us-east-1
 # This is the public key used for signing, NOT a private key
 SIGNING_KEY=GBXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
+# Automated Key Rotation Worker
+# Set to true to run the key rotation cron worker as a separate process
+ENABLE_KEY_ROTATION_WORKER=false
+# Cron schedule (default: 00:00 on the 1st of every month)
+KEY_ROTATION_WORKER_CRON=0 0 1 * *
+
 # Receiving and Distribution Accounts
 RECEIVING_ACCOUNT=GBXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 # DISTRIBUTION_ACCOUNT=GBXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

--- a/backend/docs/KEY_MANAGEMENT.md
+++ b/backend/docs/KEY_MANAGEMENT.md
@@ -141,6 +141,37 @@ const result = await batchService.executeBatch({
 
 ## Key Rotation
 
+### Automated Rotation (Cron Worker)
+
+The backend includes a dedicated cron worker that rotates encryption keys on a configurable schedule. This is the recommended approach for testnet and production deployments.
+
+**Start the worker:**
+
+```bash
+# Enable in environment
+ENABLE_KEY_ROTATION_WORKER=true
+KEY_ROTATION_WORKER_CRON=0 0 1 * *   # monthly at midnight (default)
+
+# Run as a separate process
+npm run start:worker:key-rotation
+```
+
+**Backend behavior:**
+
+| Backend | Cron action |
+|---------|-------------|
+| **AWS KMS** | Ensures automatic key rotation is enabled (annual rotation by AWS) |
+| **Vault** | Rotates the Transit engine key to a new version via `/keys/stellar-keys/rotate` |
+
+Old key versions remain available for decryption after rotation. No downtime is required.
+
+**Environment variables:**
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ENABLE_KEY_ROTATION_WORKER` | `false` | Set to `true` to activate the worker |
+| `KEY_ROTATION_WORKER_CRON` | `0 0 1 * *` | Cron expression for rotation schedule |
+
 ### Automatic Rotation (AWS KMS)
 
 AWS KMS supports automatic key rotation:

--- a/backend/package.json
+++ b/backend/package.json
@@ -9,6 +9,7 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "start:worker:recurring-payments": "node dist/workers/recurring-payments.worker.js",
+    "start:worker:key-rotation": "node dist/workers/key-rotation.worker.js",
     "bench": "ts-node -P tsconfig.perf.json perf/bench.ts",
     "bench:sep38": "cross-env BENCH_ONLY=sep38_price_get ts-node -P tsconfig.perf.json perf/bench.ts",
     "bench:sep6:deposit": "cross-env BENCH_ONLY=sep6_deposit ts-node -P tsconfig.perf.json perf/bench.ts",

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -63,6 +63,8 @@ const envSchema = z.object({
   VAULT_TOKEN: z.string().optional(),
   VAULT_TRANSIT_PATH: z.string().optional(),
   SIGNING_KEY: z.string().optional(),
+  ENABLE_KEY_ROTATION_WORKER: z.enum(['true', 'false']).default('false'),
+  KEY_ROTATION_WORKER_CRON: z.string().default('0 0 1 * *'),
   KYC_PROVIDER: z.enum(['mock', 'persona', 'shufti']).default('mock'),
   KYC_WEBHOOK_SECRET: z.string().optional(),
   PERSONA_API_KEY: z.string().optional(),

--- a/backend/src/lib/key-management.service.test.ts
+++ b/backend/src/lib/key-management.service.test.ts
@@ -20,6 +20,8 @@ jest.mock('@aws-sdk/client-kms', () => ({
   EncryptCommand: jest.fn().mockImplementation((params) => params),
   DecryptCommand: jest.fn().mockImplementation((params) => params),
   DescribeKeyCommand: jest.fn().mockImplementation((params) => params),
+  GetKeyRotationStatusCommand: jest.fn().mockImplementation((params) => params),
+  EnableKeyRotationCommand: jest.fn().mockImplementation((params) => params),
 }));
 
 describe('Key Management Service', () => {
@@ -257,6 +259,58 @@ describe('Key Management Service', () => {
         const result = await service.isHealthy();
 
         expect(result).toBe(false);
+      });
+    });
+
+    describe('rotateEncryptionKey', () => {
+      it('should enable rotation when not already enabled', async () => {
+        const mockKmsClient = {
+          send: jest
+            .fn()
+            .mockResolvedValueOnce({ KeyRotationEnabled: false })
+            .mockResolvedValueOnce({}),
+        };
+
+        jest.doMock('@aws-sdk/client-kms', () => ({
+          KMSClient: jest.fn().mockImplementation(() => mockKmsClient),
+          GetKeyRotationStatusCommand: jest.fn().mockImplementation((params) => params),
+          EnableKeyRotationCommand: jest.fn().mockImplementation((params) => params),
+        }));
+
+        const config = {
+          backend: 'aws-kms' as const,
+          keyArn: 'arn:aws:kms:us-east-1:123456789012:key/12345678',
+        };
+
+        const service = createKeyManagementService(config);
+        const result = await service.rotateEncryptionKey();
+
+        expect(result.rotated).toBe(true);
+        expect(result.backend).toBe('aws-kms');
+        expect(result.success).toBe(true);
+      });
+
+      it('should skip enable when rotation is already active', async () => {
+        const mockKmsClient = {
+          send: jest.fn().mockResolvedValue({ KeyRotationEnabled: true }),
+        };
+
+        jest.doMock('@aws-sdk/client-kms', () => ({
+          KMSClient: jest.fn().mockImplementation(() => mockKmsClient),
+          GetKeyRotationStatusCommand: jest.fn().mockImplementation((params) => params),
+          EnableKeyRotationCommand: jest.fn().mockImplementation((params) => params),
+        }));
+
+        const config = {
+          backend: 'aws-kms' as const,
+          keyArn: 'arn:aws:kms:us-east-1:123456789012:key/12345678',
+        };
+
+        const service = createKeyManagementService(config);
+        const result = await service.rotateEncryptionKey();
+
+        expect(result.rotated).toBe(false);
+        expect(result.message).toContain('already enabled');
       });
     });
   });

--- a/backend/src/lib/key-management.service.ts
+++ b/backend/src/lib/key-management.service.ts
@@ -20,6 +20,7 @@ import {
   AwsKmsConfig,
   VaultConfig,
   KeyManagementConfig,
+  KeyRotationResult,
 } from './key-management.types';
 
 /**
@@ -234,6 +235,56 @@ class AwsKmsService implements IKeyManagementService {
     }
   }
 
+  /**
+   * Ensure automatic key rotation is enabled for the AWS KMS key.
+   * AWS rotates symmetric CMKs annually once enabled; old versions remain decryptable.
+   */
+  async rotateEncryptionKey(): Promise<KeyRotationResult> {
+    const timestamp = Date.now();
+
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const { GetKeyRotationStatusCommand, EnableKeyRotationCommand } = require('@aws-sdk/client-kms');
+
+      const statusCommand = new GetKeyRotationStatusCommand({ KeyId: this.keyArn });
+      const statusResponse = await this.kmsClient.send(statusCommand);
+
+      if (statusResponse.KeyRotationEnabled) {
+        logger.info('AWS KMS automatic key rotation is already enabled');
+        return {
+          success: true,
+          backend: 'aws-kms',
+          rotated: false,
+          keyVersion: this.keyArn,
+          message: 'Automatic key rotation already enabled',
+          timestamp,
+        };
+      }
+
+      const enableCommand = new EnableKeyRotationCommand({ KeyId: this.keyArn });
+      await this.kmsClient.send(enableCommand);
+
+      logger.info('AWS KMS automatic key rotation enabled successfully');
+
+      return {
+        success: true,
+        backend: 'aws-kms',
+        rotated: true,
+        keyVersion: this.keyArn,
+        message: 'Automatic key rotation enabled',
+        timestamp,
+      };
+    } catch (error: any) {
+      logger.error(`AWS KMS key rotation failed: ${error?.name ?? error?.message ?? error}`);
+
+      throw new KeyManagementError(
+        KeyManagementErrorType.ENCRYPTION_FAILED,
+        'Failed to configure AWS KMS key rotation',
+        { originalError: error?.message }
+      );
+    }
+  }
+
   private delay(ms: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, ms));
   }
@@ -437,6 +488,48 @@ class VaultService implements IKeyManagementService {
     }
   }
 
+  /**
+   * Rotate the Vault Transit engine encryption key to a new version.
+   * Previous versions remain available for decryption.
+   */
+  async rotateEncryptionKey(): Promise<KeyRotationResult> {
+    const timestamp = Date.now();
+
+    try {
+      const response = await this.vaultClient.write(
+        `${this.transitPath}/keys/stellar-keys/rotate`
+      );
+
+      const keyVersion = response.data?.latest_version?.toString() ?? 'unknown';
+
+      logger.info(`Vault Transit key rotated successfully (version ${keyVersion})`);
+
+      return {
+        success: true,
+        backend: 'vault',
+        rotated: true,
+        keyVersion,
+        message: `Transit key rotated to version ${keyVersion}`,
+        timestamp,
+      };
+    } catch (error: any) {
+      logger.error(`Vault key rotation failed: ${error?.message ?? error}`);
+
+      let errorType = KeyManagementErrorType.ENCRYPTION_FAILED;
+      if (error?.statusCode === 403) {
+        errorType = KeyManagementErrorType.UNAUTHORIZED;
+      } else if (error?.statusCode === 404) {
+        errorType = KeyManagementErrorType.KEY_NOT_FOUND;
+      }
+
+      throw new KeyManagementError(
+        errorType,
+        'Failed to rotate Vault Transit encryption key',
+        { originalError: error?.message }
+      );
+    }
+  }
+
   private delay(ms: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, ms));
   }
@@ -484,4 +577,43 @@ export function getKeyManagementService(): IKeyManagementService {
 export function initializeKeyManagement(config: KeyManagementConfig): void {
   keyManagementServiceInstance = createKeyManagementService(config);
   logger.info(`Key management service initialized with backend: ${config.backend}`);
+}
+
+/**
+ * Build key management configuration from environment variables.
+ * Returns null when required credentials are missing.
+ */
+export function buildKeyManagementConfigFromEnv(env: {
+  KEY_MANAGEMENT_BACKEND: 'aws-kms' | 'vault';
+  AWS_KMS_KEY_ARN?: string;
+  AWS_REGION?: string;
+  AWS_ACCESS_KEY_ID?: string;
+  AWS_SECRET_ACCESS_KEY?: string;
+  VAULT_ADDR?: string;
+  VAULT_TOKEN?: string;
+  VAULT_TRANSIT_PATH?: string;
+}): KeyManagementConfig | null {
+  if (env.KEY_MANAGEMENT_BACKEND === 'aws-kms') {
+    if (!env.AWS_KMS_KEY_ARN) {
+      return null;
+    }
+    return {
+      backend: 'aws-kms',
+      keyArn: env.AWS_KMS_KEY_ARN,
+      region: env.AWS_REGION,
+      accessKeyId: env.AWS_ACCESS_KEY_ID,
+      secretAccessKey: env.AWS_SECRET_ACCESS_KEY,
+    };
+  }
+
+  if (!env.VAULT_ADDR || !env.VAULT_TOKEN || !env.VAULT_TRANSIT_PATH) {
+    return null;
+  }
+
+  return {
+    backend: 'vault',
+    address: env.VAULT_ADDR,
+    token: env.VAULT_TOKEN,
+    transitPath: env.VAULT_TRANSIT_PATH,
+  };
 }

--- a/backend/src/lib/key-management.types.ts
+++ b/backend/src/lib/key-management.types.ts
@@ -39,6 +39,20 @@ export interface EncryptedKey {
 }
 
 /**
+ * Result of an encryption key rotation operation.
+ * Contains metadata only — never plaintext key material.
+ */
+export interface KeyRotationResult {
+  success: boolean;
+  backend: 'aws-kms' | 'vault';
+  /** Whether a new key version was created or rotation was enabled */
+  rotated: boolean;
+  keyVersion?: string;
+  message: string;
+  timestamp: number;
+}
+
+/**
  * Key Management Error
  * 
  * Structured error type for key management operations.
@@ -105,6 +119,16 @@ export interface IKeyManagementService {
    * @returns true if service is healthy and accessible
    */
   isHealthy(): Promise<boolean>;
+
+  /**
+   * Rotate the encryption key at the vault/KMS backend.
+   *
+   * - AWS KMS: ensures automatic key rotation is enabled (annual rotation).
+   * - Vault: rotates the Transit engine key to a new version.
+   *
+   * Security Note: Never logs or returns plaintext key material.
+   */
+  rotateEncryptionKey(): Promise<KeyRotationResult>;
 }
 
 /**

--- a/backend/src/services/key-rotation.service.test.ts
+++ b/backend/src/services/key-rotation.service.test.ts
@@ -1,0 +1,114 @@
+import {
+  KeyManagementError,
+  KeyManagementErrorType,
+} from '../lib/key-management.types';
+import { KeyRotationService } from './key-rotation.service';
+
+jest.mock('../lib/key-management.service', () => ({
+  buildKeyManagementConfigFromEnv: jest.fn(),
+  initializeKeyManagement: jest.fn(),
+  getKeyManagementService: jest.fn(),
+}));
+
+jest.mock('../config/env', () => ({
+  config: {
+    KEY_MANAGEMENT_BACKEND: 'aws-kms',
+    AWS_KMS_KEY_ARN: 'arn:aws:kms:us-east-1:123456789012:key/test',
+  },
+}));
+
+const {
+  buildKeyManagementConfigFromEnv,
+  initializeKeyManagement,
+  getKeyManagementService,
+} = jest.requireMock('../lib/key-management.service');
+
+describe('KeyRotationService', () => {
+  let service: KeyRotationService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new KeyRotationService();
+  });
+
+  it('throws when key management is not configured', async () => {
+    buildKeyManagementConfigFromEnv.mockReturnValue(null);
+
+    await expect(service.rotateKeys()).rejects.toMatchObject({
+      type: KeyManagementErrorType.INVALID_CONFIG,
+    });
+  });
+
+  it('throws when backend health check fails', async () => {
+    buildKeyManagementConfigFromEnv.mockReturnValue({
+      backend: 'aws-kms',
+      keyArn: 'arn:aws:kms:us-east-1:123456789012:key/test',
+    });
+
+    getKeyManagementService.mockReturnValue({
+      isHealthy: jest.fn().mockResolvedValue(false),
+      rotateEncryptionKey: jest.fn(),
+    });
+
+    await expect(service.rotateKeys()).rejects.toMatchObject({
+      type: KeyManagementErrorType.VAULT_UNAVAILABLE,
+    });
+  });
+
+  it('delegates rotation to the key management service', async () => {
+    const rotationResult = {
+      success: true,
+      backend: 'vault' as const,
+      rotated: true,
+      keyVersion: '3',
+      message: 'Transit key rotated to version 3',
+      timestamp: Date.now(),
+    };
+
+    buildKeyManagementConfigFromEnv.mockReturnValue({
+      backend: 'vault',
+      address: 'https://vault.example.com',
+      token: 's.test',
+      transitPath: 'transit',
+    });
+
+    const mockKeyService = {
+      isHealthy: jest.fn().mockResolvedValue(true),
+      rotateEncryptionKey: jest.fn().mockResolvedValue(rotationResult),
+    };
+
+    getKeyManagementService.mockReturnValue(mockKeyService);
+
+    const result = await service.rotateKeys();
+
+    expect(initializeKeyManagement).toHaveBeenCalledTimes(1);
+    expect(mockKeyService.isHealthy).toHaveBeenCalled();
+    expect(mockKeyService.rotateEncryptionKey).toHaveBeenCalled();
+    expect(result).toEqual(rotationResult);
+  });
+
+  it('initializes key management only once across multiple calls', async () => {
+    buildKeyManagementConfigFromEnv.mockReturnValue({
+      backend: 'aws-kms',
+      keyArn: 'arn:aws:kms:us-east-1:123456789012:key/test',
+    });
+
+    const mockKeyService = {
+      isHealthy: jest.fn().mockResolvedValue(true),
+      rotateEncryptionKey: jest.fn().mockResolvedValue({
+        success: true,
+        backend: 'aws-kms',
+        rotated: false,
+        message: 'Automatic key rotation already enabled',
+        timestamp: Date.now(),
+      }),
+    };
+
+    getKeyManagementService.mockReturnValue(mockKeyService);
+
+    await service.rotateKeys();
+    await service.rotateKeys();
+
+    expect(initializeKeyManagement).toHaveBeenCalledTimes(1);
+  });
+});

--- a/backend/src/services/key-rotation.service.ts
+++ b/backend/src/services/key-rotation.service.ts
@@ -1,0 +1,68 @@
+import {
+  buildKeyManagementConfigFromEnv,
+  getKeyManagementService,
+  initializeKeyManagement,
+} from '../lib/key-management.service';
+import {
+  KeyManagementError,
+  KeyManagementErrorType,
+  KeyRotationResult,
+} from '../lib/key-management.types';
+import { config } from '../config/env';
+import logger from '../utils/logger';
+
+/**
+ * Service for automated encryption key rotation.
+ * Delegates to the configured vault/KMS backend without exposing key material.
+ */
+export class KeyRotationService {
+  private initialized = false;
+
+  /**
+   * Initialize the key management backend from environment configuration.
+   */
+  ensureInitialized(): void {
+    if (this.initialized) {
+      return;
+    }
+
+    const keyConfig = buildKeyManagementConfigFromEnv(config);
+    if (!keyConfig) {
+      throw new KeyManagementError(
+        KeyManagementErrorType.INVALID_CONFIG,
+        'Key management is not configured. Set AWS_KMS_KEY_ARN or Vault credentials.'
+      );
+    }
+
+    initializeKeyManagement(keyConfig);
+    this.initialized = true;
+  }
+
+  /**
+   * Run a key rotation cycle: health check, then rotate at the backend.
+   */
+  async rotateKeys(): Promise<KeyRotationResult> {
+    this.ensureInitialized();
+
+    const keyManagementService = getKeyManagementService();
+    const healthy = await keyManagementService.isHealthy();
+
+    if (!healthy) {
+      throw new KeyManagementError(
+        KeyManagementErrorType.VAULT_UNAVAILABLE,
+        'Key management backend is unavailable; skipping rotation'
+      );
+    }
+
+    logger.info('Starting automated key rotation');
+    const result = await keyManagementService.rotateEncryptionKey();
+
+    logger.info('Automated key rotation completed', {
+      backend: result.backend,
+      rotated: result.rotated,
+      keyVersion: result.keyVersion,
+    });
+
+    return result;
+  }
+}

--- a/backend/src/workers/key-rotation.worker.ts
+++ b/backend/src/workers/key-rotation.worker.ts
@@ -1,0 +1,48 @@
+import cron from 'node-cron';
+import logger from '../utils/logger';
+import { config } from '../config/env';
+import { KeyRotationService } from '../services/key-rotation.service';
+
+const service = new KeyRotationService();
+
+function startWorker(): void {
+  if (config.ENABLE_KEY_ROTATION_WORKER !== 'true') {
+    logger.info('Key rotation worker disabled via ENABLE_KEY_ROTATION_WORKER');
+    return;
+  }
+
+  const schedule = config.KEY_ROTATION_WORKER_CRON;
+  const validSchedule = cron.validate(schedule)
+    ? schedule
+    : (() => {
+        logger.error(
+          `Invalid KEY_ROTATION_WORKER_CRON "${schedule}", falling back to "0 0 1 * *"`
+        );
+        return '0 0 1 * *';
+      })();
+
+  cron.schedule(validSchedule, () => {
+    service
+      .rotateKeys()
+      .then((result) => {
+        logger.info('Key rotation cron tick completed', {
+          backend: result.backend,
+          rotated: result.rotated,
+          message: result.message,
+        });
+      })
+      .catch((err) =>
+        logger.error(`Key rotation tick failed: ${(err as Error).message}`)
+      );
+  });
+
+  logger.info('Key rotation worker started');
+  logger.info(`   Cron: ${validSchedule}`);
+  logger.info(`   Backend: ${config.KEY_MANAGEMENT_BACKEND}`);
+}
+
+if (require.main === module) {
+  startWorker();
+}
+
+export { startWorker };


### PR DESCRIPTION
## Summary

Adds an automated key rotation cron worker that periodically rotates encryption keys at the configured vault/KMS backend, supporting testnet deployment readiness without manual intervention.

## Purpose / Motivation

Provider private keys are encrypted at rest via AWS KMS or HashiCorp Vault, but no automated rotation mechanism existed. Manual rotation is error-prone and does not meet security best practices for testnet/production. This change closes that gap with a scheduled worker that safely rotates keys without exposing plaintext material.

## Changes Made

- Added `rotateEncryptionKey()` to the key management service interface with AWS KMS and Vault implementations
- AWS KMS: verifies and enables automatic annual key rotation (idempotent)
- Vault: rotates the Transit engine key to a new version via the `/rotate` endpoint
- Created `KeyRotationService` to orchestrate health checks and rotation
- Created `key-rotation.worker.ts` cron worker following existing worker patterns
- Added `ENABLE_KEY_ROTATION_WORKER` and `KEY_ROTATION_WORKER_CRON` environment variables
- Added `npm run start:worker:key-rotation` script
- Added unit tests for the rotation service and KMS rotation logic
- Updated `KEY_MANAGEMENT.md` and `.env.example` with automated rotation documentation

## How to Test

1. **Unit tests**
   ```bash
   cd backend
   npm test -- --testPathPattern="key-rotation|key-management"
   ```

2. **Vault backend (manual)**
   - Set `KEY_MANAGEMENT_BACKEND=vault` with valid Vault credentials
   - Set `ENABLE_KEY_ROTATION_WORKER=true`
   - Run `npm run build && npm run start:worker:key-rotation`
   - Verify logs show `Key rotation worker started` and, on schedule tick, `Transit key rotated to version N`

3. **AWS KMS backend (manual)**
   - Set `KEY_MANAGEMENT_BACKEND=aws-kms` with a valid `AWS_KMS_KEY_ARN`
   - Run the worker as above
   - Verify logs show rotation enabled or already enabled

4. **Disabled worker**
   - Leave `ENABLE_KEY_ROTATION_WORKER=false` (default)
   - Run the worker — expect log: `Key rotation worker disabled via ENABLE_KEY_ROTATION_WORKER`

## Breaking Changes

- None. The worker is opt-in via `ENABLE_KEY_ROTATION_WORKER=true`.

## Related Issues

Closes ceejaylaboratory/AnchorPoint#371

## Checklist

- [x] Code builds successfully
- [x] Tests added/updated
- [x] No console errors
- [x] Documentation updated (if needed)
