### PR TITLE
fix(backend): SMTP alert email templates for hot-wallet monitoring

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -90,7 +90,14 @@ REDIS_URL=redis://localhost:6379
 
 # Alert Notifications
 # ALERT_WEBHOOK_URL=https://your-webhook.com/alerts
-# ALERT_EMAIL_RECIPIENTS=admin@example.com
+# ALERT_EMAIL_RECIPIENTS=admin@example.com,ops@example.com
+
+# SMTP (admin password reset + alert emails)
+# SMTP_HOST=smtp.example.com
+# SMTP_PORT=587
+# SMTP_USER=
+# SMTP_PASS=
+# SMTP_FROM=alerts@example.com
 
 # Feature Flags
 # FEATURE_FLAG_MULTISIG=true

--- a/backend/README.md
+++ b/backend/README.md
@@ -99,3 +99,5 @@ Optional SMTP environment variables:
 - `SMTP_PASS`
 - `SMTP_FROM`
 - `ADMIN_PASSWORD_RESET_URL_BASE`
+
+When SMTP is configured, the backend also sends HTML alert emails (for example hot-wallet low-balance notifications) using the same transport. Set `ALERT_EMAIL_RECIPIENTS` to a comma-separated list of operator addresses. If SMTP is not configured, alert content is logged at `info` level for local development.

--- a/backend/src/lib/email/alert-email.templates.test.ts
+++ b/backend/src/lib/email/alert-email.templates.test.ts
@@ -1,0 +1,39 @@
+import {
+  renderHotWalletLowBalanceAlert,
+  renderSystemAlert,
+} from './alert-email.templates';
+
+describe('alert email templates', () => {
+  it('renders hot wallet low balance subject and body fields', () => {
+    const content = renderHotWalletLowBalanceAlert({
+      walletLabel: 'Main XLM',
+      publicKey: 'GABC123',
+      assetCode: 'XLM',
+      currentBalance: 12.5,
+      thresholdAmount: 100,
+      checkedAt: '2026-05-30T12:00:00.000Z',
+    });
+
+    expect(content.subject).toBe('[AnchorPoint] Low Balance Alert: Main XLM');
+    expect(content.text).toContain('Main XLM');
+    expect(content.text).toContain('GABC123');
+    expect(content.html).toContain('Hot Wallet Low Balance');
+    expect(content.html).toContain('12.5');
+  });
+
+  it('escapes HTML in system alert messages', () => {
+    const content = renderSystemAlert({
+      severity: 'critical',
+      metric: 'error_rate',
+      message: '<script>alert(1)</script>',
+      value: '7%',
+      threshold: '5%',
+      window: '5m',
+      detectedAt: '2026-05-30T12:00:00.000Z',
+    });
+
+    expect(content.subject).toContain('[CRITICAL]');
+    expect(content.html).not.toContain('<script>');
+    expect(content.html).toContain('&lt;script&gt;');
+  });
+});

--- a/backend/src/lib/email/alert-email.templates.ts
+++ b/backend/src/lib/email/alert-email.templates.ts
@@ -1,0 +1,138 @@
+import type { AlertPayload } from '../../types/alerts';
+
+export interface AlertEmailContent {
+  subject: string;
+  text: string;
+  html: string;
+}
+
+export type SystemAlertSeverity = 'info' | 'warning' | 'critical';
+
+export interface SystemAlertTemplateInput {
+  severity: SystemAlertSeverity;
+  metric: string;
+  message: string;
+  value?: string | number;
+  threshold?: string | number;
+  window?: string;
+  detectedAt?: string;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function severityColor(severity: SystemAlertSeverity): string {
+  switch (severity) {
+    case 'critical':
+      return '#dc2626';
+    case 'warning':
+      return '#d97706';
+    default:
+      return '#2563eb';
+  }
+}
+
+function wrapAlertHtml(title: string, severity: SystemAlertSeverity, bodyHtml: string): string {
+  const accent = severityColor(severity);
+  return `
+<!DOCTYPE html>
+<html lang="en">
+  <body style="margin:0;padding:24px;background:#0f172a;font-family:Arial,Helvetica,sans-serif;color:#e2e8f0;">
+    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="max-width:640px;margin:0 auto;background:#111827;border:1px solid #1e293b;border-radius:8px;">
+      <tr>
+        <td style="padding:20px 24px;border-bottom:3px solid ${accent};">
+          <p style="margin:0;font-size:12px;letter-spacing:0.08em;text-transform:uppercase;color:#94a3b8;">AnchorPoint Alert</p>
+          <h1 style="margin:8px 0 0;font-size:20px;color:#f8fafc;">${escapeHtml(title)}</h1>
+        </td>
+      </tr>
+      <tr>
+        <td style="padding:24px;">${bodyHtml}</td>
+      </tr>
+      <tr>
+        <td style="padding:16px 24px;border-top:1px solid #1e293b;font-size:12px;color:#64748b;">
+          Automated notification from AnchorPoint. Do not reply to this email.
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>`.trim();
+}
+
+export function renderHotWalletLowBalanceAlert(alert: AlertPayload): AlertEmailContent {
+  const subject = `[AnchorPoint] Low Balance Alert: ${alert.walletLabel}`;
+  const text = [
+    'Hot Wallet Low Balance Alert',
+    '',
+    `Wallet: ${alert.walletLabel}`,
+    `Asset: ${alert.assetCode}`,
+    `Current Balance: ${alert.currentBalance}`,
+    `Threshold: ${alert.thresholdAmount}`,
+    `Public Key: ${alert.publicKey}`,
+    `Detected At: ${alert.checkedAt}`,
+    '',
+    'Please fund the wallet or investigate unexpected outflows.',
+  ].join('\n');
+
+  const html = wrapAlertHtml(
+    'Hot Wallet Low Balance',
+    'critical',
+    `
+      <p style="margin:0 0 16px;color:#cbd5e1;">A monitored hot wallet balance has fallen below its configured threshold.</p>
+      <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="font-size:14px;">
+        <tr><td style="padding:6px 0;color:#94a3b8;width:160px;">Wallet</td><td style="padding:6px 0;color:#f8fafc;">${escapeHtml(alert.walletLabel)}</td></tr>
+        <tr><td style="padding:6px 0;color:#94a3b8;">Asset</td><td style="padding:6px 0;color:#f8fafc;">${escapeHtml(alert.assetCode)}</td></tr>
+        <tr><td style="padding:6px 0;color:#94a3b8;">Current Balance</td><td style="padding:6px 0;color:#f8fafc;">${escapeHtml(String(alert.currentBalance))}</td></tr>
+        <tr><td style="padding:6px 0;color:#94a3b8;">Threshold</td><td style="padding:6px 0;color:#f8fafc;">${escapeHtml(String(alert.thresholdAmount))}</td></tr>
+        <tr><td style="padding:6px 0;color:#94a3b8;">Public Key</td><td style="padding:6px 0;color:#f8fafc;word-break:break-all;">${escapeHtml(alert.publicKey)}</td></tr>
+        <tr><td style="padding:6px 0;color:#94a3b8;">Detected At</td><td style="padding:6px 0;color:#f8fafc;">${escapeHtml(alert.checkedAt)}</td></tr>
+      </table>
+    `,
+  );
+
+  return { subject, text, html };
+}
+
+export function renderSystemAlert(input: SystemAlertTemplateInput): AlertEmailContent {
+  const severityLabel = input.severity.toUpperCase();
+  const subject = `[AnchorPoint] [${severityLabel}] ${input.metric}`;
+  const detectedAt = input.detectedAt ?? new Date().toISOString();
+
+  const detailLines = [
+    `Severity: ${severityLabel}`,
+    `Metric: ${input.metric}`,
+    `Message: ${input.message}`,
+    input.value !== undefined ? `Value: ${input.value}` : null,
+    input.threshold !== undefined ? `Threshold: ${input.threshold}` : null,
+    input.window ? `Window: ${input.window}` : null,
+    `Detected At: ${detectedAt}`,
+  ].filter((line): line is string => line !== null);
+
+  const text = ['AnchorPoint System Alert', '', ...detailLines].join('\n');
+
+  const detailRows = detailLines
+    .map((line) => {
+      const [label, ...rest] = line.split(': ');
+      const value = rest.join(': ');
+      return `<tr><td style="padding:6px 0;color:#94a3b8;width:160px;">${escapeHtml(label)}</td><td style="padding:6px 0;color:#f8fafc;">${escapeHtml(value)}</td></tr>`;
+    })
+    .join('');
+
+  const html = wrapAlertHtml(
+    input.metric,
+    input.severity,
+    `
+      <p style="margin:0 0 16px;color:#cbd5e1;">${escapeHtml(input.message)}</p>
+      <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="font-size:14px;">
+        ${detailRows}
+      </table>
+    `,
+  );
+
+  return { subject, text, html };
+}

--- a/backend/src/lib/smtp/create-transporter.ts
+++ b/backend/src/lib/smtp/create-transporter.ts
@@ -1,0 +1,33 @@
+import nodemailer, { type Transporter } from 'nodemailer';
+
+import { config } from '../../config/env';
+
+export function isSmtpConfigured(): boolean {
+  return Boolean(config.SMTP_HOST && config.SMTP_PORT && config.SMTP_FROM);
+}
+
+export function createSmtpTransporter(): Transporter {
+  if (!isSmtpConfigured()) {
+    throw new Error('SMTP is not configured');
+  }
+
+  return nodemailer.createTransport({
+    host: config.SMTP_HOST,
+    port: config.SMTP_PORT,
+    secure: config.SMTP_PORT === 465,
+    auth:
+      config.SMTP_USER && config.SMTP_PASS
+        ? {
+            user: config.SMTP_USER,
+            pass: config.SMTP_PASS,
+          }
+        : undefined,
+  });
+}
+
+export function parseEmailRecipients(recipients: string): string[] {
+  return recipients
+    .split(',')
+    .map((address) => address.trim())
+    .filter(Boolean);
+}

--- a/backend/src/services/admin-email.service.ts
+++ b/backend/src/services/admin-email.service.ts
@@ -1,6 +1,5 @@
-import nodemailer from 'nodemailer';
-
 import { config } from '../config/env';
+import { createSmtpTransporter, isSmtpConfigured } from '../lib/smtp/create-transporter';
 import logger from '../utils/logger';
 
 export interface PasswordResetEmailInput {
@@ -17,7 +16,7 @@ export class SmtpAdminEmailService implements AdminEmailService {
   async sendPasswordResetEmail(input: PasswordResetEmailInput): Promise<void> {
     const resetUrl = `${config.ADMIN_PASSWORD_RESET_URL_BASE}?token=${encodeURIComponent(input.token)}`;
 
-    if (!config.SMTP_HOST || !config.SMTP_PORT || !config.SMTP_FROM) {
+    if (!isSmtpConfigured()) {
       logger.info('SMTP not configured; password reset email logged for development', {
         to: input.to,
         resetUrl,
@@ -26,18 +25,7 @@ export class SmtpAdminEmailService implements AdminEmailService {
       return;
     }
 
-    const transporter = nodemailer.createTransport({
-      host: config.SMTP_HOST,
-      port: config.SMTP_PORT,
-      secure: config.SMTP_PORT === 465,
-      auth:
-        config.SMTP_USER && config.SMTP_PASS
-          ? {
-              user: config.SMTP_USER,
-              pass: config.SMTP_PASS,
-            }
-          : undefined,
-    });
+    const transporter = createSmtpTransporter();
 
     await transporter.sendMail({
       from: config.SMTP_FROM,

--- a/backend/src/services/alert-email.service.test.ts
+++ b/backend/src/services/alert-email.service.test.ts
@@ -1,0 +1,67 @@
+import * as smtp from '../lib/smtp/create-transporter';
+import { SmtpAlertEmailService } from './alert-email.service';
+
+jest.mock('../config/env', () => ({
+  config: { SMTP_FROM: 'alerts@example.com' },
+}));
+jest.mock('../lib/smtp/create-transporter');
+jest.mock('../utils/logger', () => ({
+  __esModule: true,
+  default: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+describe('SmtpAlertEmailService', () => {
+  const sendMail = jest.fn().mockResolvedValue({ messageId: 'test-id' });
+  const mockedSmtp = smtp as jest.Mocked<typeof smtp>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedSmtp.isSmtpConfigured.mockReturnValue(true);
+    mockedSmtp.parseEmailRecipients.mockImplementation((value: string) =>
+      value.split(',').map((entry) => entry.trim()).filter(Boolean),
+    );
+    mockedSmtp.createSmtpTransporter.mockReturnValue({ sendMail } as never);
+  });
+
+  it('sends hot wallet alert email when SMTP is configured', async () => {
+    const service = new SmtpAlertEmailService();
+
+    await service.sendHotWalletLowBalanceAlert('ops@example.com, finance@example.com', {
+      walletLabel: 'Main XLM',
+      publicKey: 'GABC123',
+      assetCode: 'XLM',
+      currentBalance: 10,
+      thresholdAmount: 100,
+      checkedAt: '2026-05-30T12:00:00.000Z',
+    });
+
+    expect(sendMail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        from: 'alerts@example.com',
+        to: 'ops@example.com, finance@example.com',
+        subject: '[AnchorPoint] Low Balance Alert: Main XLM',
+      }),
+    );
+  });
+
+  it('logs instead of sending when SMTP is not configured', async () => {
+    mockedSmtp.isSmtpConfigured.mockReturnValue(false);
+    const service = new SmtpAlertEmailService();
+
+    await service.sendHotWalletLowBalanceAlert('ops@example.com', {
+      walletLabel: 'Main XLM',
+      publicKey: 'GABC123',
+      assetCode: 'XLM',
+      currentBalance: 10,
+      thresholdAmount: 100,
+      checkedAt: '2026-05-30T12:00:00.000Z',
+    });
+
+    expect(sendMail).not.toHaveBeenCalled();
+    expect(mockedSmtp.createSmtpTransporter).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/services/alert-email.service.ts
+++ b/backend/src/services/alert-email.service.ts
@@ -1,0 +1,69 @@
+import { config } from '../config/env';
+import { renderHotWalletLowBalanceAlert, renderSystemAlert } from '../lib/email/alert-email.templates';
+import type { SystemAlertTemplateInput } from '../lib/email/alert-email.templates';
+import {
+  createSmtpTransporter,
+  isSmtpConfigured,
+  parseEmailRecipients,
+} from '../lib/smtp/create-transporter';
+import type { AlertPayload } from '../types/alerts';
+import logger from '../utils/logger';
+
+export interface AlertEmailService {
+  sendHotWalletLowBalanceAlert(recipients: string, alert: AlertPayload): Promise<void>;
+  sendSystemAlert(recipients: string, alert: SystemAlertTemplateInput): Promise<void>;
+}
+
+export class SmtpAlertEmailService implements AlertEmailService {
+  async sendHotWalletLowBalanceAlert(recipients: string, alert: AlertPayload): Promise<void> {
+    const content = renderHotWalletLowBalanceAlert(alert);
+    await this.sendAlertEmail(recipients, content, {
+      logContext: 'hot wallet low balance',
+      walletLabel: alert.walletLabel,
+    });
+  }
+
+  async sendSystemAlert(recipients: string, alert: SystemAlertTemplateInput): Promise<void> {
+    const content = renderSystemAlert(alert);
+    await this.sendAlertEmail(recipients, content, {
+      logContext: 'system alert',
+      metric: alert.metric,
+    });
+  }
+
+  private async sendAlertEmail(
+    recipients: string,
+    content: { subject: string; text: string; html: string },
+    metadata: Record<string, string>,
+  ): Promise<void> {
+    const to = parseEmailRecipients(recipients);
+
+    if (to.length === 0) {
+      logger.warn('[AlertEmail] No valid email recipients provided', metadata);
+      return;
+    }
+
+    if (!isSmtpConfigured()) {
+      logger.info('[AlertEmail] SMTP not configured; alert logged for development', {
+        ...metadata,
+        to,
+        subject: content.subject,
+      });
+      return;
+    }
+
+    const transporter = createSmtpTransporter();
+
+    await transporter.sendMail({
+      from: config.SMTP_FROM!,
+      to: to.join(', '),
+      subject: content.subject,
+      text: content.text,
+      html: content.html,
+    });
+
+    logger.info('[AlertEmail] Alert email sent', { ...metadata, to, subject: content.subject });
+  }
+}
+
+export const alertEmailService = new SmtpAlertEmailService();

--- a/backend/src/services/hot-wallet-monitor.service.test.ts
+++ b/backend/src/services/hot-wallet-monitor.service.test.ts
@@ -1,4 +1,5 @@
-import { HotWalletMonitorService, HotWallet, AlertPayload } from './hot-wallet-monitor.service';
+import { HotWalletMonitorService, HotWallet } from './hot-wallet-monitor.service';
+import type { AlertEmailService } from './alert-email.service';
 import { stellarService } from './stellar.service';
 import { redis } from '../lib/redis';
 import logger from '../utils/logger';
@@ -50,10 +51,21 @@ const USDC_WALLET: HotWallet = {
   thresholdAmount: 500,
 };
 
-function makeService(wallets: HotWallet[] = [XLM_WALLET]) {
+function makeService(
+  wallets: HotWallet[] = [XLM_WALLET],
+  options: {
+    alertEmailService?: AlertEmailService;
+    alertChannels?: { emailRecipients?: string };
+  } = {},
+) {
   // Reset singleton for each test
   (HotWalletMonitorService as any).instance = undefined;
-  return HotWalletMonitorService.getInstance({ wallets, alertCooldownSeconds: 3600 });
+  return HotWalletMonitorService.getInstance({
+    wallets,
+    alertCooldownSeconds: 3600,
+    alertEmailService: options.alertEmailService,
+    alertChannels: options.alertChannels,
+  });
 }
 
 function mockHorizonAccount(balances: object[]) {
@@ -180,6 +192,30 @@ describe('HotWalletMonitorService — alert de-duplication', () => {
       expect.anything()
     );
     expect(redis.set).not.toHaveBeenCalled();
+  });
+
+  it('dispatches SMTP alert email when recipients are configured', async () => {
+    mockHorizonAccount([{ asset_type: 'native', balance: '10.0000000' }]);
+    const alertEmailService = {
+      sendHotWalletLowBalanceAlert: jest.fn().mockResolvedValue(undefined),
+      sendSystemAlert: jest.fn(),
+    };
+
+    const svc = makeService([XLM_WALLET], {
+      alertEmailService,
+      alertChannels: { emailRecipients: 'ops@example.com' },
+    });
+
+    await svc.checkWallet(XLM_WALLET);
+
+    expect(alertEmailService.sendHotWalletLowBalanceAlert).toHaveBeenCalledWith(
+      'ops@example.com',
+      expect.objectContaining({
+        walletLabel: 'XLM Hot Wallet',
+        currentBalance: 10,
+        thresholdAmount: 100,
+      }),
+    );
   });
 });
 

--- a/backend/src/services/hot-wallet-monitor.service.ts
+++ b/backend/src/services/hot-wallet-monitor.service.ts
@@ -1,9 +1,12 @@
-import { Horizon } from '@stellar/stellar-sdk';
 import { stellarService } from './stellar.service';
 import { metricsService } from './metrics.service';
 import { redis } from '../lib/redis';
+import type { AlertPayload } from '../types/alerts';
 import logger from '../utils/logger';
 import promClient, { Gauge } from 'prom-client';
+import { type AlertEmailService, SmtpAlertEmailService } from './alert-email.service';
+
+export type { AlertPayload } from '../types/alerts';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -27,15 +30,6 @@ export interface WalletBalanceSnapshot {
   checkedAt: string;
 }
 
-export interface AlertPayload {
-  walletLabel: string;
-  publicKey: string;
-  assetCode: string;
-  currentBalance: number;
-  thresholdAmount: number;
-  checkedAt: string;
-}
-
 export interface AlertChannelConfig {
   /** Slack incoming-webhook URL */
   slackWebhookUrl?: string;
@@ -54,6 +48,8 @@ export interface HotWalletMonitorConfig {
   alertChannels?: AlertChannelConfig;
   /** Redis key TTL for de-duplication, in seconds (default: 3600) */
   alertCooldownSeconds?: number;
+  /** SMTP-backed alert email delivery */
+  alertEmailService?: AlertEmailService;
 }
 
 // ─── Prometheus gauges ────────────────────────────────────────────────────────
@@ -78,6 +74,7 @@ export class HotWalletMonitorService {
   private static instance: HotWalletMonitorService;
 
   private config: HotWalletMonitorConfig;
+  private readonly alertEmailService: AlertEmailService;
   private timer: ReturnType<typeof setInterval> | null = null;
   private readonly COOLDOWN_KEY_PREFIX = 'hot_wallet_alert:';
 
@@ -90,8 +87,10 @@ export class HotWalletMonitorService {
         emailRecipients: process.env.ALERT_EMAIL_RECIPIENTS,
         customWebhookUrl: process.env.ALERT_WEBHOOK_URL,
       },
+      alertEmailService: config.alertEmailService ?? new SmtpAlertEmailService(),
       ...config,
     };
+    this.alertEmailService = this.config.alertEmailService!;
   }
 
   public static getInstance(config?: HotWalletMonitorConfig): HotWalletMonitorService {
@@ -302,20 +301,8 @@ export class HotWalletMonitorService {
   }
 
   private async sendEmailAlert(recipients: string, alert: AlertPayload): Promise<void> {
-    // This project has no email transport wired up yet.
-    // Log the intent so an operator / future SMTP integration can act on it.
-    logger.warn('[HotWalletMonitor] Email alert (no transport configured — log only)', {
-      recipients,
-      alert,
-    });
-
-    // TODO: wire up nodemailer / SendGrid / SES here when an SMTP service is added.
-    // Example:
-    //   await mailer.sendMail({
-    //     to: recipients,
-    //     subject: `[AnchorPoint] Low Balance: ${alert.walletLabel}`,
-    //     text: formatEmailBody(alert),
-    //   });
+    await this.alertEmailService.sendHotWalletLowBalanceAlert(recipients, alert);
+    logger.info('[HotWalletMonitor] Email alert dispatched', { wallet: alert.walletLabel });
   }
 
   private async sendCustomWebhook(url: string, alert: AlertPayload): Promise<void> {

--- a/backend/src/types/alerts.ts
+++ b/backend/src/types/alerts.ts
@@ -1,0 +1,8 @@
+export interface AlertPayload {
+  walletLabel: string;
+  publicKey: string;
+  assetCode: string;
+  currentBalance: number;
+  thresholdAmount: number;
+  checkedAt: string;
+}


### PR DESCRIPTION
## Summary
Adds SMTP-backed HTML/text email templates for operational alerts and wires hot-wallet low-balance notifications through the shared mail transport.

## Purpose / Motivation
Hot-wallet monitoring already supported `ALERT_EMAIL_RECIPIENTS`, but email delivery was log-only. Testnet readiness requires real operator notifications with consistent, readable alert content.

## Changes Made
- Introduced reusable SMTP helpers (`createSmtpTransporter`, recipient parsing) shared by admin and alert mailers.
- Added alert email templates for hot-wallet low balance and generic system alerts (error rate / latency style metadata).
- Implemented `SmtpAlertEmailService` with safe dev fallback when SMTP is unset.
- Wired `HotWalletMonitorService` to dispatch templated alert emails.
- Refactored admin password-reset mailer to use the shared SMTP helper.
- Added unit tests for templates, alert mailer, and hot-wallet email dispatch.

## How to Test
1. Configure SMTP variables (`SMTP_HOST`, `SMTP_PORT`, `SMTP_FROM`, optional auth) and set `ALERT_EMAIL_RECIPIENTS`.
2. Configure `HOT_WALLETS` with a threshold above the wallet's current balance.
3. Start the backend and confirm a low-balance check triggers an email with subject `[AnchorPoint] Low Balance Alert: ...`.
4. Unset SMTP variables and repeat; confirm alert details are logged at info without throwing.
5. Run `npx jest src/lib/email/alert-email.templates.test.ts src/services/alert-email.service.test.ts --coverage=false` in `backend/`.

## Screenshots (if applicable)
N/A (backend only).

## Breaking Changes
- None.

## Related Issues
Closes ceejaylaboratory/AnchorPoint#365

## Checklist
- [x] Code builds successfully
- [x] Tests added/updated
- [x] No console errors
- [x] Documentation updated (if needed)