### PR TITLE
fix: SEP-24 interactive URL token validation

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -9,6 +9,8 @@ DATABASE_URL=file:./prisma/dev.db
 
 # JWT
 JWT_SECRET=your-secret-key-min-8-chars
+SEP24_INTERACTIVE_URL_JWT_SECRET=your-sep24-interactive-secret-min-8-chars
+SEP24_INTERACTIVE_URL_JWT_EXPIRATION_SECONDS=600
 
 # URLs
 INTERACTIVE_URL=http://localhost:3000

--- a/backend/src/api/routes/sep24.route.test.ts
+++ b/backend/src/api/routes/sep24.route.test.ts
@@ -1,5 +1,17 @@
 import express from 'express';
 import request from 'supertest';
+import jwt from 'jsonwebtoken';
+
+const tokenSecret = 'sep24-route-test-secret';
+
+jest.mock('../../config/env', () => ({
+  config: {
+    SEP24_INTERACTIVE_URL_JWT_SECRET: tokenSecret,
+    SEP24_INTERACTIVE_URL_JWT_EXPIRATION_SECONDS: 600,
+    JWT_SECRET: tokenSecret,
+    INTERACTIVE_URL: 'http://localhost:4100',
+  },
+}));
 
 jest.mock('crypto', () => {
   const actual = jest.requireActual('crypto');
@@ -8,6 +20,15 @@ jest.mock('crypto', () => {
     randomUUID: jest.fn(() => '00000000-0000-0000-0000-000000000000')
   };
 });
+
+jest.mock('../../lib/prisma', () => ({
+  __esModule: true,
+  default: {
+    quote: {
+      findUnique: jest.fn(),
+    },
+  },
+}));
 
 import sep24Router from './sep24.route';
 
@@ -19,6 +40,28 @@ describe('SEP-24 Routes', () => {
   app.use('/', sep24Router);
 
   const baseUrl = 'http://localhost:4100';
+
+  const signRouteToken = (overrides: Partial<{
+    transactionId: string;
+    account: string;
+    assetCode: string;
+    amount: string;
+    lang: string;
+    flow: 'deposit' | 'withdraw';
+  }> = {}) => jwt.sign(
+    {
+      sub: overrides.account ?? 'GACCOUNT',
+      jti: overrides.transactionId ?? '00000000-0000-0000-0000-000000000000',
+      data: {
+        asset: overrides.assetCode ?? 'USDC',
+        ...(overrides.amount ? { amount: overrides.amount } : {}),
+        lang: overrides.lang ?? 'en',
+        flow: overrides.flow ?? 'deposit',
+      },
+    },
+    tokenSecret,
+    { algorithm: 'HS256', expiresIn: 600 },
+  );
 
   beforeEach(() => {
     process.env.INTERACTIVE_URL = baseUrl;
@@ -45,7 +88,7 @@ describe('SEP-24 Routes', () => {
 
       expect(res.statusCode).toBe(400);
       expect(res.body.error).toContain('Asset DOGE is not supported');
-      expect(res.body.error).toContain('Supported assets: USDC, USD, BTC, ETH');
+      expect(res.body.error).toContain('Supported assets: USDC, USD');
     });
 
     it('returns an interactive URL for supported assets (with optional params)', async () => {
@@ -69,6 +112,7 @@ describe('SEP-24 Routes', () => {
       expect(parsed.searchParams.get('account')).toBe('GACCOUNT');
       expect(parsed.searchParams.get('amount')).toBe('12.50');
       expect(parsed.searchParams.get('lang')).toBe('fr');
+      expect(parsed.searchParams.get('token')).toEqual(expect.any(String));
     });
 
     it('defaults lang to en when omitted', async () => {
@@ -100,14 +144,14 @@ describe('SEP-24 Routes', () => {
 
       expect(res.statusCode).toBe(400);
       expect(res.body.error).toContain('Asset DOGE is not supported');
-      expect(res.body.error).toContain('Supported assets: USDC, USD, BTC, ETH');
+      expect(res.body.error).toContain('Supported assets: USDC, USD');
     });
 
     it('returns an interactive URL for supported assets', async () => {
       const res = await request(app)
         .post('/transactions/withdraw/interactive')
         .send({
-          asset_code: 'BTC',
+          asset_code: 'USD',
           account: 'GACCOUNT',
           amount: '1'
         });
@@ -115,9 +159,69 @@ describe('SEP-24 Routes', () => {
       expect(res.statusCode).toBe(200);
       const parsed = new URL(res.body.url);
       expect(parsed.pathname).toBe('/kyc-withdraw');
-      expect(parsed.searchParams.get('asset_code')).toBe('BTC');
+      expect(parsed.searchParams.get('asset_code')).toBe('USD');
       expect(parsed.searchParams.get('account')).toBe('GACCOUNT');
       expect(parsed.searchParams.get('amount')).toBe('1');
+      expect(parsed.searchParams.get('token')).toEqual(expect.any(String));
+    });
+  });
+
+  describe('GET /interactive/validate', () => {
+    it('returns 400 when token is missing', async () => {
+      const res = await request(app).get('/interactive/validate');
+
+      expect(res.statusCode).toBe(400);
+      expect(res.body.error).toBe('token is required');
+    });
+
+    it('returns session details for a valid token', async () => {
+      const token = signRouteToken({
+        assetCode: 'USDC',
+        amount: '12.50',
+        lang: 'fr',
+        flow: 'deposit',
+      });
+
+      const res = await request(app).get('/interactive/validate').query({ token });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toMatchObject({
+        transaction_id: '00000000-0000-0000-0000-000000000000',
+        account: 'GACCOUNT',
+        asset_code: 'USDC',
+        amount: '12.50',
+        lang: 'fr',
+        flow: 'deposit',
+      });
+      expect(res.body.expires_at).toEqual(expect.any(String));
+    });
+
+    it('returns 401 for an invalid token', async () => {
+      const res = await request(app)
+        .get('/interactive/validate')
+        .query({ token: 'invalid-token' });
+
+      expect(res.statusCode).toBe(401);
+      expect(res.body.error).toBe('Invalid token');
+    });
+
+    it('returns 401 for an expired token', async () => {
+      const expiredToken = jwt.sign(
+        {
+          sub: 'GACCOUNT',
+          jti: '00000000-0000-0000-0000-000000000000',
+          data: { asset: 'USDC', lang: 'en', flow: 'deposit' },
+        },
+        tokenSecret,
+        { algorithm: 'HS256', expiresIn: -1 },
+      );
+
+      const res = await request(app)
+        .get('/interactive/validate')
+        .query({ token: expiredToken });
+
+      expect(res.statusCode).toBe(401);
+      expect(res.body.error).toBe('Token has expired');
     });
   });
 });

--- a/backend/src/api/routes/sep24.route.ts
+++ b/backend/src/api/routes/sep24.route.ts
@@ -7,7 +7,12 @@ import {
   normalizeAssetCode,
   SUPPORTED_ASSETS,
 } from '../../services/kyc.service';
+import {
+  InteractiveTokenError,
+  validateInteractiveToken,
+} from '../../services/sep24-interactive-token.service';
 import prisma from '../../lib/prisma';
+import logger from '../../utils/logger';
 
 const router = Router();
 
@@ -211,6 +216,56 @@ router.post('/transactions/withdraw/interactive', async (req: Request, res: Resp
   };
 
   return res.json(response);
+});
+
+/**
+ * @swagger
+ * /sep24/interactive/validate:
+ *   get:
+ *     summary: Validate SEP-24 interactive URL token
+ *     description: Validates the short-lived JWT embedded in a SEP-24 interactive URL before starting the hosted flow.
+ *     tags: [SEP-24]
+ *     parameters:
+ *       - in: query
+ *         name: token
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: JWT token from the interactive URL query string
+ *     responses:
+ *       200:
+ *         description: Token is valid
+ *       401:
+ *         description: Token is invalid or expired
+ */
+router.get('/interactive/validate', (req: Request, res: Response) => {
+  const token = typeof req.query.token === 'string' ? req.query.token : '';
+
+  if (!token) {
+    return res.status(400).json({ error: 'token is required' });
+  }
+
+  try {
+    const claims = validateInteractiveToken(token);
+
+    return res.json({
+      transaction_id: claims.jti,
+      account: claims.sub || undefined,
+      asset_code: claims.data.asset,
+      amount: claims.data.amount,
+      lang: claims.data.lang,
+      flow: claims.data.flow,
+      expires_at: new Date(claims.exp * 1000).toISOString(),
+    });
+  } catch (error) {
+    if (error instanceof InteractiveTokenError) {
+      logger.warn('SEP-24 interactive token rejected', { reason: error.message });
+      return res.status(401).json({ error: error.message });
+    }
+
+    logger.error('SEP-24 interactive token validation failed unexpectedly', { error });
+    return res.status(401).json({ error: 'Invalid token' });
+  }
 });
 
 export default router;

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -14,6 +14,15 @@ const envSchema = z.object({
     .pipe(z.number().positive()),
   DATABASE_URL: z.string().min(1, 'DATABASE_URL is required').default('file:./prisma/dev.db'),
   JWT_SECRET: z.string().min(8, 'JWT_SECRET must be at least 8 characters').default('stellar-anchor-secret'),
+  SEP24_INTERACTIVE_URL_JWT_SECRET: z
+    .string()
+    .min(8, 'SEP24_INTERACTIVE_URL_JWT_SECRET must be at least 8 characters')
+    .optional(),
+  SEP24_INTERACTIVE_URL_JWT_EXPIRATION_SECONDS: z
+    .string()
+    .default('600')
+    .transform((val: string) => parseInt(val, 10))
+    .pipe(z.number().int().min(60).max(86400)),
   INTERACTIVE_URL: z.string().url().default('http://localhost:3000'),
   WEBHOOK_URL: z.string().url().optional(),
   WEBHOOK_SECRET: z.string().min(1, 'WEBHOOK_SECRET cannot be empty').optional(),
@@ -34,13 +43,11 @@ const envSchema = z.object({
     .pipe(z.number().int().min(0)),
   STELLAR_NETWORK: z.enum(['testnet', 'public', 'futurenet']).default('testnet'),
   RECURRING_PAYMENTS_WORKER_CRON: z.string().default('*/1 * * * *'),
-  STELLAR_NETWORK: z.enum(['testnet', 'public']).default('testnet'),
   STELLAR_NETWORK_PASSPHRASE: z
     .string()
     .default('Test SDF Network ; September 2015'),
   STELLAR_HORIZON_URL: z.string().url().default('https://horizon-testnet.stellar.org'),
   HORIZON_URL: z.string().url().default('https://horizon-testnet.stellar.org'),
-  STELLAR_NETWORK_PASSPHRASE: z.string().default('Test SDF Network ; September 2015'),
   STELLAR_FEE_BUMP_SECRET: z.string().optional(),
   STELLAR_DISTRIBUTION_SECRET: z.string().optional(),
   STELLAR_BASE_FEE: z.string().default('100'),

--- a/backend/src/services/kyc.service.test.ts
+++ b/backend/src/services/kyc.service.test.ts
@@ -7,6 +7,10 @@ import {
   SUPPORTED_ASSETS
 } from './kyc.service';
 
+jest.mock('./sep24-interactive-token.service', () => ({
+  signInteractiveToken: jest.fn(() => 'mock-interactive-token'),
+}));
+
 describe('KYC Service', () => {
   it('normalizeAssetCode trims and uppercases', () => {
     expect(normalizeAssetCode(' usdc ')).toBe('USDC');
@@ -22,7 +26,8 @@ describe('KYC Service', () => {
       baseUrl: 'http://localhost:3000',
       transactionId: 'tx_1',
       assetCode: 'USDC',
-      path: '/kyc-deposit'
+      path: '/kyc-deposit',
+      flow: 'deposit',
     });
 
     const parsed = new URL(url);
@@ -30,6 +35,7 @@ describe('KYC Service', () => {
     expect(parsed.searchParams.get('transaction_id')).toBe('tx_1');
     expect(parsed.searchParams.get('asset_code')).toBe('USDC');
     expect(parsed.searchParams.get('lang')).toBe('en');
+    expect(parsed.searchParams.get('token')).toBe('mock-interactive-token');
     expect(parsed.searchParams.get('account')).toBeNull();
     expect(parsed.searchParams.get('amount')).toBeNull();
   });
@@ -51,6 +57,7 @@ describe('KYC Service', () => {
     expect(parsed.searchParams.get('account')).toBe('GACCOUNT');
     expect(parsed.searchParams.get('amount')).toBe('12.50');
     expect(parsed.searchParams.get('lang')).toBe('fr');
+    expect(parsed.searchParams.get('token')).toBe('mock-interactive-token');
   });
 
   it('createWithdrawInteractiveUrl uses the withdraw path', () => {
@@ -63,6 +70,7 @@ describe('KYC Service', () => {
     const parsed = new URL(url);
     expect(parsed.pathname).toBe('/kyc-withdraw');
     expect(parsed.searchParams.get('transaction_id')).toBe('tx_3');
+    expect(parsed.searchParams.get('token')).toBe('mock-interactive-token');
   });
 });
 

--- a/backend/src/services/kyc.service.ts
+++ b/backend/src/services/kyc.service.ts
@@ -1,4 +1,8 @@
 import { SUPPORTED_ASSET_CODES, getAsset, isDepositSupported, isWithdrawSupported } from '../config/assets';
+import {
+  InteractiveFlow,
+  signInteractiveToken,
+} from './sep24-interactive-token.service';
 
 // Re-export for backward compatibility
 export { SUPPORTED_ASSET_CODES as SUPPORTED_ASSETS };
@@ -20,6 +24,7 @@ interface InteractiveUrlParams {
   amount?: string;
   lang?: string;
   path: string;
+  flow: InteractiveFlow;
 }
 
 export const buildInteractiveUrl = ({
@@ -30,13 +35,24 @@ export const buildInteractiveUrl = ({
   amount,
   lang = 'en',
   path,
+  flow,
 }: InteractiveUrlParams): string => {
+  const token = signInteractiveToken({
+    transactionId,
+    account,
+    assetCode,
+    amount,
+    lang,
+    flow,
+  });
+
   const url = new URL(path, baseUrl);
   url.searchParams.append('transaction_id', transactionId);
   url.searchParams.append('asset_code', assetCode);
   if (account) url.searchParams.append('account', account);
   if (amount) url.searchParams.append('amount', amount);
   url.searchParams.append('lang', lang);
+  url.searchParams.append('token', token);
   return url.toString();
 };
 
@@ -48,7 +64,12 @@ export const createDepositInteractiveUrl = (params: {
   amount?: string;
   lang?: string;
 }): string =>
-  buildInteractiveUrl({ ...params, path: '/kyc-deposit', assetCode: normalizeAssetCode(params.assetCode) });
+  buildInteractiveUrl({
+    ...params,
+    path: '/kyc-deposit',
+    assetCode: normalizeAssetCode(params.assetCode),
+    flow: 'deposit',
+  });
 
 export const createWithdrawInteractiveUrl = (params: {
   baseUrl: string;
@@ -58,4 +79,9 @@ export const createWithdrawInteractiveUrl = (params: {
   amount?: string;
   lang?: string;
 }): string =>
-  buildInteractiveUrl({ ...params, path: '/kyc-withdraw', assetCode: normalizeAssetCode(params.assetCode) });
+  buildInteractiveUrl({
+    ...params,
+    path: '/kyc-withdraw',
+    assetCode: normalizeAssetCode(params.assetCode),
+    flow: 'withdraw',
+  });

--- a/backend/src/services/sep24-interactive-token.service.test.ts
+++ b/backend/src/services/sep24-interactive-token.service.test.ts
@@ -1,0 +1,113 @@
+import jwt from 'jsonwebtoken';
+
+const tokenSecret = 'sep24-interactive-test-secret';
+
+jest.mock('../config/env', () => ({
+  config: {
+    SEP24_INTERACTIVE_URL_JWT_SECRET: tokenSecret,
+    SEP24_INTERACTIVE_URL_JWT_EXPIRATION_SECONDS: 600,
+    JWT_SECRET: tokenSecret,
+  },
+}));
+
+jest.mock('../utils/logger', () => ({
+  __esModule: true,
+  default: {
+    warn: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+  },
+}));
+
+const loadTokenService = () => {
+  jest.resetModules();
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  return require('./sep24-interactive-token.service') as typeof import('./sep24-interactive-token.service');
+};
+
+describe('SEP-24 Interactive Token Service', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('signInteractiveToken embeds transaction fields in the JWT payload', () => {
+    const { signInteractiveToken } = loadTokenService();
+    const token = signInteractiveToken({
+      transactionId: 'tx_123',
+      account: 'GACCOUNT',
+      assetCode: 'USDC',
+      amount: '10.00',
+      lang: 'fr',
+      flow: 'deposit',
+    });
+
+    const decoded = jwt.verify(token, tokenSecret) as jwt.JwtPayload & {
+      sub: string;
+      jti: string;
+      data: { asset: string; amount: string; lang: string; flow: string };
+    };
+
+    expect(decoded.sub).toBe('GACCOUNT');
+    expect(decoded.jti).toBe('tx_123');
+    expect(decoded.data).toEqual({
+      asset: 'USDC',
+      amount: '10.00',
+      lang: 'fr',
+      flow: 'deposit',
+    });
+  });
+
+  it('validateInteractiveToken returns decoded claims for a valid token', () => {
+    const { signInteractiveToken, validateInteractiveToken } = loadTokenService();
+    const token = signInteractiveToken({
+      transactionId: 'tx_456',
+      assetCode: 'BTC',
+      flow: 'withdraw',
+    });
+
+    const claims = validateInteractiveToken(token);
+
+    expect(claims.jti).toBe('tx_456');
+    expect(claims.data.asset).toBe('BTC');
+    expect(claims.data.flow).toBe('withdraw');
+    expect(claims.data.lang).toBe('en');
+  });
+
+  it('validateInteractiveToken rejects expired tokens', () => {
+    const { validateInteractiveToken, InteractiveTokenError } = loadTokenService();
+    const expiredToken = jwt.sign(
+      {
+        sub: 'GACCOUNT',
+        jti: 'tx_expired',
+        data: { asset: 'USDC', lang: 'en', flow: 'deposit' },
+      },
+      tokenSecret,
+      { algorithm: 'HS256', expiresIn: -1 },
+    );
+
+    expect(() => validateInteractiveToken(expiredToken)).toThrow(InteractiveTokenError);
+    expect(() => validateInteractiveToken(expiredToken)).toThrow('Token has expired');
+  });
+
+  it('validateInteractiveToken rejects tampered tokens', () => {
+    const { validateInteractiveToken, InteractiveTokenError } = loadTokenService();
+
+    expect(() => validateInteractiveToken('not-a-valid-token')).toThrow(InteractiveTokenError);
+    expect(() => validateInteractiveToken('not-a-valid-token')).toThrow('Invalid token');
+  });
+
+  it('validateInteractiveToken rejects tokens signed with a different secret', () => {
+    const { validateInteractiveToken, InteractiveTokenError } = loadTokenService();
+    const token = jwt.sign(
+      {
+        sub: 'GACCOUNT',
+        jti: 'tx_other',
+        data: { asset: 'USDC', lang: 'en', flow: 'deposit' },
+      },
+      'different-secret-value',
+      { algorithm: 'HS256', expiresIn: 600 },
+    );
+
+    expect(() => validateInteractiveToken(token)).toThrow(InteractiveTokenError);
+  });
+});

--- a/backend/src/services/sep24-interactive-token.service.ts
+++ b/backend/src/services/sep24-interactive-token.service.ts
@@ -1,0 +1,100 @@
+import jwt from 'jsonwebtoken';
+import { config } from '../config/env';
+import logger from '../utils/logger';
+
+export type InteractiveFlow = 'deposit' | 'withdraw';
+
+export interface InteractiveTokenData {
+  asset: string;
+  amount?: string;
+  lang: string;
+  flow: InteractiveFlow;
+}
+
+export interface InteractiveTokenClaims {
+  sub: string;
+  jti: string;
+  data: InteractiveTokenData;
+}
+
+export interface ValidatedInteractiveToken extends InteractiveTokenClaims {
+  exp: number;
+  iat: number;
+}
+
+export class InteractiveTokenError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InteractiveTokenError';
+  }
+}
+
+export interface SignInteractiveTokenParams {
+  transactionId: string;
+  account?: string;
+  assetCode: string;
+  amount?: string;
+  lang?: string;
+  flow: InteractiveFlow;
+}
+
+const getSecret = (): string =>
+  config.SEP24_INTERACTIVE_URL_JWT_SECRET ?? config.JWT_SECRET;
+
+const getExpirationSeconds = (): number => config.SEP24_INTERACTIVE_URL_JWT_EXPIRATION_SECONDS;
+
+export const signInteractiveToken = ({
+  transactionId,
+  account,
+  assetCode,
+  amount,
+  lang = 'en',
+  flow,
+}: SignInteractiveTokenParams): string => {
+  const payload: InteractiveTokenClaims = {
+    sub: account ?? '',
+    jti: transactionId,
+    data: {
+      asset: assetCode,
+      ...(amount ? { amount } : {}),
+      lang,
+      flow,
+    },
+  };
+
+  return jwt.sign(payload, getSecret(), {
+    algorithm: 'HS256',
+    expiresIn: getExpirationSeconds(),
+  });
+};
+
+export const validateInteractiveToken = (token: string): ValidatedInteractiveToken => {
+  try {
+    const decoded = jwt.verify(token, getSecret(), {
+      algorithms: ['HS256'],
+    }) as jwt.JwtPayload & InteractiveTokenClaims;
+
+    if (!decoded.jti || !decoded.data?.asset || !decoded.data?.flow) {
+      throw new InteractiveTokenError('Invalid token payload');
+    }
+
+    if (decoded.data.flow !== 'deposit' && decoded.data.flow !== 'withdraw') {
+      throw new InteractiveTokenError('Invalid token flow');
+    }
+
+    return decoded as ValidatedInteractiveToken;
+  } catch (error) {
+    if (error instanceof InteractiveTokenError) {
+      throw error;
+    }
+    if (error instanceof jwt.TokenExpiredError) {
+      logger.warn('SEP-24 interactive token expired');
+      throw new InteractiveTokenError('Token has expired');
+    }
+    if (error instanceof jwt.JsonWebTokenError) {
+      logger.warn('SEP-24 interactive token validation failed', { error: error.message });
+      throw new InteractiveTokenError('Invalid token');
+    }
+    throw error;
+  }
+};


### PR DESCRIPTION
## Summary

Adds short-lived JWT signing and validation for SEP-24 interactive URLs so hosted deposit/withdraw flows can authenticate sessions without exposing long-lived credentials in query strings.

## Purpose / Motivation

SEP-24 interactive URLs are opened in a webview where Authorization headers are unavailable. Per Stellar Anchor Platform conventions, anchors should embed a short-lived JWT in the interactive URL and validate it before starting the hosted flow. Previously, interactive URLs only carried plain query parameters with no integrity or expiry checks.

## Changes Made

- Added `sep24-interactive-token.service.ts` to sign and validate interactive URL JWTs (HS256, configurable expiry)
- Embedded a `token` query parameter when building deposit/withdraw interactive URLs
- Added `GET /sep24/interactive/validate?token=` to verify tokens and return session context
- Added `SEP24_INTERACTIVE_URL_JWT_SECRET` and `SEP24_INTERACTIVE_URL_JWT_EXPIRATION_SECONDS` configuration (secret falls back to `JWT_SECRET` when unset)
- Added unit tests for token signing/validation, URL generation, and the validate route

## How to Test

1. **Unit tests**
   ```bash
   cd backend
   npm test -- --testPathPattern="sep24-interactive-token|kyc.service|sep24.route"
   ```

2. **Interactive deposit URL**
   ```bash
   curl -s -X POST http://localhost:3002/sep24/transactions/deposit/interactive \
     -H "Content-Type: application/json" \
     -d '{"asset_code":"USDC","account":"GACCOUNT","amount":"10"}' | jq .
   ```
   Confirm the returned `url` includes a `token` query parameter.

3. **Validate token**
   ```bash
   TOKEN="<token from previous step>"
   curl -s "http://localhost:3002/sep24/interactive/validate?token=$TOKEN" | jq .
   ```
   Expect `200` with `transaction_id`, `asset_code`, `flow`, and `expires_at`.

4. **Invalid/expired token**
   ```bash
   curl -s "http://localhost:3002/sep24/interactive/validate?token=bad-token" | jq .
   ```
   Expect `401` with `{ "error": "Invalid token" }`.

## Breaking Changes

- None. Interactive URLs gain an additional `token` query parameter; existing query params are unchanged.

## Related Issues

Closes ceejaylaboratory/AnchorPoint#372

## Checklist

- [x] Code builds successfully
- [x] Tests added/updated
- [x] No console errors
- [x] Documentation updated (if needed)