### PR TITLE
fix: rate limiting polish, KMS startup validation, SEP-24 integration tests, Logstash log format

### DIFF
--- a/backend/src/api/middleware/rate-limit.middleware.ts
+++ b/backend/src/api/middleware/rate-limit.middleware.ts
@@ -4,7 +4,9 @@ import { redis } from '../../lib/redis';
 import logger from '../../utils/logger';
 import { Request, Response, NextFunction } from 'express';
 import * as StellarSdk from '@stellar/stellar-sdk';
+import { config } from '../../config/env';
 
+const HEALTH_SKIP_PATHS = ['/health', '/api-docs', '/api-docs.json'];
 
 /**
  * Interface for rate limit options
@@ -14,6 +16,8 @@ export interface RateLimitOptions {
   max?: number;
   message?: string;
   keyPrefix?: string;
+  /** Paths that bypass rate limiting entirely (in addition to the default health/docs paths) */
+  skipPaths?: string[];
 }
 
 /**
@@ -23,26 +27,29 @@ export interface RateLimitOptions {
  */
 export const createRateLimiter = (options: RateLimitOptions = {}) => {
   const {
-    windowMs = 15 * 60 * 1000, // Default 15 minutes
-    max = 100, // Default 100 requests per windowMs
+    windowMs = 15 * 60 * 1000,
+    max = 100,
     message = 'Too many requests from this IP, please try again later.',
     keyPrefix = 'rl:',
+    skipPaths = [],
   } = options;
+
+  const allSkipPaths = [...HEALTH_SKIP_PATHS, ...skipPaths];
 
   return rateLimit({
     windowMs,
     max,
     message: { error: message },
-    standardHeaders: true, // Return rate limit info in `RateLimit-*` headers
-    legacyHeaders: false, // Disable the `X-RateLimit-*` headers
-    // Redis store configuration
+    standardHeaders: true,
+    legacyHeaders: false,
+    skip: (req: Request) => allSkipPaths.some(p => req.path === p || req.path.startsWith(p)),
     store: new RedisStore({
       sendCommand: (...args: string[]) => redis.call(...args),
       prefix: keyPrefix,
     }),
 
     handler: (req: Request, res: Response, _next: NextFunction, options: any) => {
-      logger.warn(`Rate limit exceeded for IP: ${req.ip}`);
+      logger.warn(`Rate limit exceeded`, { ip: req.ip, path: req.path, keyPrefix });
       res.status(options.statusCode).send(options.message);
     },
   });
@@ -92,14 +99,14 @@ export const submissionLimiterOptions = {
   keyGenerator: (req: Request) => {
     try {
       if (req.body && req.body.xdr) {
-        const tx = StellarSdk.TransactionBuilder.fromXDR(req.body.xdr, StellarSdk.Networks.TESTNET);
+        const tx = StellarSdk.TransactionBuilder.fromXDR(req.body.xdr, config.STELLAR_NETWORK_PASSPHRASE);
         if (tx instanceof StellarSdk.FeeBumpTransaction) {
           return tx.innerTransaction.source;
         }
         return tx.source;
       }
     } catch (e) {
-      // Fallback to IP if XDR is invalid
+      logger.debug('Failed to parse XDR for rate-limit key, falling back to IP', { error: (e as Error).message });
     }
     return req.ip || 'unknown';
   },

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -23,12 +23,11 @@ import feeReportRouter from './api/routes/fee-report.route';
 import { feeReportScheduler } from './workers/fee-report.scheduler';
 import eventRouter from './api/routes/event.route';
 import notificationsRouter from './api/routes/notifications.route';
-import { errorHandler } from './api/middleware/error.middleware';
-import { metricsMiddleware, connectionTracker } from './api/middleware/metrics.middleware';
 import { publicLimiter } from './api/middleware/rate-limit.middleware';
 import { notificationService } from './services/notification.service';
 import { ConsoleEmailProvider, ConsoleSmsProvider, ConsolePushProvider } from './lib/notifications/providers';
 import { NotificationType } from '@prisma/client';
+import { validateKmsConfigOnStartup } from './lib/key-management.service';
 
 // Initialize Notification Engine
 notificationService.registerProvider(NotificationType.EMAIL, new ConsoleEmailProvider());
@@ -130,24 +129,13 @@ app.use('/api/notifications', notificationsRouter);
 // Relayer API for gasless token approvals
 app.use('/api/relayer', relayerRouter);
 
-// Prometheus metrics endpoint
-app.use('/metrics', metricsRouter);
-
-// SEP-38 Price Quotes API
-app.use('/sep38', sep38Router);
-
 // SEP-40 Swap Rates API
 app.use('/sep40', sep40Router);
-
-// SEP-1 Info endpoint
-app.use('/info', infoRouter);
 
 // SEP-12 KYC routes
 app.use('/sep12', sep12Router);
 
-// SEP-24 routes
-app.use('/sep24', sep24Router);
-// Public endpoints with shared Redis-backed rate limit state
+// Public endpoints — shared Redis-backed rate limit state
 app.use('/sep38', publicLimiter, sep38Router);
 app.use('/info', publicLimiter, infoRouter);
 app.use('/sep24', publicLimiter, sep24Router);
@@ -161,6 +149,8 @@ app.use(errorHandler);
 
 /* istanbul ignore next */
 if (process.env.NODE_ENV !== 'test') {
+  validateKmsConfigOnStartup(config);
+
   configService.initialize()
     .catch((error) => {
       logger.error('Failed to initialize config service:', error);
@@ -169,15 +159,9 @@ if (process.env.NODE_ENV !== 'test') {
       app.listen(PORT, () => {
         logger.info(`Backend service listening at http://localhost:${PORT}`);
         logger.info(`API Documentation available at http://localhost:${PORT}/api-docs`);
+        feeReportScheduler.start();
       });
     });
-  app.listen(PORT, () => {
-    logger.info(`Backend service listening at http://localhost:${PORT}`);
-    logger.info(`API Documentation available at http://localhost:${PORT}/api-docs`);
-    
-    // Start fee report scheduler
-    feeReportScheduler.start();
-  });
 }
 
 export default app;

--- a/backend/src/lib/key-management.service.ts
+++ b/backend/src/lib/key-management.service.ts
@@ -580,6 +580,62 @@ export function initializeKeyManagement(config: KeyManagementConfig): void {
 }
 
 /**
+ * Validate AWS KMS / Vault configuration at startup and emit structured
+ * diagnostic log entries.  Never throws — missing config is surfaced as a
+ * warning so the process can still start and serve non-key-management routes.
+ */
+export function validateKmsConfigOnStartup(envConfig: {
+  KEY_MANAGEMENT_BACKEND?: string;
+  AWS_KMS_KEY_ARN?: string;
+  AWS_REGION?: string;
+  VAULT_ADDR?: string;
+  VAULT_TOKEN?: string;
+  VAULT_TRANSIT_PATH?: string;
+}): void {
+  const backend = envConfig.KEY_MANAGEMENT_BACKEND ?? 'aws-kms';
+
+  if (backend === 'aws-kms') {
+    if (!envConfig.AWS_KMS_KEY_ARN) {
+      logger.warn('KMS startup validation: KEY_MANAGEMENT_BACKEND=aws-kms but AWS_KMS_KEY_ARN is not set — key encryption/decryption unavailable', {
+        backend,
+        missingVars: ['AWS_KMS_KEY_ARN'],
+      });
+    } else {
+      const maskedArn = envConfig.AWS_KMS_KEY_ARN.replace(/(?<=.{20}).+(?=.{6})/, '***');
+      logger.info('KMS startup validation: AWS KMS configuration present', {
+        backend,
+        keyArn: maskedArn,
+        region: envConfig.AWS_REGION ?? 'us-east-1 (default)',
+      });
+    }
+    return;
+  }
+
+  if (backend === 'vault') {
+    const missingVars: string[] = [];
+    if (!envConfig.VAULT_ADDR) missingVars.push('VAULT_ADDR');
+    if (!envConfig.VAULT_TOKEN) missingVars.push('VAULT_TOKEN');
+    if (!envConfig.VAULT_TRANSIT_PATH) missingVars.push('VAULT_TRANSIT_PATH');
+
+    if (missingVars.length > 0) {
+      logger.warn('KMS startup validation: KEY_MANAGEMENT_BACKEND=vault but required vars are missing — key encryption/decryption unavailable', {
+        backend,
+        missingVars,
+      });
+    } else {
+      logger.info('KMS startup validation: HashiCorp Vault configuration present', {
+        backend,
+        vaultAddr: envConfig.VAULT_ADDR,
+        transitPath: envConfig.VAULT_TRANSIT_PATH,
+      });
+    }
+    return;
+  }
+
+  logger.warn('KMS startup validation: unrecognised KEY_MANAGEMENT_BACKEND value', { backend });
+}
+
+/**
  * Build key management configuration from environment variables.
  * Returns null when required credentials are missing.
  */

--- a/backend/src/test/sep24.test.ts
+++ b/backend/src/test/sep24.test.ts
@@ -1,0 +1,281 @@
+import express, { Express } from 'express';
+import request from 'supertest';
+
+jest.mock('crypto', () => {
+  const actual = jest.requireActual('crypto');
+  return {
+    ...actual,
+    randomUUID: jest.fn(() => 'test-uuid-1234-5678-9abc-def012345678'),
+  };
+});
+
+jest.mock('../lib/prisma', () => ({
+  quote: {
+    findUnique: jest.fn(),
+  },
+}));
+
+import sep24Router from '../api/routes/sep24.route';
+import prisma from '../lib/prisma';
+
+const mockPrisma = prisma as jest.Mocked<typeof prisma>;
+
+function buildApp(): Express {
+  const app = express();
+  app.use(express.json());
+  app.use('/sep24', sep24Router);
+  return app;
+}
+
+const app = buildApp();
+const BASE = '/sep24/transactions';
+const BASE_URL = 'http://localhost:4200';
+
+beforeEach(() => {
+  process.env.INTERACTIVE_URL = BASE_URL;
+  jest.clearAllMocks();
+});
+
+afterEach(() => {
+  delete process.env.INTERACTIVE_URL;
+});
+
+// ─── Deposit ──────────────────────────────────────────────────────────────────
+
+describe('POST /sep24/transactions/deposit/interactive', () => {
+  it('returns 400 when asset_code is missing', async () => {
+    const res = await request(app).post(`${BASE}/deposit/interactive`).send({});
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error).toBe('asset_code is required');
+  });
+
+  it('returns 400 for an unsupported asset', async () => {
+    const res = await request(app)
+      .post(`${BASE}/deposit/interactive`)
+      .send({ asset_code: 'DOGE' });
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error).toContain('DOGE is not supported');
+    expect(res.body.error).toContain('Supported assets:');
+  });
+
+  it('returns 200 with interactive_customer_info_needed for a supported asset', async () => {
+    const res = await request(app)
+      .post(`${BASE}/deposit/interactive`)
+      .send({ asset_code: 'USDC', account: 'GACCOUNT123', amount: '50.00' });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.type).toBe('interactive_customer_info_needed');
+    expect(res.body.id).toBe('test-uuid-1234-5678-9abc-def012345678');
+
+    const parsed = new URL(res.body.url);
+    expect(parsed.pathname).toBe('/kyc-deposit');
+    expect(parsed.searchParams.get('transaction_id')).toBe(res.body.id);
+    expect(parsed.searchParams.get('asset_code')).toBe('USDC');
+    expect(parsed.searchParams.get('account')).toBe('GACCOUNT123');
+    expect(parsed.searchParams.get('amount')).toBe('50.00');
+  });
+
+  it('normalises asset_code to uppercase', async () => {
+    const res = await request(app)
+      .post(`${BASE}/deposit/interactive`)
+      .send({ asset_code: 'usdc' });
+
+    expect(res.statusCode).toBe(200);
+    const parsed = new URL(res.body.url);
+    expect(parsed.searchParams.get('asset_code')).toBe('USDC');
+  });
+
+  it('defaults lang to en when omitted', async () => {
+    const res = await request(app)
+      .post(`${BASE}/deposit/interactive`)
+      .send({ asset_code: 'USDC' });
+
+    const parsed = new URL(res.body.url);
+    expect(parsed.searchParams.get('lang')).toBe('en');
+  });
+
+  it('passes lang parameter into the redirect URL', async () => {
+    const res = await request(app)
+      .post(`${BASE}/deposit/interactive`)
+      .send({ asset_code: 'USD', lang: 'es' });
+
+    const parsed = new URL(res.body.url);
+    expect(parsed.searchParams.get('lang')).toBe('es');
+  });
+
+  it('returns 400 when quote_id is not found', async () => {
+    (mockPrisma.quote.findUnique as jest.Mock).mockResolvedValueOnce(null);
+
+    const res = await request(app)
+      .post(`${BASE}/deposit/interactive`)
+      .send({ asset_code: 'USDC', quote_id: 'nonexistent-quote' });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error).toBe('Quote not found');
+  });
+
+  it('returns 400 when quote is expired', async () => {
+    (mockPrisma.quote.findUnique as jest.Mock).mockResolvedValueOnce({
+      id: 'expired-quote',
+      expiresAt: new Date(Date.now() - 60_000),
+    });
+
+    const res = await request(app)
+      .post(`${BASE}/deposit/interactive`)
+      .send({ asset_code: 'USDC', quote_id: 'expired-quote' });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error).toBe('Quote has expired');
+  });
+
+  it('returns 200 with a valid non-expired quote', async () => {
+    (mockPrisma.quote.findUnique as jest.Mock).mockResolvedValueOnce({
+      id: 'valid-quote',
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+
+    const res = await request(app)
+      .post(`${BASE}/deposit/interactive`)
+      .send({ asset_code: 'USDC', quote_id: 'valid-quote' });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.type).toBe('interactive_customer_info_needed');
+  });
+
+  it('omits optional params from URL when not provided', async () => {
+    const res = await request(app)
+      .post(`${BASE}/deposit/interactive`)
+      .send({ asset_code: 'USD' });
+
+    const parsed = new URL(res.body.url);
+    expect(parsed.searchParams.has('account')).toBe(false);
+    expect(parsed.searchParams.has('amount')).toBe(false);
+  });
+});
+
+// ─── Withdraw ─────────────────────────────────────────────────────────────────
+
+describe('POST /sep24/transactions/withdraw/interactive', () => {
+  it('returns 400 when asset_code is missing', async () => {
+    const res = await request(app).post(`${BASE}/withdraw/interactive`).send({});
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error).toBe('asset_code is required');
+  });
+
+  it('returns 400 for an unsupported asset', async () => {
+    const res = await request(app)
+      .post(`${BASE}/withdraw/interactive`)
+      .send({ asset_code: 'SHIB' });
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error).toContain('SHIB is not supported');
+  });
+
+  it('returns 200 with interactive_customer_info_needed for a supported asset', async () => {
+    const res = await request(app)
+      .post(`${BASE}/withdraw/interactive`)
+      .send({ asset_code: 'USD', account: 'GWALLET', amount: '200' });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.type).toBe('interactive_customer_info_needed');
+    expect(res.body.id).toBe('test-uuid-1234-5678-9abc-def012345678');
+
+    const parsed = new URL(res.body.url);
+    expect(parsed.pathname).toBe('/kyc-withdraw');
+    expect(parsed.searchParams.get('asset_code')).toBe('USD');
+    expect(parsed.searchParams.get('account')).toBe('GWALLET');
+    expect(parsed.searchParams.get('amount')).toBe('200');
+  });
+
+  it('normalises asset_code to uppercase', async () => {
+    const res = await request(app)
+      .post(`${BASE}/withdraw/interactive`)
+      .send({ asset_code: 'usdc' });
+
+    expect(res.statusCode).toBe(200);
+    const parsed = new URL(res.body.url);
+    expect(parsed.searchParams.get('asset_code')).toBe('USDC');
+  });
+
+  it('defaults lang to en when omitted', async () => {
+    const res = await request(app)
+      .post(`${BASE}/withdraw/interactive`)
+      .send({ asset_code: 'USDC' });
+
+    const parsed = new URL(res.body.url);
+    expect(parsed.searchParams.get('lang')).toBe('en');
+  });
+
+  it('passes lang parameter into the redirect URL', async () => {
+    const res = await request(app)
+      .post(`${BASE}/withdraw/interactive`)
+      .send({ asset_code: 'USDC', lang: 'fr' });
+
+    const parsed = new URL(res.body.url);
+    expect(parsed.searchParams.get('lang')).toBe('fr');
+  });
+
+  it('returns 400 when quote_id is not found', async () => {
+    (mockPrisma.quote.findUnique as jest.Mock).mockResolvedValueOnce(null);
+
+    const res = await request(app)
+      .post(`${BASE}/withdraw/interactive`)
+      .send({ asset_code: 'USDC', quote_id: 'ghost-quote' });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error).toBe('Quote not found');
+  });
+
+  it('returns 400 when quote is expired', async () => {
+    (mockPrisma.quote.findUnique as jest.Mock).mockResolvedValueOnce({
+      id: 'stale-quote',
+      expiresAt: new Date(Date.now() - 5_000),
+    });
+
+    const res = await request(app)
+      .post(`${BASE}/withdraw/interactive`)
+      .send({ asset_code: 'USDC', quote_id: 'stale-quote' });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error).toBe('Quote has expired');
+  });
+
+  it('returns 200 with a valid non-expired quote', async () => {
+    (mockPrisma.quote.findUnique as jest.Mock).mockResolvedValueOnce({
+      id: 'fresh-quote',
+      expiresAt: new Date(Date.now() + 120_000),
+    });
+
+    const res = await request(app)
+      .post(`${BASE}/withdraw/interactive`)
+      .send({ asset_code: 'USD', quote_id: 'fresh-quote' });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.type).toBe('interactive_customer_info_needed');
+  });
+
+  it('omits optional params from URL when not provided', async () => {
+    const res = await request(app)
+      .post(`${BASE}/withdraw/interactive`)
+      .send({ asset_code: 'USDC' });
+
+    const parsed = new URL(res.body.url);
+    expect(parsed.searchParams.has('account')).toBe(false);
+    expect(parsed.searchParams.has('amount')).toBe(false);
+  });
+
+  it('includes all optional query params in the redirect URL', async () => {
+    const res = await request(app)
+      .post(`${BASE}/withdraw/interactive`)
+      .send({
+        asset_code: 'USDC',
+        account: 'GTEST',
+        amount: '75.50',
+        lang: 'de',
+      });
+
+    const parsed = new URL(res.body.url);
+    expect(parsed.searchParams.get('account')).toBe('GTEST');
+    expect(parsed.searchParams.get('amount')).toBe('75.50');
+    expect(parsed.searchParams.get('lang')).toBe('de');
+  });
+});

--- a/backend/src/utils/log-format.ts
+++ b/backend/src/utils/log-format.ts
@@ -2,20 +2,23 @@ import winston from "winston";
 
 /**
  * Custom Winston format that produces structured JSON log entries conforming
- * to the ELK logging schema.
+ * to the ELK/Logstash logging schema.
  *
  * Responsibilities:
- * - Enforces ISO 8601 timestamp
+ * - Enforces ISO 8601 timestamp and Logstash-compatible @timestamp / @version
  * - Injects `service` from defaultMeta and `environment` from NODE_ENV
- * - Serialises Error objects to top-level `errorMessage` / `errorStack` fields
+ * - Serialises Error objects to errorMessage / errorStack / errorName / errorCode
  *   and removes any top-level `error` key
  * - Delegates traceId/spanId injection to traceContextFormat() (called earlier
  *   in the format chain); omits both keys when absent
  */
 export function structuredJsonFormat(): winston.Logform.Format {
   return winston.format((info) => {
-    // 1. Enforce ISO 8601 timestamp (override whatever was set upstream)
-    info["timestamp"] = new Date().toISOString();
+    // 1. Enforce ISO 8601 timestamp and Logstash canonical fields
+    const ts = new Date().toISOString();
+    info["timestamp"] = ts;
+    info["@timestamp"] = ts;   // Logstash convention
+    info["@version"] = "1";    // Logstash convention
 
     // 2. Inject environment from NODE_ENV
     info["environment"] = process.env.NODE_ENV ?? "development";
@@ -31,6 +34,13 @@ export function structuredJsonFormat(): winston.Logform.Format {
     if (rawError instanceof Error) {
       info["errorMessage"] = rawError.message;
       info["errorStack"] = rawError.stack;
+      // errorName lets Logstash/ELK filter by error class (e.g. TypeError, KeyManagementError)
+      info["errorName"] = rawError.name;
+      // errorCode captures Node.js system error codes (e.g. ECONNREFUSED, ETIMEDOUT)
+      const errCode = (rawError as NodeJS.ErrnoException).code;
+      if (errCode) {
+        info["errorCode"] = errCode;
+      }
       // Remove the top-level `error` key as required
       delete (info as Record<string, unknown>)["error"];
       // If the message was the Error itself, replace with its message string
@@ -46,7 +56,6 @@ export function structuredJsonFormat(): winston.Logform.Format {
       !info["errorStack"]
     ) {
       info["errorStack"] = (info as Record<string, unknown>)["stack"];
-      // Derive errorMessage from the message field if not already set
       if (!info["errorMessage"]) {
         info["errorMessage"] = info.message;
       }


### PR DESCRIPTION
## Summary

This PR closes four testnet deployment readiness tasks across the backend.

### #367 — Rate Limiting Middleware Polish
- Added `skipPaths` option to `createRateLimiter` with a built-in bypass for `/health`, `/api-docs`, and `/api-docs.json` so health checks and Swagger docs are never blocked
- Replaced hardcoded `Networks.TESTNET` passphrase in `submissionLimiter` with `config.STELLAR_NETWORK_PASSPHRASE` so the correct network is used across all environments
- Added structured debug log in the XDR parse catch block instead of swallowing errors silently
- Improved rate-limit exceeded handler log to include `path` and `keyPrefix` for better observability
- Fixed `index.ts`: removed duplicate imports, collapsed duplicate route mounts (`sep38`, `info`, `sep24`, `metrics` were each registered twice — once without the rate limiter making the rate-limited mounts dead code), and consolidated the double `app.listen` call into a single startup path

### #369 — AWS KMS Config Validation on Startup
- Added `validateKmsConfigOnStartup()` to `key-management.service.ts`; validates required env vars for the configured backend (`aws-kms` or `vault`) and emits structured `info`/`warn` log entries — never throws so non-KMS routes still start normally
- Called at server startup in `index.ts` so misconfigured deployments surface diagnostics at boot time instead of failing silently at runtime

### #377 — Backend Integration Tests for SEP-24
- Created `backend/src/test/sep24.test.ts` with **21 integration tests** using supertest against a real Express router instance
- Covers both `POST /sep24/transactions/deposit/interactive` and `POST /sep24/transactions/withdraw/interactive`
- Tests: missing `asset_code`, unsupported asset, valid request, asset code normalisation, `lang` default/override, `quote_id` not found, expired quote, valid quote, optional param omission, and full optional-param pass-through
- Prisma `quote.findUnique` is mocked per-test so all quote-validation branches are exercised without a live database

### #379 — Improved Error Logging Format for Logstash
- Added `@timestamp` (ISO 8601 alias of `timestamp`) and `@version: "1"` to every log entry in `structuredJsonFormat` — Logstash canonical fields that allow ingestion without an additional mapping pipeline
- Extended error serialisation to capture `errorName` (e.g. `TypeError`, `KeyManagementError`) and `errorCode` (Node.js errno codes such as `ECONNREFUSED`, `ETIMEDOUT`) alongside the existing `errorMessage` / `errorStack` fields, enabling precise Logstash/Kibana filter rules

## Test plan
- [ ] `npx jest --testPathPattern="src/test/sep24"` — 21 tests pass
- [ ] `npx jest --testPathPattern="elk-logging|logger.test"` — 20 tests pass
- [ ] `npx tsc --noEmit` — no errors in modified files
- [ ] Server starts and logs KMS validation output at boot
- [ ] Rate-limited endpoints (`/sep38`, `/info`, `/sep24`, `/metrics`) are correctly protected; `/health` bypasses rate limiting

Closes #367
Closes #369
Closes #377
Closes #379