### PR TITLE
fix: migrate SQLite to PostgreSQL, configure BullMQ testnet priorities, and add Rust unit tests

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -4,8 +4,11 @@
 NODE_ENV=development
 PORT=3002
 
-# Database
-DATABASE_URL=file:./prisma/dev.db
+# Database (PostgreSQL)
+DATABASE_URL=postgresql://anchorpoint:anchorpoint@localhost:5432/anchorpoint
+# POSTGRES_USER=anchorpoint
+# POSTGRES_PASSWORD=anchorpoint
+# POSTGRES_DB=anchorpoint
 
 # JWT
 JWT_SECRET=your-secret-key-min-8-chars

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -6,7 +6,7 @@ generator client {
 }
 
 datasource db {
-  provider = "sqlite"
+  provider = "postgresql"
   url      = env("DATABASE_URL")
 }
 
@@ -17,25 +17,17 @@ enum Tier {
 }
 
 model User {
-  id            String        @id @default(uuid())
-  publicKey     String        @unique
-  email         String?
-  createdAt     DateTime      @default(now())
-  updatedAt     DateTime      @updatedAt
-  transactions  Transaction[]
-  kycCustomer   KycCustomer?
-  apiKeys       ApiKey[]
+  id                        String                    @id @default(uuid())
+  publicKey                 String                    @unique
+  email                     String?
+  phone                     String?
+  createdAt                 DateTime                  @default(now())
+  updatedAt                 DateTime                  @updatedAt
+  transactions              Transaction[]
+  kycCustomer               KycCustomer?
+  apiKeys                   ApiKey[]
   recurringPaymentSchedules RecurringPaymentSchedule[]
-  id                    String                 @id @default(uuid())
-  publicKey             String                 @unique
-  email                 String?
-  phone                 String?
-  createdAt             DateTime               @default(now())
-  updatedAt             DateTime               @updatedAt
-  transactions          Transaction[]
-  kycCustomer           KycCustomer?
-  apiKeys               ApiKey[]
-  notificationPreference NotificationPreference?
+  notificationPreference    NotificationPreference?
 
   @@index([publicKey])
 }
@@ -91,9 +83,9 @@ enum RecurringPaymentRunStatus {
 }
 
 model RecurringPaymentSchedule {
-  id          String   @id @default(uuid())
+  id          String                         @id @default(uuid())
   userId      String
-  user        User     @relation(fields: [userId], references: [id])
+  user        User                           @relation(fields: [userId], references: [id])
   destination String
   assetCode   String
   amount      String
@@ -101,8 +93,8 @@ model RecurringPaymentSchedule {
   status      RecurringPaymentScheduleStatus @default(ACTIVE)
   nextRunAt   DateTime
   lastRunAt   DateTime?
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  createdAt   DateTime                       @default(now())
+  updatedAt   DateTime                       @updatedAt
   runs        RecurringPaymentRun[]
 
   @@index([userId])
@@ -110,17 +102,17 @@ model RecurringPaymentSchedule {
 }
 
 model RecurringPaymentRun {
-  id          String   @id @default(uuid())
+  id          String                    @id @default(uuid())
   scheduleId  String
-  schedule    RecurringPaymentSchedule @relation(fields: [scheduleId], references: [id])
+  schedule    RecurringPaymentSchedule  @relation(fields: [scheduleId], references: [id])
   status      RecurringPaymentRunStatus @default(PENDING)
-  attempt     Int      @default(0)
-  stellarTxId String?  @unique
+  attempt     Int                       @default(0)
+  stellarTxId String?                   @unique
   error       String?
   startedAt   DateTime?
   finishedAt  DateTime?
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  createdAt   DateTime                  @default(now())
+  updatedAt   DateTime                  @updatedAt
 
   @@index([scheduleId])
   @@index([status])
@@ -132,14 +124,8 @@ model Transaction {
   user                User           @relation(fields: [userId], references: [id])
   assetCode           String
   amount              String
-  type                String    // DEPOSIT | WITHDRAW | SEP31 | SWAP
-  status              String    // PENDING, COMPLETED, FAILED
-  externalId          String?   @unique
-  stellarTxId         String?   @unique
-  createdAt           DateTime  @default(now())
-  updatedAt           DateTime  @updatedAt
-  type                String         // DEPOSIT | WITHDRAW | SEP31
-  status              String         // PENDING, COMPLETED, FAILED
+  type                String
+  status              String
   externalId          String?        @unique
   stellarTxId         String?        @unique
   createdAt           DateTime       @default(now())
@@ -147,9 +133,9 @@ model Transaction {
   notifications       Notification[]
 
   // Fee tracking
-  feeAmount           String?   @default("0")  // Fee amount in asset units
-  feeAssetCode        String?   // Asset code for fee (e.g., XLM, USDC)
-  feeType             String?   // FLAT, PERCENTAGE, TIERED
+  feeAmount           String?        @default("0")
+  feeAssetCode        String?
+  feeType             String?
 
   // SEP-31 specific fields (nullable for backward compatibility)
   senderInfo          Json?
@@ -167,17 +153,17 @@ model Transaction {
 }
 
 model FeeReport {
-  id              String    @id @default(uuid())
-  reportType      String    // DAILY, MONTHLY
+  id              String   @id @default(uuid())
+  reportType      String
   startDate       DateTime
   endDate         DateTime
-  totalFees       String    // Total fees collected in base asset
-  totalFeesXLM    String    // Total fees converted to XLM
-  operationCounts Json      // { DEPOSIT: 10, WITHDRAW: 5, SWAP: 3, SEP31: 2 }
-  feeBreakdown    Json      // Detailed breakdown by operation type
-  generatedAt     DateTime  @default(now())
-  filePath        String?   // Path to generated report file
-  fileType        String?   // JSON, PDF
+  totalFees       String
+  totalFeesXLM    String
+  operationCounts Json
+  feeBreakdown    Json
+  generatedAt     DateTime @default(now())
+  filePath        String?
+  fileType        String?
 
   @@index([reportType])
   @@index([startDate])
@@ -254,6 +240,8 @@ model SystemConfig {
 
   @@index([isActive])
   @@index([createdAt])
+}
+
 enum JobStatus {
   PENDING
   ACTIVE
@@ -270,31 +258,31 @@ enum JobPriority {
 }
 
 model ContractJob {
-  id          String      @id @default(uuid())
-  jobId       String      @unique
-  type        String
-  priority    JobPriority @default(NORMAL)
-  status      JobStatus   @default(PENDING)
-  contractId  String?
-  functionName String?
-  parameters   Json?
-  result      Json?
-  error       String?
-  errorCategory String?
-  errorSeverity String?
-  errorCode   String?
-  userMessage String?
+  id              String      @id @default(uuid())
+  jobId           String      @unique
+  type            String
+  priority        JobPriority @default(NORMAL)
+  status          JobStatus   @default(PENDING)
+  contractId      String?
+  functionName    String?
+  parameters      Json?
+  result          Json?
+  error           String?
+  errorCategory   String?
+  errorSeverity   String?
+  errorCode       String?
+  userMessage     String?
   suggestedAction String?
-  retryable   Boolean     @default(false)
-  attempts    Int         @default(0)
-  maxAttempts Int         @default(3)
-  createdBy   String?
-  metadata    Json?
-  startedAt   DateTime?
-  completedAt DateTime?
-  failedAt    DateTime?
-  createdAt   DateTime    @default(now())
-  updatedAt   DateTime    @updatedAt
+  retryable       Boolean     @default(false)
+  attempts        Int         @default(0)
+  maxAttempts     Int         @default(3)
+  createdBy       String?
+  metadata        Json?
+  startedAt       DateTime?
+  completedAt     DateTime?
+  failedAt        DateTime?
+  createdAt       DateTime    @default(now())
+  updatedAt       DateTime    @updatedAt
 
   @@index([jobId])
   @@index([status])

--- a/backend/src/config/queue.ts
+++ b/backend/src/config/queue.ts
@@ -13,6 +13,14 @@ export const queueConnection = {
   db: parseInt(process.env.REDIS_DB || '0', 10),
 };
 
+// Priority mapping — must be declared before jobTypeConfigs to allow direct references
+export enum JobPriority {
+  LOW = 1,
+  NORMAL = 2,
+  HIGH = 3,
+  URGENT = 4,
+}
+
 // Default queue options
 export const defaultQueueOptions: QueueOptions = {
   connection: queueConnection,
@@ -32,7 +40,7 @@ export const defaultQueueOptions: QueueOptions = {
   },
 };
 
-// Worker options
+// Worker options (mainnet defaults)
 export const defaultWorkerOptions: WorkerOptions = {
   connection: queueConnection,
   concurrency: parseInt(process.env.QUEUE_CONCURRENCY || '5', 10),
@@ -42,7 +50,17 @@ export const defaultWorkerOptions: WorkerOptions = {
   },
 };
 
-// Job type configurations
+// Testnet worker options — lower concurrency and rate limit to avoid saturating testnet RPC
+export const testnetWorkerOptions: WorkerOptions = {
+  connection: queueConnection,
+  concurrency: parseInt(process.env.QUEUE_CONCURRENCY || '2', 10),
+  limiter: {
+    max: 5, // Max 5 jobs per second on testnet
+    duration: 1000,
+  },
+};
+
+// Job type configurations (mainnet defaults)
 export const jobTypeConfigs: Record<string, Partial<JobsOptions>> = {
   CONTRACT_CALL: {
     attempts: 5,
@@ -50,7 +68,7 @@ export const jobTypeConfigs: Record<string, Partial<JobsOptions>> = {
       type: 'exponential',
       delay: 3000,
     },
-    priority: 2, // Normal priority
+    priority: JobPriority.NORMAL,
   },
   CONTRACT_DEPLOY: {
     attempts: 3,
@@ -58,7 +76,7 @@ export const jobTypeConfigs: Record<string, Partial<JobsOptions>> = {
       type: 'exponential',
       delay: 5000,
     },
-    priority: 3, // Higher priority
+    priority: JobPriority.HIGH,
   },
   SETTLEMENT: {
     attempts: 10,
@@ -66,7 +84,7 @@ export const jobTypeConfigs: Record<string, Partial<JobsOptions>> = {
       type: 'exponential',
       delay: 2000,
     },
-    priority: 4, // Urgent priority
+    priority: JobPriority.URGENT,
   },
   BATCH_OPERATION: {
     attempts: 3,
@@ -74,7 +92,7 @@ export const jobTypeConfigs: Record<string, Partial<JobsOptions>> = {
       type: 'fixed',
       delay: 10000,
     },
-    priority: 1, // Low priority
+    priority: JobPriority.LOW,
   },
   TRANSACTION_SUBMIT: {
     attempts: 5,
@@ -82,17 +100,71 @@ export const jobTypeConfigs: Record<string, Partial<JobsOptions>> = {
       type: 'exponential',
       delay: 2000,
     },
-    priority: 3,
+    priority: JobPriority.HIGH,
+  },
+  NOTIFICATION: {
+    attempts: 3,
+    backoff: {
+      type: 'fixed',
+      delay: 5000,
+    },
+    priority: JobPriority.LOW,
   },
 };
 
-// Priority mapping
-export enum JobPriority {
-  LOW = 1,
-  NORMAL = 2,
-  HIGH = 3,
-  URGENT = 4,
-}
+// Testnet-specific job type configurations.
+// CONTRACT_DEPLOY is elevated to URGENT for faster iteration during testnet deployments.
+// BATCH_OPERATION and NOTIFICATION are kept LOW to avoid saturating testnet RPC endpoints.
+export const testnetJobTypeConfigs: Record<string, Partial<JobsOptions>> = {
+  CONTRACT_CALL: {
+    attempts: 3,
+    backoff: {
+      type: 'exponential',
+      delay: 5000, // longer delay — testnet finality is slower
+    },
+    priority: JobPriority.HIGH,
+  },
+  CONTRACT_DEPLOY: {
+    attempts: 2,
+    backoff: {
+      type: 'exponential',
+      delay: 8000,
+    },
+    priority: JobPriority.URGENT, // deployments are the primary testnet workflow
+  },
+  SETTLEMENT: {
+    attempts: 5,
+    backoff: {
+      type: 'exponential',
+      delay: 3000,
+    },
+    priority: JobPriority.URGENT,
+  },
+  BATCH_OPERATION: {
+    attempts: 2,
+    backoff: {
+      type: 'fixed',
+      delay: 15000,
+    },
+    priority: JobPriority.LOW,
+  },
+  TRANSACTION_SUBMIT: {
+    attempts: 3,
+    backoff: {
+      type: 'exponential',
+      delay: 4000,
+    },
+    priority: JobPriority.NORMAL,
+  },
+  NOTIFICATION: {
+    attempts: 2,
+    backoff: {
+      type: 'fixed',
+      delay: 5000,
+    },
+    priority: JobPriority.LOW,
+  },
+};
 
 // Retry strategies for specific errors
 export const retryStrategies = {
@@ -127,3 +199,17 @@ export const QUEUE_NAMES = {
 } as const;
 
 export type QueueName = typeof QUEUE_NAMES[keyof typeof QUEUE_NAMES];
+
+// Returns effective job options for a given type, adjusted for STELLAR_NETWORK
+export function getEffectiveJobOptions(jobType: string): Partial<JobsOptions> {
+  const configs =
+    process.env.STELLAR_NETWORK === 'testnet' ? testnetJobTypeConfigs : jobTypeConfigs;
+  return configs[jobType] ?? {};
+}
+
+// Returns effective worker options adjusted for STELLAR_NETWORK
+export function getEffectiveWorkerOptions(): WorkerOptions {
+  return process.env.STELLAR_NETWORK === 'testnet'
+    ? testnetWorkerOptions
+    : defaultWorkerOptions;
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,27 @@
 version: '3.8'
 
 services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: anchorpoint-postgres
+    ports:
+      - "5432:5432"
+    environment:
+      - POSTGRES_USER=anchorpoint
+      - POSTGRES_PASSWORD=anchorpoint
+      - POSTGRES_DB=anchorpoint
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U anchorpoint"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    restart: unless-stopped
+    networks:
+      - anchorpoint-network
+
   backend:
     build:
       context: ./backend
@@ -12,15 +33,15 @@ services:
     environment:
       - NODE_ENV=production
       - PORT=3002
-      - DATABASE_URL=file:/app/data/dev.db
+      - DATABASE_URL=postgresql://anchorpoint:anchorpoint@postgres:5432/anchorpoint
       - REDIS_URL=redis://redis:6379
       - JAEGER_ENDPOINT=http://jaeger:14268/api/traces
       - PROMETHEUS_METRICS_PORT=9464
       - OTEL_SERVICE_NAME=anchorpoint-backend
       - OTEL_RESOURCE_ATTRIBUTES=service.name=anchorpoint-backend,service.version=1.0.0
-    volumes:
-      - backend-data:/app/data
     depends_on:
+      postgres:
+        condition: service_healthy
       redis:
         condition: service_healthy
     healthcheck:
@@ -85,7 +106,7 @@ services:
       - anchorpoint-network
 
 volumes:
-  backend-data:
+  postgres-data:
     driver: local
   redis-data:
     driver: local

--- a/src/event_hub/lib.rs
+++ b/src/event_hub/lib.rs
@@ -489,4 +489,239 @@ mod tests {
         let contract2_events = client.get_events_by_contract(&contract2, &10u32);
         assert_eq!(contract2_events.len(), 1);
     }
+
+    // ── Double-init guard ─────────────────────────────────────────────────────
+
+    #[test]
+    #[should_panic(expected = "already initialized")]
+    fn test_double_initialize_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(EventHub, ());
+        let client = EventHubClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+        client.initialize(&admin);
+    }
+
+    // ── Unregistered source contract ─────────────────────────────────────────
+
+    #[test]
+    #[should_panic(expected = "source contract not registered")]
+    fn test_capture_from_unregistered_contract_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(EventHub, ());
+        let client = EventHubClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+
+        let unregistered = Address::generate(&env);
+        let event_type = SorobanString::from_slice(&env, b"transfer");
+        let event_data = Bytes::from_slice(&env, b"data");
+        client.capture_event(&unregistered, &event_type, &event_data);
+    }
+
+    // ── get_event by ID ──────────────────────────────────────────────────────
+
+    #[test]
+    fn test_get_event_by_id() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().set_timestamp(2_000_000u64);
+
+        let contract_id = env.register(EventHub, ());
+        let client = EventHubClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+
+        let source = Address::generate(&env);
+        client.register_contract(&admin, &source);
+
+        let event_type = SorobanString::from_slice(&env, b"stake");
+        let event_data = Bytes::from_slice(&env, b"payload");
+        client.capture_event(&source, &event_type, &event_data);
+
+        let entry = client.get_event(&1u64);
+        assert_eq!(entry.id, 1u64);
+        assert_eq!(entry.source_contract, source);
+        assert_eq!(entry.event_type, event_type);
+        assert_eq!(entry.event_data, event_data);
+        assert_eq!(entry.timestamp, 2_000_000u64);
+    }
+
+    #[test]
+    #[should_panic(expected = "event not found")]
+    fn test_get_event_not_found_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(EventHub, ());
+        let client = EventHubClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+
+        client.get_event(&99u64);
+    }
+
+    // ── Event counter ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_event_counter_increments_per_capture() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register(EventHub, ());
+        let client = EventHubClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+        assert_eq!(client.get_event_count(), 0);
+
+        let source = Address::generate(&env);
+        client.register_contract(&admin, &source);
+
+        let event_type = SorobanString::from_slice(&env, b"tx");
+        let event_data = Bytes::from_slice(&env, b"d");
+
+        client.capture_event(&source, &event_type, &event_data);
+        assert_eq!(client.get_event_count(), 1);
+
+        client.capture_event(&source, &event_type, &event_data);
+        assert_eq!(client.get_event_count(), 2);
+
+        client.capture_event(&source, &event_type, &event_data);
+        assert_eq!(client.get_event_count(), 3);
+    }
+
+    // ── Pagination ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_get_events_pagination() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register(EventHub, ());
+        let client = EventHubClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+
+        let source = Address::generate(&env);
+        client.register_contract(&admin, &source);
+
+        let event_type = SorobanString::from_slice(&env, b"evt");
+        let event_data = Bytes::from_slice(&env, b"data");
+
+        for _ in 0..5 {
+            client.capture_event(&source, &event_type, &event_data);
+        }
+
+        // First page — events 1-3
+        let page1 = client.get_events(&1u64, &3u32);
+        assert_eq!(page1.len(), 3);
+        assert_eq!(page1.get(0).unwrap().id, 1u64);
+        assert_eq!(page1.get(2).unwrap().id, 3u64);
+
+        // Second page — events 4-5
+        let page2 = client.get_events(&4u64, &10u32);
+        assert_eq!(page2.len(), 2);
+        assert_eq!(page2.get(0).unwrap().id, 4u64);
+
+        // Zero limit returns nothing
+        let empty = client.get_events(&1u64, &0u32);
+        assert_eq!(empty.len(), 0);
+    }
+
+    // ── get_registered_contracts ──────────────────────────────────────────────
+
+    #[test]
+    fn test_get_registered_contracts() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register(EventHub, ());
+        let client = EventHubClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+
+        // No contracts registered initially
+        let registered = client.get_registered_contracts();
+        assert_eq!(registered.len(), 0);
+
+        let c1 = Address::generate(&env);
+        let c2 = Address::generate(&env);
+        client.register_contract(&admin, &c1);
+        client.register_contract(&admin, &c2);
+
+        let registered = client.get_registered_contracts();
+        assert_eq!(registered.len(), 2);
+    }
+
+    // ── Unauthorized access ───────────────────────────────────────────────────
+
+    #[test]
+    #[should_panic(expected = "unauthorized")]
+    fn test_register_unauthorized_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register(EventHub, ());
+        let client = EventHubClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+
+        let impostor = Address::generate(&env);
+        let source = Address::generate(&env);
+        // impostor != admin so the assert_eq inside register_contract panics
+        client.register_contract(&impostor, &source);
+    }
+
+    #[test]
+    #[should_panic(expected = "unauthorized")]
+    fn test_unregister_unauthorized_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register(EventHub, ());
+        let client = EventHubClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+
+        let source = Address::generate(&env);
+        client.register_contract(&admin, &source);
+
+        let impostor = Address::generate(&env);
+        client.unregister_contract(&impostor, &source);
+    }
+
+    // ── Unregister then capture panics ────────────────────────────────────────
+
+    #[test]
+    #[should_panic(expected = "source contract not registered")]
+    fn test_capture_after_unregister_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register(EventHub, ());
+        let client = EventHubClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+
+        let source = Address::generate(&env);
+        client.register_contract(&admin, &source);
+        client.unregister_contract(&admin, &source);
+
+        let event_type = SorobanString::from_slice(&env, b"transfer");
+        let event_data = Bytes::from_slice(&env, b"data");
+        // Should panic — contract was unregistered
+        client.capture_event(&source, &event_type, &event_data);
+    }
 }

--- a/src/proxy/lib.rs
+++ b/src/proxy/lib.rs
@@ -289,4 +289,133 @@ mod tests {
         let result_u32: u32 = result.try_into_val(&env).unwrap();
         assert_eq!(result_u32, 42);
     }
+
+    // ── Pre-init guards ───────────────────────────────────────────────────────
+
+    #[test]
+    #[should_panic(expected = "not initialized")]
+    fn test_get_admin_panics_before_init() {
+        let env = Env::default();
+        let proxy_id = env.register(ProxyContract, ());
+        let proxy = ProxyContractClient::new(&env, &proxy_id);
+        proxy.get_admin();
+    }
+
+    #[test]
+    #[should_panic(expected = "not initialized")]
+    fn test_get_implementation_panics_before_init() {
+        let env = Env::default();
+        let proxy_id = env.register(ProxyContract, ());
+        let proxy = ProxyContractClient::new(&env, &proxy_id);
+        proxy.get_implementation();
+    }
+
+    #[test]
+    #[should_panic(expected = "not initialized")]
+    fn test_upgrade_panics_before_init() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let proxy_id = env.register(ProxyContract, ());
+        let proxy = ProxyContractClient::new(&env, &proxy_id);
+        let new_impl = env.register(MockImpl, ());
+        proxy.upgrade(&new_impl);
+    }
+
+    #[test]
+    #[should_panic(expected = "not initialized")]
+    fn test_forward_panics_before_init() {
+        let env = Env::default();
+        let proxy_id = env.register(ProxyContract, ());
+        let proxy = ProxyContractClient::new(&env, &proxy_id);
+        proxy.forward(&Symbol::new(&env, "ping"), &soroban_sdk::vec![&env]);
+    }
+
+    // ── Multiple sequential upgrades ─────────────────────────────────────────
+
+    #[test]
+    fn test_multiple_sequential_upgrades() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (proxy, _admin, first_impl) = setup(&env);
+        assert_eq!(proxy.get_implementation(), first_impl);
+
+        let impl_v2 = env.register(MockImpl, ());
+        proxy.upgrade(&impl_v2);
+        assert_eq!(proxy.get_implementation(), impl_v2);
+
+        let impl_v3 = env.register(MockImpl, ());
+        proxy.upgrade(&impl_v3);
+        assert_eq!(proxy.get_implementation(), impl_v3);
+
+        let impl_v4 = env.register(MockImpl, ());
+        proxy.upgrade(&impl_v4);
+        assert_eq!(proxy.get_implementation(), impl_v4);
+    }
+
+    #[test]
+    fn test_forward_after_multiple_upgrades() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (proxy, _admin, _first_impl) = setup(&env);
+
+        let impl_v2 = env.register(MockImpl, ());
+        proxy.upgrade(&impl_v2);
+
+        let impl_v3 = env.register(MockImpl, ());
+        proxy.upgrade(&impl_v3);
+
+        // forward should still resolve through the latest implementation
+        let result: Val = proxy.forward(&Symbol::new(&env, "ping"), &soroban_sdk::vec![&env]);
+        let result_u32: u32 = result.try_into_val(&env).unwrap();
+        assert_eq!(result_u32, 42);
+    }
+
+    #[test]
+    fn test_forward_add_after_multiple_upgrades() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (proxy, _admin, _first_impl) = setup(&env);
+
+        let impl_v2 = env.register(MockImpl, ());
+        proxy.upgrade(&impl_v2);
+
+        let result: Val = proxy.forward(
+            &Symbol::new(&env, "add"),
+            &soroban_sdk::vec![&env, 20i128.into_val(&env), 22i128.into_val(&env)],
+        );
+        let result_i128: i128 = result.try_into_val(&env).unwrap();
+        assert_eq!(result_i128, 42);
+    }
+
+    // ── Admin transfer + upgradeability ──────────────────────────────────────
+
+    #[test]
+    fn test_transfer_admin_preserves_implementation() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (proxy, _old_admin, impl_id) = setup(&env);
+
+        let new_admin = Address::generate(&env);
+        proxy.transfer_admin(&new_admin);
+
+        // Admin changed but implementation must remain unchanged
+        assert_eq!(proxy.get_admin(), new_admin);
+        assert_eq!(proxy.get_implementation(), impl_id);
+    }
+
+    #[test]
+    fn test_upgrade_after_admin_transfer() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (proxy, _old_admin, _impl_id) = setup(&env);
+
+        let new_admin = Address::generate(&env);
+        proxy.transfer_admin(&new_admin);
+
+        // New admin should be able to upgrade
+        let new_impl = env.register(MockImpl, ());
+        proxy.upgrade(&new_impl);
+        assert_eq!(proxy.get_implementation(), new_impl);
+        assert_eq!(proxy.get_admin(), new_admin);
+    }
 }


### PR DESCRIPTION
## Summary

- **#359** — Migrated Prisma datasource from SQLite to PostgreSQL; updated `.env.example` and `docker-compose.yml` to provision and connect to a `postgres:16-alpine` service
- **#363** — Refactored BullMQ queue config with named `JobPriority` enum, added testnet-specific worker options and job type configs, and exposed `getEffectiveJobOptions` / `getEffectiveWorkerOptions` helpers driven by `STELLAR_NETWORK`
- **#403** — Added 9 upgradeability unit tests to the Proxy contract covering pre-init guards, sequential upgrades, forwarding after upgrade, and admin transfer scenarios
- **#404** — Added 10 unit tests to the Event Hub contract covering double-init guard, unregistered-source panics, event-by-ID retrieval, counter increments, pagination edge cases, registered-contracts listing, unauthorized access, and capture-after-unregister

## Changes by file

| File | Issue | Change |
|---|---|---|
| `backend/prisma/schema.prisma` | #359 | Provider changed to `postgresql`; cleaned up duplicate field definitions |
| `backend/.env.example` | #359 | Updated `DATABASE_URL` to PostgreSQL; added credential reference vars |
| `docker-compose.yml` | #359 | Added `postgres:16-alpine` service; wired backend dependency and volume |
| `backend/src/config/queue.ts` | #363 | Named priority enum, testnet worker + job configs, helper functions |
| `src/proxy/lib.rs` | #403 | 9 new upgradeability tests in `#[cfg(test)]` module |
| `src/event_hub/lib.rs` | #404 | 10 new unit tests in `#[cfg(test)]` module |

## Test plan

- [ ] `cd backend && npx prisma validate` — schema passes validation
- [ ] `docker compose up postgres -d` — postgres starts healthy
- [ ] `STELLAR_NETWORK=testnet` — `getEffectiveJobOptions` returns testnet configs; `getEffectiveWorkerOptions` returns testnet worker options
- [ ] `STELLAR_NETWORK=mainnet` (or unset) — mainnet defaults are returned
- [ ] `cargo test -p proxy` — all proxy tests pass
- [ ] `cargo test -p event_hub` — all event hub tests pass

Closes #359
Closes #363
Closes #403
Closes #404