### PR TITLE
feat(dashboard): SEP-24 withdrawal form, interactive webview, transaction history table, and status badges

### DIFF
--- a/dashboard/src/components/InteractiveWebview.tsx
+++ b/dashboard/src/components/InteractiveWebview.tsx
@@ -1,0 +1,255 @@
+import { useState } from 'react';
+import { ShieldCheck, ExternalLink, Lock, AlertTriangle, CheckCircle2, X } from 'lucide-react';
+import { motion, AnimatePresence } from 'framer-motion';
+
+type WebviewState = 'idle' | 'loading' | 'active' | 'approved' | 'rejected';
+
+interface InteractiveWebviewProps {
+  /** The anchor brand name shown in the security header */
+  anchorName: string;
+  /** The SEP-24 interactive URL that would be loaded in production */
+  interactiveUrl?: string;
+  /** Called when the user approves/completes the webview flow */
+  onComplete: () => void;
+  /** Called when the user dismisses/rejects the webview flow */
+  onDismiss?: () => void;
+  /** Title shown above the webview panel */
+  title?: string;
+}
+
+const SIMULATED_STEPS = [
+  { label: 'Establishing secure channel…', duration: 800 },
+  { label: 'Loading anchor KYC flow…',     duration: 900 },
+  { label: 'Rendering interactive form…',  duration: 700 },
+];
+
+export const InteractiveWebview = ({
+  anchorName,
+  interactiveUrl,
+  onComplete,
+  onDismiss,
+  title = 'Anchor Interactive Flow',
+}: InteractiveWebviewProps) => {
+  const [webviewState, setWebviewState] = useState<WebviewState>('idle');
+  const [loadStep, setLoadStep] = useState(0);
+  const [simulatedField, setSimulatedField] = useState('');
+
+  const handleLaunch = () => {
+    setWebviewState('loading');
+    setLoadStep(0);
+
+    SIMULATED_STEPS.forEach((step, i) => {
+      const delay = SIMULATED_STEPS.slice(0, i).reduce((acc, s) => acc + s.duration, 0);
+      setTimeout(() => setLoadStep(i + 1), delay + step.duration);
+    });
+
+    const total = SIMULATED_STEPS.reduce((acc, s) => acc + s.duration, 0);
+    setTimeout(() => setWebviewState('active'), total);
+  };
+
+  const handleApprove = () => {
+    setWebviewState('approved');
+    setTimeout(() => onComplete(), 1200);
+  };
+
+  const handleReject = () => {
+    setWebviewState('rejected');
+    onDismiss?.();
+  };
+
+  return (
+    <div className="space-y-3">
+      {/* Security header */}
+      <div className="flex items-center gap-2 rounded-lg border border-emerald-500/20 bg-emerald-500/5 px-4 py-2.5">
+        <Lock size={13} className="text-emerald-400 shrink-0" aria-hidden="true" />
+        <p className="text-xs text-emerald-300">
+          Secure SEP-24 session — content served by {anchorName}
+        </p>
+        {interactiveUrl && (
+          <a
+            href={interactiveUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="ml-auto text-xs text-emerald-400 hover:underline inline-flex items-center gap-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/50 rounded"
+            aria-label={`Open ${anchorName} interactive flow in a new tab`}
+          >
+            Open in tab <ExternalLink size={11} aria-hidden="true" />
+          </a>
+        )}
+      </div>
+
+      {/* Webview panel */}
+      <div
+        className="relative aspect-video rounded-xl border border-slate-700 bg-slate-950 overflow-hidden"
+        role="region"
+        aria-label={`${title} interactive panel`}
+        aria-live="polite"
+        aria-busy={webviewState === 'loading'}
+      >
+        <AnimatePresence mode="wait">
+
+          {/* Idle state */}
+          {webviewState === 'idle' && (
+            <motion.div
+              key="idle"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              className="absolute inset-0 flex flex-col items-center justify-center gap-4 p-6 text-center"
+            >
+              <div className="flex h-16 w-16 items-center justify-center rounded-full bg-primary/10">
+                <ShieldCheck size={32} className="text-primary" aria-hidden="true" />
+              </div>
+              <div>
+                <p className="font-medium text-slate-200">{anchorName} Secure Portal</p>
+                <p className="mt-1 text-sm text-slate-500">
+                  Complete your identity verification through the anchor's interactive flow.
+                </p>
+              </div>
+              <button
+                onClick={handleLaunch}
+                className="btn-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
+                aria-label={`Launch ${anchorName} KYC portal`}
+              >
+                Launch KYC Portal
+              </button>
+            </motion.div>
+          )}
+
+          {/* Loading state */}
+          {webviewState === 'loading' && (
+            <motion.div
+              key="loading"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              className="absolute inset-0 flex flex-col items-center justify-center gap-5 p-6"
+            >
+              <div className="h-10 w-10 animate-spin rounded-full border-4 border-slate-700 border-t-primary" aria-hidden="true" />
+              <div className="space-y-2 text-center">
+                {SIMULATED_STEPS.map((step, i) => (
+                  <p
+                    key={step.label}
+                    className={`text-sm transition-colors ${
+                      i < loadStep ? 'text-emerald-400' : i === loadStep ? 'text-slate-300' : 'text-slate-600'
+                    }`}
+                  >
+                    {i < loadStep ? '✓ ' : ''}{step.label}
+                  </p>
+                ))}
+              </div>
+            </motion.div>
+          )}
+
+          {/* Active / form state */}
+          {webviewState === 'active' && (
+            <motion.div
+              key="active"
+              initial={{ opacity: 0, y: 8 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0 }}
+              className="absolute inset-0 flex flex-col"
+            >
+              {/* Simulated browser chrome */}
+              <div className="flex items-center gap-2 border-b border-slate-800 bg-slate-900 px-4 py-2">
+                <div className="flex gap-1.5" aria-hidden="true">
+                  <span className="h-2.5 w-2.5 rounded-full bg-rose-500/60" />
+                  <span className="h-2.5 w-2.5 rounded-full bg-amber-500/60" />
+                  <span className="h-2.5 w-2.5 rounded-full bg-emerald-500/60" />
+                </div>
+                <div className="flex flex-1 items-center gap-2 rounded bg-slate-800 px-3 py-1">
+                  <Lock size={10} className="text-emerald-400 shrink-0" aria-hidden="true" />
+                  <span className="text-xs text-slate-400 truncate">
+                    {interactiveUrl ?? `https://kyc.${anchorName.toLowerCase().replace(/\s+/g, '')}.example/sep24`}
+                  </span>
+                </div>
+              </div>
+
+              {/* Simulated KYC form content */}
+              <div className="flex flex-1 flex-col items-center justify-center gap-4 p-6">
+                <p className="text-sm font-semibold text-slate-200">{anchorName} — Identity Verification</p>
+                <div className="w-full max-w-xs space-y-3">
+                  <div>
+                    <label htmlFor="webview-fullname" className="mb-1 block text-xs text-slate-400">
+                      Full Name
+                    </label>
+                    <input
+                      id="webview-fullname"
+                      type="text"
+                      placeholder="Jane Doe"
+                      value={simulatedField}
+                      onChange={(e) => setSimulatedField(e.target.value)}
+                      className="input-field w-full text-sm"
+                    />
+                  </div>
+                  <div className="flex items-center gap-2 rounded-lg border border-amber-500/20 bg-amber-500/5 px-3 py-2">
+                    <AlertTriangle size={12} className="text-amber-400 shrink-0" aria-hidden="true" />
+                    <p className="text-[11px] text-amber-300">
+                      Demo mode — no real data is collected.
+                    </p>
+                  </div>
+                </div>
+                <div className="flex gap-3">
+                  <button
+                    onClick={handleReject}
+                    className="flex items-center gap-1.5 rounded-lg border border-slate-700 px-4 py-2 text-sm text-slate-400 transition-all hover:border-rose-500/40 hover:text-rose-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-500/50"
+                    aria-label="Cancel KYC verification"
+                  >
+                    <X size={14} aria-hidden="true" /> Cancel
+                  </button>
+                  <button
+                    onClick={handleApprove}
+                    className="btn-primary text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
+                    aria-label="Submit KYC and continue"
+                  >
+                    Submit &amp; Continue
+                  </button>
+                </div>
+              </div>
+            </motion.div>
+          )}
+
+          {/* Approved state */}
+          {webviewState === 'approved' && (
+            <motion.div
+              key="approved"
+              initial={{ opacity: 0, scale: 0.95 }}
+              animate={{ opacity: 1, scale: 1 }}
+              className="absolute inset-0 flex flex-col items-center justify-center gap-3 p-6 text-center"
+            >
+              <div className="flex h-16 w-16 items-center justify-center rounded-full bg-emerald-500/10">
+                <CheckCircle2 size={36} className="text-emerald-400" aria-hidden="true" />
+              </div>
+              <p className="font-medium text-emerald-300">Verification Approved</p>
+              <p className="text-sm text-slate-500">Continuing to next step…</p>
+            </motion.div>
+          )}
+
+          {/* Rejected state */}
+          {webviewState === 'rejected' && (
+            <motion.div
+              key="rejected"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              className="absolute inset-0 flex flex-col items-center justify-center gap-3 p-6 text-center"
+            >
+              <div className="flex h-16 w-16 items-center justify-center rounded-full bg-rose-500/10">
+                <X size={36} className="text-rose-400" aria-hidden="true" />
+              </div>
+              <p className="font-medium text-rose-300">Verification Cancelled</p>
+              <button
+                onClick={() => setWebviewState('idle')}
+                className="text-sm text-primary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 rounded"
+              >
+                Try again
+              </button>
+            </motion.div>
+          )}
+
+        </AnimatePresence>
+      </div>
+    </div>
+  );
+};
+
+export default InteractiveWebview;

--- a/dashboard/src/components/SEP24Flow.tsx
+++ b/dashboard/src/components/SEP24Flow.tsx
@@ -1,25 +1,41 @@
 import { useState } from 'react';
-import { ArrowUpRight, ShieldCheck, CheckCircle2 } from 'lucide-react';
+import { ArrowUpRight, CheckCircle2 } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { RequirementList } from './RequirementList';
+import { WithdrawalForm } from './WithdrawalForm';
+import { InteractiveWebview } from './InteractiveWebview';
 import type { UiConfig } from '../types';
 
 const STEP_LABELS = [
   'Select Asset',
+  'Fill Details',
   'Identity Verification',
   'Transaction Complete',
 ] as const;
+
+// Deposit keeps a 3-step flow; withdrawal adds a form step (step 2).
+const DEPOSIT_STEPS = [1, 3, 4] as const;
+const WITHDRAW_STEPS = [1, 2, 3, 4] as const;
 
 export const SEP24Flow = ({ type, uiConfig }: { type: 'deposit' | 'withdraw'; uiConfig: UiConfig }) => {
   const [step, setStep] = useState(1);
   const transactionFields = uiConfig.fieldRequirements[type];
   const flowLabel = type === 'deposit' ? 'Deposit' : 'Withdrawal';
 
+  // For display, map logical step to the label index
+  const isWithdraw = type === 'withdraw';
+  const visibleSteps = isWithdraw ? WITHDRAW_STEPS : DEPOSIT_STEPS;
+  const totalSteps = visibleSteps.length;
+  const currentStepIndex = visibleSteps.indexOf(step as never);
+  const displayStep = currentStepIndex + 1;
+
+  const goToStep = (s: number) => setStep(s);
+
   return (
     <div className="mx-auto max-w-4xl glass-card p-6 sm:p-8">
       {/* Live region announces step changes to screen readers */}
       <div aria-live="polite" aria-atomic="true" className="sr-only">
-        {`Step ${step} of 3: ${STEP_LABELS[step - 1]}`}
+        {`Step ${displayStep} of ${totalSteps}: ${STEP_LABELS[step - 1]}`}
       </div>
 
       {/* Step indicator */}
@@ -28,7 +44,7 @@ export const SEP24Flow = ({ type, uiConfig }: { type: 'deposit' | 'withdraw'; ui
         aria-label={`${flowLabel} progress`}
       >
         <ol className="flex w-full justify-between list-none p-0 m-0">
-          {([1, 2, 3] as const).map((s) => (
+          {visibleSteps.map((s, idx) => (
             <li key={s} className="flex items-center">
               <div
                 className={`flex h-10 w-10 items-center justify-center rounded-full font-bold transition-all ${
@@ -36,16 +52,16 @@ export const SEP24Flow = ({ type, uiConfig }: { type: 'deposit' | 'withdraw'; ui
                     ? 'bg-primary text-primary-foreground shadow-lg shadow-primary/20'
                     : 'bg-slate-800 text-slate-500'
                 }`}
-                aria-label={`Step ${s} of 3: ${STEP_LABELS[s - 1]}${
+                aria-label={`Step ${idx + 1} of ${totalSteps}: ${STEP_LABELS[s - 1]}${
                   step === s ? ' (current)' : step > s ? ' (completed)' : ''
                 }`}
                 aria-current={step === s ? 'step' : undefined}
               >
-                <span aria-hidden="true">{s}</span>
+                <span aria-hidden="true">{idx + 1}</span>
               </div>
-              {s < 3 && (
+              {idx < totalSteps - 1 && (
                 <div
-                  className={`mx-2 h-1 w-20 rounded bg-slate-800 transition-colors ${step > s ? 'bg-primary' : ''}`}
+                  className={`mx-2 h-1 w-16 rounded bg-slate-800 transition-colors ${step > s ? 'bg-primary' : ''}`}
                   aria-hidden="true"
                 />
               )}
@@ -55,6 +71,8 @@ export const SEP24Flow = ({ type, uiConfig }: { type: 'deposit' | 'withdraw'; ui
       </nav>
 
       <AnimatePresence mode="wait">
+
+        {/* Step 1 — Asset selection (both deposit and withdrawal) */}
         {step === 1 && (
           <motion.div
             key="step-select-asset"
@@ -77,7 +95,7 @@ export const SEP24Flow = ({ type, uiConfig }: { type: 'deposit' | 'withdraw'; ui
                   <button
                     key={asset}
                     role="listitem"
-                    onClick={() => setStep(2)}
+                    onClick={() => goToStep(isWithdraw ? 2 : 3)}
                     aria-label={`Select ${asset} for ${flowLabel.toLowerCase()}`}
                     className="flex items-center justify-between rounded-xl border border-slate-700 bg-slate-900 p-4 transition-all hover:border-primary/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
                   >
@@ -103,7 +121,40 @@ export const SEP24Flow = ({ type, uiConfig }: { type: 'deposit' | 'withdraw'; ui
           </motion.div>
         )}
 
-        {step === 2 && (
+        {/* Step 2 — Withdrawal details form (withdrawal only) */}
+        {step === 2 && isWithdraw && (
+          <motion.div
+            key="step-withdrawal-form"
+            initial={{ opacity: 0, x: 20 }}
+            animate={{ opacity: 1, x: 0 }}
+            exit={{ opacity: 0, x: -20 }}
+            className="grid gap-6 lg:grid-cols-[1.2fr_0.8fr]"
+          >
+            <div className="space-y-4">
+              <h2 className="font-display text-2xl font-bold">Withdrawal Details</h2>
+              <p className="text-slate-400">
+                All fields are validated before proceeding. Required fields are marked accordingly.
+              </p>
+              <WithdrawalForm
+                fields={transactionFields}
+                onSubmit={() => goToStep(3)}
+              />
+              <button
+                onClick={() => goToStep(1)}
+                className="text-sm text-slate-500 hover:text-slate-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 rounded"
+              >
+                ← Back to asset selection
+              </button>
+            </div>
+            <RequirementList
+              title="Withdrawal Requirements"
+              fields={transactionFields}
+            />
+          </motion.div>
+        )}
+
+        {/* Step 3 — Identity Verification (KYC interactive webview) */}
+        {step === 3 && (
           <motion.div
             key="step-kyc"
             initial={{ opacity: 0, x: 20 }}
@@ -114,29 +165,21 @@ export const SEP24Flow = ({ type, uiConfig }: { type: 'deposit' | 'withdraw'; ui
             <div className="space-y-4">
               <h2 className="font-display text-2xl font-bold">Identity Verification</h2>
               <p className="text-slate-400">
-                KYC requirements are also backend-driven, so each anchor can tighten or relax the form without redeploying the dashboard.
+                KYC requirements are backend-driven, so each anchor can tighten or relax the form without redeploying the dashboard.
               </p>
-              <div className="aspect-video rounded-xl border border-dashed border-slate-700 bg-slate-900 p-6 text-center">
-                <div className="flex h-full flex-col items-center justify-center">
-                  <ShieldCheck size={48} className="mb-4 text-primary" aria-hidden="true" />
-                  <p className="font-medium text-slate-300">{uiConfig.brandName} Secure KYC</p>
-                  <p className="mt-2 text-sm text-slate-500">Placeholder for SEP-12 interactive webview</p>
-                  <button
-                    onClick={() => setStep(3)}
-                    className="btn-primary mt-6 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
-                    aria-label="Launch KYC verification portal"
-                  >
-                    Launch KYC Portal
-                  </button>
-                </div>
-              </div>
+              <InteractiveWebview
+                anchorName={uiConfig.brandName}
+                onComplete={() => goToStep(4)}
+                onDismiss={() => goToStep(isWithdraw ? 2 : 1)}
+                title="SEP-24 KYC Webview"
+              />
             </div>
-
             <RequirementList title="KYC Requirements" fields={uiConfig.fieldRequirements.kyc} />
           </motion.div>
         )}
 
-        {step === 3 && (
+        {/* Step 4 — Transaction complete */}
+        {step === 4 && (
           <motion.div
             key="step-complete"
             initial={{ opacity: 0, scale: 0.95 }}
@@ -156,13 +199,14 @@ export const SEP24Flow = ({ type, uiConfig }: { type: 'deposit' | 'withdraw'; ui
               rules pulled from the backend.
             </p>
             <button
-              onClick={() => setStep(1)}
+              onClick={() => goToStep(1)}
               className="font-medium text-primary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
             >
               Back to Dashboard
             </button>
           </motion.div>
         )}
+
       </AnimatePresence>
     </div>
   );

--- a/dashboard/src/components/TransactionHistory.tsx
+++ b/dashboard/src/components/TransactionHistory.tsx
@@ -1,63 +1,251 @@
-import { ArrowDownLeft, ArrowUpRight } from 'lucide-react';
+import { useState, useMemo, useCallback } from 'react';
+import { ArrowDownLeft, ArrowUpRight, ChevronUp, ChevronDown, ChevronsUpDown, Search, ChevronLeft, ChevronRight } from 'lucide-react';
+import { TransactionStatusBadge } from './TransactionStatusBadge';
+import type { TransactionStatus } from './TransactionStatusBadge';
 
-const TRANSACTIONS = [
-  { type: 'Deposit', asset: 'USDC', amount: '500.00', status: 'Completed', date: '2024-03-15' },
-  { type: 'Withdrawal', asset: 'USDC', amount: '120.50', status: 'Pending', date: '2024-03-16' },
-  { type: 'Deposit', asset: 'USDC', amount: '1,000.00', status: 'Processing', date: '2024-03-16' },
-] as const;
+type TransactionType = 'Deposit' | 'Withdrawal';
+type SortKey = 'type' | 'asset' | 'amount' | 'status' | 'date';
+type SortDir = 'asc' | 'desc';
 
-const STATUS_CLASSES = {
-  Completed: 'bg-emerald-500/10 text-emerald-400',
-  Pending: 'bg-amber-500/10 text-amber-400',
-  Processing: 'bg-blue-500/10 text-blue-400',
-} as const;
+interface Transaction {
+  id: string;
+  type: TransactionType;
+  asset: string;
+  amount: number;
+  status: TransactionStatus;
+  date: string;
+  reference: string;
+}
 
-export const TransactionHistory = () => (
-  <div className="glass-card overflow-x-auto">
-    <table className="w-full text-left" aria-label="Transaction history">
-      <caption className="sr-only">
-        Transaction history showing type, asset, amount, status, and date for recent transactions
-      </caption>
-      <thead>
-        <tr className="border-b border-slate-800 text-sm text-slate-400">
-          <th scope="col" className="p-4 font-medium">Type</th>
-          <th scope="col" className="p-4 font-medium">Asset</th>
-          <th scope="col" className="p-4 font-medium">Amount</th>
-          <th scope="col" className="p-4 font-medium">Status</th>
-          <th scope="col" className="p-4 font-medium">Date</th>
-        </tr>
-      </thead>
-      <tbody className="divide-y divide-slate-800">
-        {TRANSACTIONS.map((tx) => (
-          <tr
-            key={`${tx.type}-${tx.amount}-${tx.date}`}
-            className="transition-colors hover:bg-slate-900/50"
+const ALL_TRANSACTIONS: Transaction[] = [
+  { id: 'tx-001', type: 'Deposit',    asset: 'USDC', amount: 500.00,    status: 'Completed',  date: '2024-03-15', reference: 'REF-A1B2' },
+  { id: 'tx-002', type: 'Withdrawal', asset: 'USDC', amount: 120.50,    status: 'Pending',     date: '2024-03-16', reference: 'REF-C3D4' },
+  { id: 'tx-003', type: 'Deposit',    asset: 'USDC', amount: 1000.00,   status: 'Processing',  date: '2024-03-16', reference: 'REF-E5F6' },
+  { id: 'tx-004', type: 'Withdrawal', asset: 'EURT', amount: 250.75,    status: 'Completed',   date: '2024-03-17', reference: 'REF-G7H8' },
+  { id: 'tx-005', type: 'Deposit',    asset: 'ARST', amount: 5000.00,   status: 'Failed',      date: '2024-03-17', reference: 'REF-I9J0' },
+  { id: 'tx-006', type: 'Withdrawal', asset: 'USDC', amount: 75.00,     status: 'Cancelled',   date: '2024-03-18', reference: 'REF-K1L2' },
+  { id: 'tx-007', type: 'Deposit',    asset: 'EURT', amount: 3200.00,   status: 'Completed',   date: '2024-03-18', reference: 'REF-M3N4' },
+  { id: 'tx-008', type: 'Withdrawal', asset: 'ARST', amount: 800.00,    status: 'Processing',  date: '2024-03-19', reference: 'REF-O5P6' },
+  { id: 'tx-009', type: 'Deposit',    asset: 'USDC', amount: 10000.00,  status: 'Pending',     date: '2024-03-19', reference: 'REF-Q7R8' },
+  { id: 'tx-010', type: 'Withdrawal', asset: 'USDC', amount: 450.25,    status: 'Completed',   date: '2024-03-20', reference: 'REF-S9T0' },
+  { id: 'tx-011', type: 'Deposit',    asset: 'EURT', amount: 600.00,    status: 'Completed',   date: '2024-03-20', reference: 'REF-U1V2' },
+  { id: 'tx-012', type: 'Withdrawal', asset: 'USDC', amount: 1500.00,   status: 'Failed',      date: '2024-03-21', reference: 'REF-W3X4' },
+];
+
+const PAGE_SIZE_OPTIONS = [5, 10, 20] as const;
+
+const fmtAmount = (n: number) =>
+  n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+
+const SortIcon = ({ col, sortKey, dir }: { col: SortKey; sortKey: SortKey; dir: SortDir }) => {
+  if (col !== sortKey) return <ChevronsUpDown size={13} className="text-slate-600" aria-hidden="true" />;
+  return dir === 'asc'
+    ? <ChevronUp size={13} className="text-primary" aria-hidden="true" />
+    : <ChevronDown size={13} className="text-primary" aria-hidden="true" />;
+};
+
+export const TransactionHistory = () => {
+  const [query, setQuery] = useState('');
+  const [statusFilter, setStatusFilter] = useState<TransactionStatus | 'All'>('All');
+  const [sortKey, setSortKey] = useState<SortKey>('date');
+  const [sortDir, setSortDir] = useState<SortDir>('desc');
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState<(typeof PAGE_SIZE_OPTIONS)[number]>(5);
+
+  const handleSort = useCallback((key: SortKey) => {
+    setSortDir((prev) => (sortKey === key ? (prev === 'asc' ? 'desc' : 'asc') : 'asc'));
+    setSortKey(key);
+    setPage(1);
+  }, [sortKey]);
+
+  const filtered = useMemo(() => {
+    const q = query.toLowerCase();
+    return ALL_TRANSACTIONS.filter((tx) => {
+      const matchesQuery =
+        !q ||
+        tx.type.toLowerCase().includes(q) ||
+        tx.asset.toLowerCase().includes(q) ||
+        tx.reference.toLowerCase().includes(q) ||
+        tx.status.toLowerCase().includes(q);
+      const matchesStatus = statusFilter === 'All' || tx.status === statusFilter;
+      return matchesQuery && matchesStatus;
+    });
+  }, [query, statusFilter]);
+
+  const sorted = useMemo(() => {
+    return [...filtered].sort((a, b) => {
+      let cmp = 0;
+      if (sortKey === 'amount') {
+        cmp = a.amount - b.amount;
+      } else {
+        cmp = a[sortKey].localeCompare(b[sortKey]);
+      }
+      return sortDir === 'asc' ? cmp : -cmp;
+    });
+  }, [filtered, sortKey, sortDir]);
+
+  const totalPages = Math.max(1, Math.ceil(sorted.length / pageSize));
+  const safePage = Math.min(page, totalPages);
+  const paginated = sorted.slice((safePage - 1) * pageSize, safePage * pageSize);
+
+  const HEADERS: { key: SortKey; label: string }[] = [
+    { key: 'type',   label: 'Type'      },
+    { key: 'asset',  label: 'Asset'     },
+    { key: 'amount', label: 'Amount'    },
+    { key: 'status', label: 'Status'    },
+    { key: 'date',   label: 'Date'      },
+  ];
+
+  const statusOptions: Array<TransactionStatus | 'All'> = [
+    'All', 'Completed', 'Pending', 'Processing', 'Failed', 'Cancelled',
+  ];
+
+  return (
+    <div className="space-y-4">
+      {/* Toolbar */}
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="relative flex-1 max-w-sm">
+          <Search size={15} className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-slate-500" aria-hidden="true" />
+          <input
+            type="search"
+            placeholder="Search by type, asset, reference…"
+            value={query}
+            onChange={(e) => { setQuery(e.target.value); setPage(1); }}
+            aria-label="Search transactions"
+            className="input-field w-full pl-9 text-sm"
+          />
+        </div>
+
+        <div className="flex items-center gap-2">
+          <label htmlFor="status-filter" className="sr-only">Filter by status</label>
+          <select
+            id="status-filter"
+            value={statusFilter}
+            onChange={(e) => { setStatusFilter(e.target.value as TransactionStatus | 'All'); setPage(1); }}
+            className="input-field text-sm"
           >
-            <td className="flex items-center gap-2 p-4">
-              {tx.type === 'Deposit' ? (
-                <ArrowDownLeft size={16} className="text-emerald-400" aria-hidden="true" />
-              ) : (
-                <ArrowUpRight size={16} className="text-rose-400" aria-hidden="true" />
-              )}
-              {tx.type}
-            </td>
-            <td className="p-4">{tx.asset}</td>
-            <td className="p-4 font-mono">${tx.amount}</td>
-            <td className="p-4">
-              <span
-                className={`rounded-full px-2 py-1 text-[10px] font-bold uppercase tracking-wider ${STATUS_CLASSES[tx.status]}`}
-              >
-                {tx.status}
-              </span>
-            </td>
-            <td className="p-4 text-sm text-slate-400">
-              <time dateTime={tx.date}>{tx.date}</time>
-            </td>
-          </tr>
-        ))}
-      </tbody>
-    </table>
-  </div>
-);
+            {statusOptions.map((s) => (
+              <option key={s} value={s}>{s === 'All' ? 'All Statuses' : s}</option>
+            ))}
+          </select>
+
+          <label htmlFor="page-size" className="sr-only">Rows per page</label>
+          <select
+            id="page-size"
+            value={pageSize}
+            onChange={(e) => { setPageSize(Number(e.target.value) as typeof pageSize); setPage(1); }}
+            className="input-field text-sm"
+          >
+            {PAGE_SIZE_OPTIONS.map((n) => (
+              <option key={n} value={n}>{n} / page</option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {/* Table */}
+      <div className="glass-card overflow-x-auto">
+        <table className="w-full text-left" aria-label="Transaction history">
+          <caption className="sr-only">
+            Transaction history — {sorted.length} result{sorted.length !== 1 ? 's' : ''}
+          </caption>
+          <thead>
+            <tr className="border-b border-slate-800 text-sm text-slate-400">
+              {HEADERS.map(({ key, label }) => (
+                <th key={key} scope="col" className="p-4 font-medium">
+                  <button
+                    onClick={() => handleSort(key)}
+                    className="inline-flex items-center gap-1 hover:text-slate-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 rounded"
+                    aria-label={`Sort by ${label}${sortKey === key ? `, currently ${sortDir}ending` : ''}`}
+                  >
+                    {label}
+                    <SortIcon col={key} sortKey={sortKey} dir={sortDir} />
+                  </button>
+                </th>
+              ))}
+              <th scope="col" className="p-4 font-medium text-slate-400">Reference</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-800">
+            {paginated.length === 0 ? (
+              <tr>
+                <td colSpan={6} className="p-8 text-center text-slate-500">
+                  No transactions match your filters.
+                </td>
+              </tr>
+            ) : (
+              paginated.map((tx) => (
+                <tr
+                  key={tx.id}
+                  className="transition-colors hover:bg-slate-900/50"
+                >
+                  <td className="flex items-center gap-2 p-4">
+                    {tx.type === 'Deposit' ? (
+                      <ArrowDownLeft size={16} className="text-emerald-400" aria-hidden="true" />
+                    ) : (
+                      <ArrowUpRight size={16} className="text-rose-400" aria-hidden="true" />
+                    )}
+                    {tx.type}
+                  </td>
+                  <td className="p-4">{tx.asset}</td>
+                  <td className="p-4 font-mono">${fmtAmount(tx.amount)}</td>
+                  <td className="p-4">
+                    <TransactionStatusBadge status={tx.status} />
+                  </td>
+                  <td className="p-4 text-sm text-slate-400">
+                    <time dateTime={tx.date}>{tx.date}</time>
+                  </td>
+                  <td className="p-4 font-mono text-xs text-slate-500">{tx.reference}</td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Pagination */}
+      <div className="flex items-center justify-between text-sm text-slate-400">
+        <span aria-live="polite" aria-atomic="true">
+          {sorted.length === 0
+            ? 'No results'
+            : `Showing ${(safePage - 1) * pageSize + 1}–${Math.min(safePage * pageSize, sorted.length)} of ${sorted.length}`}
+        </span>
+        <div className="flex items-center gap-1" role="navigation" aria-label="Pagination">
+          <button
+            onClick={() => setPage((p) => Math.max(1, p - 1))}
+            disabled={safePage === 1}
+            aria-label="Previous page"
+            className="rounded p-1.5 hover:bg-slate-800 disabled:opacity-30 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
+          >
+            <ChevronLeft size={16} aria-hidden="true" />
+          </button>
+          {Array.from({ length: totalPages }, (_, i) => i + 1).map((p) => (
+            <button
+              key={p}
+              onClick={() => setPage(p)}
+              aria-label={`Page ${p}`}
+              aria-current={p === safePage ? 'page' : undefined}
+              className={`min-w-[2rem] rounded px-2 py-1 text-xs font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 ${
+                p === safePage
+                  ? 'bg-primary text-primary-foreground'
+                  : 'hover:bg-slate-800'
+              }`}
+            >
+              {p}
+            </button>
+          ))}
+          <button
+            onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+            disabled={safePage === totalPages}
+            aria-label="Next page"
+            className="rounded p-1.5 hover:bg-slate-800 disabled:opacity-30 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
+          >
+            <ChevronRight size={16} aria-hidden="true" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
 
 export default TransactionHistory;

--- a/dashboard/src/components/TransactionStatusBadge.tsx
+++ b/dashboard/src/components/TransactionStatusBadge.tsx
@@ -1,0 +1,74 @@
+import type { FC } from 'react';
+import { CheckCircle2, Clock, Loader2, XCircle, Ban } from 'lucide-react';
+
+export type TransactionStatus = 'Completed' | 'Pending' | 'Processing' | 'Failed' | 'Cancelled';
+
+interface StatusConfig {
+  label: string;
+  className: string;
+  Icon: typeof CheckCircle2;
+}
+
+const STATUS_CONFIG: Record<TransactionStatus, StatusConfig> = {
+  Completed: {
+    label: 'Completed',
+    className: 'bg-emerald-500/10 text-emerald-400 border-emerald-500/20',
+    Icon: CheckCircle2,
+  },
+  Pending: {
+    label: 'Pending',
+    className: 'bg-amber-500/10 text-amber-400 border-amber-500/20',
+    Icon: Clock,
+  },
+  Processing: {
+    label: 'Processing',
+    className: 'bg-blue-500/10 text-blue-400 border-blue-500/20',
+    Icon: Loader2,
+  },
+  Failed: {
+    label: 'Failed',
+    className: 'bg-rose-500/10 text-rose-400 border-rose-500/20',
+    Icon: XCircle,
+  },
+  Cancelled: {
+    label: 'Cancelled',
+    className: 'bg-slate-500/10 text-slate-400 border-slate-500/20',
+    Icon: Ban,
+  },
+};
+
+interface TransactionStatusBadgeProps {
+  status: TransactionStatus;
+  /** Show icon alongside label (default: true) */
+  showIcon?: boolean;
+  /** Additional CSS classes */
+  className?: string;
+}
+
+export const TransactionStatusBadge: FC<TransactionStatusBadgeProps> = ({
+  status,
+  showIcon = true,
+  className = '',
+}) => {
+  const config = STATUS_CONFIG[status];
+  const { Icon } = config;
+
+  return (
+    <span
+      role="status"
+      aria-label={`Transaction status: ${config.label}`}
+      className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-[10px] font-bold uppercase tracking-wider ${config.className} ${className}`}
+    >
+      {showIcon && (
+        <Icon
+          size={11}
+          aria-hidden="true"
+          className={status === 'Processing' ? 'animate-spin' : ''}
+        />
+      )}
+      {config.label}
+    </span>
+  );
+};
+
+export default TransactionStatusBadge;

--- a/dashboard/src/components/WithdrawalForm.tsx
+++ b/dashboard/src/components/WithdrawalForm.tsx
@@ -1,0 +1,227 @@
+import { useState, useId } from 'react';
+import type { FormEvent } from 'react';
+import { AlertCircle, CheckCircle2 } from 'lucide-react';
+import type { FieldRequirement } from '../types';
+
+interface FormValues {
+  [key: string]: string;
+}
+
+interface FieldError {
+  [key: string]: string;
+}
+
+interface WithdrawalFormProps {
+  /** Field definitions driven by the backend UiConfig */
+  fields: FieldRequirement[];
+  /** Called with validated form values when the user submits */
+  onSubmit: (values: FormValues) => void;
+}
+
+const AMOUNT_PATTERN = /^\d+(\.\d{1,2})?$/;
+const BANK_ACCOUNT_PATTERN = /^\d{6,20}$/;
+const WALLET_PATTERN = /^G[A-Z0-9]{55}$/;
+
+const getFieldType = (key: string): React.HTMLInputTypeAttribute => {
+  if (key.toLowerCase().includes('amount')) return 'number';
+  if (key.toLowerCase().includes('email')) return 'email';
+  return 'text';
+};
+
+const validateField = (field: FieldRequirement, value: string): string => {
+  const trimmed = value.trim();
+
+  if (field.required && !trimmed) {
+    return `${field.label} is required.`;
+  }
+
+  if (!trimmed) return '';
+
+  const key = field.key.toLowerCase();
+
+  if (key.includes('amount')) {
+    if (!AMOUNT_PATTERN.test(trimmed)) {
+      return 'Enter a valid amount (e.g. 120.50).';
+    }
+    const num = parseFloat(trimmed);
+    if (num <= 0) return 'Amount must be greater than zero.';
+    if (num > 1_000_000) return 'Amount exceeds the maximum single-transaction limit.';
+  }
+
+  if (key.includes('bankaccount') || key.includes('bank_account') || key.includes('account')) {
+    if (!BANK_ACCOUNT_PATTERN.test(trimmed)) {
+      return 'Bank account must be 6–20 digits.';
+    }
+  }
+
+  if (key.includes('wallet') || key.includes('address')) {
+    if (!WALLET_PATTERN.test(trimmed)) {
+      return 'Enter a valid Stellar wallet address starting with G.';
+    }
+  }
+
+  return '';
+};
+
+const validateAll = (fields: FieldRequirement[], values: FormValues): FieldError => {
+  const errors: FieldError = {};
+  for (const field of fields) {
+    const err = validateField(field, values[field.key] ?? '');
+    if (err) errors[field.key] = err;
+  }
+  return errors;
+};
+
+export const WithdrawalForm = ({ fields, onSubmit }: WithdrawalFormProps) => {
+  const formId = useId();
+  const [values, setValues] = useState<FormValues>(() =>
+    Object.fromEntries(fields.map((f) => [f.key, ''])),
+  );
+  const [errors, setErrors] = useState<FieldError>({});
+  const [touched, setTouched] = useState<Record<string, boolean>>({});
+  const [submitted, setSubmitted] = useState(false);
+
+  const handleChange = (key: string, value: string) => {
+    setValues((prev) => ({ ...prev, [key]: value }));
+    if (touched[key]) {
+      const field = fields.find((f) => f.key === key)!;
+      const err = validateField(field, value);
+      setErrors((prev) => ({ ...prev, [key]: err }));
+    }
+  };
+
+  const handleBlur = (key: string) => {
+    setTouched((prev) => ({ ...prev, [key]: true }));
+    const field = fields.find((f) => f.key === key)!;
+    const err = validateField(field, values[key] ?? '');
+    setErrors((prev) => ({ ...prev, [key]: err }));
+  };
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    setSubmitted(true);
+    const allTouched = Object.fromEntries(fields.map((f) => [f.key, true]));
+    setTouched(allTouched);
+
+    const allErrors = validateAll(fields, values);
+    setErrors(allErrors);
+
+    if (Object.keys(allErrors).length === 0) {
+      onSubmit(values);
+    }
+  };
+
+  const hasErrors = Object.values(errors).some(Boolean);
+  const errorCount = Object.values(errors).filter(Boolean).length;
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      noValidate
+      aria-label="Withdrawal form"
+      className="space-y-5"
+    >
+      {/* Summary error alert shown after first submit attempt */}
+      {submitted && hasErrors && (
+        <div
+          role="alert"
+          aria-live="assertive"
+          className="flex items-start gap-3 rounded-lg border border-rose-500/30 bg-rose-500/10 px-4 py-3"
+        >
+          <AlertCircle size={16} className="mt-0.5 shrink-0 text-rose-400" aria-hidden="true" />
+          <p className="text-sm text-rose-300">
+            Please fix {errorCount} error{errorCount !== 1 ? 's' : ''} before continuing.
+          </p>
+        </div>
+      )}
+
+      {fields.map((field) => {
+        const inputId = `${formId}-${field.key}`;
+        const errorId = `${formId}-${field.key}-error`;
+        const hintId = field.helpText ? `${formId}-${field.key}-hint` : undefined;
+        const err = errors[field.key];
+        const isInvalid = touched[field.key] && Boolean(err);
+
+        return (
+          <div key={field.key} className="space-y-1.5">
+            <label
+              htmlFor={inputId}
+              className="flex items-center gap-2 text-sm font-medium text-slate-300"
+            >
+              {field.label}
+              {field.required ? (
+                <span className="text-xs font-normal text-amber-400" aria-hidden="true">
+                  Required
+                </span>
+              ) : (
+                <span className="text-xs font-normal text-slate-500" aria-hidden="true">
+                  Optional
+                </span>
+              )}
+            </label>
+
+            {field.helpText && (
+              <p id={hintId} className="text-xs text-slate-500">
+                {field.helpText}
+              </p>
+            )}
+
+            <div className="relative">
+              <input
+                id={inputId}
+                type={getFieldType(field.key)}
+                value={values[field.key] ?? ''}
+                onChange={(e) => handleChange(field.key, e.target.value)}
+                onBlur={() => handleBlur(field.key)}
+                placeholder={field.placeholder}
+                required={field.required}
+                aria-required={field.required}
+                aria-invalid={isInvalid}
+                aria-describedby={
+                  [errorId, hintId].filter(Boolean).join(' ') || undefined
+                }
+                className={`input-field w-full pr-9 text-sm transition-all ${
+                  isInvalid
+                    ? 'border-rose-500/60 focus:ring-rose-500/40'
+                    : touched[field.key] && !err
+                    ? 'border-emerald-500/40 focus:ring-emerald-500/30'
+                    : ''
+                }`}
+              />
+              {touched[field.key] && !err && values[field.key] && (
+                <CheckCircle2
+                  size={15}
+                  className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-emerald-400"
+                  aria-hidden="true"
+                />
+              )}
+              {isInvalid && (
+                <AlertCircle
+                  size={15}
+                  className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-rose-400"
+                  aria-hidden="true"
+                />
+              )}
+            </div>
+
+            {isInvalid && (
+              <p id={errorId} role="alert" className="flex items-center gap-1.5 text-xs text-rose-400">
+                <AlertCircle size={11} aria-hidden="true" />
+                {err}
+              </p>
+            )}
+          </div>
+        );
+      })}
+
+      <button
+        type="submit"
+        className="btn-primary w-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
+      >
+        Continue to Verification
+      </button>
+    </form>
+  );
+};
+
+export default WithdrawalForm;


### PR DESCRIPTION
## Summary

- **#336** — `WithdrawalForm.tsx`: backend-driven withdrawal form with real-time field validation (amount limits, bank account pattern, Stellar wallet regex), per-field inline errors, submit-time error summary, and full ARIA accessibility
- **#337** — `InteractiveWebview.tsx`: SEP-24 KYC webview simulation with a five-state machine (idle → loading → active → approved/rejected), framer-motion animated transitions, simulated browser chrome, and a security header; `SEP24Flow.tsx` updated to integrate both new components and support a 4-step withdrawal flow vs a 3-step deposit flow
- **#338** — `TransactionHistory.tsx`: full interactive data table with sortable columns, free-text search, status filter, configurable pagination (5/10/20 rows), and accessible live region result count — replaces the previous 3-row static stub
- **#339** — `TransactionStatusBadge.tsx`: reusable status badge covering Completed, Pending, Processing, Failed, and Cancelled with colour-coded dark-mode tokens, paired Lucide icons (Processing spins), `role="status"` and descriptive aria-label

## Files changed

| File | Change |
|---|---|
| `dashboard/src/components/WithdrawalForm.tsx` | New — #336 |
| `dashboard/src/components/InteractiveWebview.tsx` | New — #337 |
| `dashboard/src/components/TransactionStatusBadge.tsx` | New — #339 |
| `dashboard/src/components/SEP24Flow.tsx` | Modified — integrates #336 & #337, adds 4-step withdrawal flow |
| `dashboard/src/components/TransactionHistory.tsx` | Modified — full data table rewrite for #338, uses #339 |

## Test plan

- [ ] Navigate to **Withdraw** tab → select an asset → verify form fields render with Required/Optional labels
- [ ] Submit the withdrawal form with empty required fields → confirm error summary and per-field messages appear
- [ ] Enter an invalid amount (e.g. `0`, `-5`, `abc`) → confirm field-level validation message
- [ ] Enter a valid bank account and amount → confirm green checkmarks appear and form advances to step 3
- [ ] On step 3, click **Launch KYC Portal** → watch loading steps animate → interact with simulated form → click **Submit & Continue** → confirm step 4 success screen
- [ ] Click **Cancel** in the webview → confirm rejection state and "Try again" link resets to idle
- [ ] Navigate to **History** tab → verify 12 transactions render across pages
- [ ] Click column headers to sort asc/desc; verify arrow icons update correctly
- [ ] Type in the search box to filter by asset/type/reference; verify live count updates
- [ ] Change the status filter dropdown; verify only matching rows show
- [ ] Change page size and paginate; verify "Showing X–Y of Z" label is accurate
- [ ] Inspect status badges — Completed (emerald), Pending (amber), Processing (blue + spin), Failed (rose), Cancelled (slate)

Closes #336
Closes #337
Closes #338
Closes #339