### PR TITLE
chore(security): document trufflehog audit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# AnchorPoint local Docker Compose configuration
+
+POSTGRES_USER=anchorpoint
+POSTGRES_PASSWORD=replace-with-a-strong-local-password
+POSTGRES_DB=anchorpoint

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,9 +7,9 @@ services:
     ports:
       - "5432:5432"
     environment:
-      - POSTGRES_USER=anchorpoint
-      - POSTGRES_PASSWORD=anchorpoint
-      - POSTGRES_DB=anchorpoint
+      - POSTGRES_USER=${POSTGRES_USER:-anchorpoint}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in your local environment or .env file}
+      - POSTGRES_DB=${POSTGRES_DB:-anchorpoint}
     volumes:
       - postgres-data:/var/lib/postgresql/data
     healthcheck:
@@ -33,7 +33,7 @@ services:
     environment:
       - NODE_ENV=production
       - PORT=3002
-      - DATABASE_URL=postgresql://anchorpoint:anchorpoint@postgres:5432/anchorpoint
+      - DATABASE_URL=postgresql://${POSTGRES_USER:-anchorpoint}:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in your local environment or .env file}@postgres:5432/${POSTGRES_DB:-anchorpoint}
       - REDIS_URL=redis://redis:6379
       - JAEGER_ENDPOINT=http://jaeger:14268/api/traces
       - PROMETHEUS_METRICS_PORT=9464

--- a/docs/security/trufflehog-audit-2026-05-31.md
+++ b/docs/security/trufflehog-audit-2026-05-31.md
@@ -1,0 +1,36 @@
+# TruffleHog Secret Scan Audit - 2026-05-31
+
+## Scope
+
+- Repository: `AnchorPoint`
+- Issue: `#438` - Review codebase for exposed secrets (TruffleHog)
+- Tool: TruffleHog `3.95.3`
+- Scans:
+  - `trufflehog filesystem --json --no-update .`
+  - `trufflehog git --json --no-update file:///Users/DONALD/Desktop/Prosper%20space/AnchorPoint`
+
+## Initial Findings
+
+- Current filesystem scan verified secrets: `0`
+- Current filesystem scan unverified findings before remediation: `1`
+- Git history scan verified secrets: `0`
+- Git history scan unverified findings: `1`
+- Detector: `Postgres`
+- Location: `docker-compose.yml`
+
+The finding was a hardcoded local PostgreSQL credential embedded in the Docker Compose database URL. It was not verified as a live secret, but it still trained deployments toward committed credentials.
+
+## Remediation
+
+- Replaced hardcoded Docker Compose database credentials with environment variable interpolation.
+- Added a root `.env.example` with non-secret placeholders for local Compose setup.
+- Kept real `.env` files ignored by Git.
+
+## Validation
+
+After remediation:
+
+- `trufflehog filesystem --json --no-update .` reported `0` verified and `0` unverified findings in the current working tree.
+- `trufflehog git --json --no-update file:///Users/DONALD/Desktop/Prosper%20space/AnchorPoint` reported `0` verified findings and retained `1` unverified historical Postgres finding from commit `c9221b3808e38dee54559fec266c5bdf7f19453a`.
+
+No history rewrite was performed because the historical finding is an unverified local-development credential, not a verified live secret.


### PR DESCRIPTION
Summary
This PR addresses issue #438 by reviewing the codebase for exposed secrets with TruffleHog and removing a hardcoded local PostgreSQL credential from docker-compose.yml.

What changed

Replaced hardcoded POSTGRES_* values in [docker-compose.yml](/C:/Users/DONALD/Desktop/Prosper space/AnchorPoint/docker-compose.yml) with environment-driven values
Added a root [.env.example](/C:/Users/DONALD/Desktop/Prosper space/AnchorPoint/.env.example) for safe local Compose setup
Added a TruffleHog audit report at [docs/security/trufflehog-audit-2026-05-31.md](/C:/Users/DONALD/Desktop/Prosper space/AnchorPoint/docs/security/trufflehog-audit-2026-05-31.md)
Validation

TruffleHog filesystem scan: 0 verified, 0 unverified findings
TruffleHog git-history scan: 0 verified findings, 1 historical unverified local-dev Postgres finding remains from an older commit
Notes

No history rewrite was performed because the remaining finding is an unverified local-development credential, not a verified live secret.

Closes #438