### PR TITLE
feat: add automated Soroban security audit for Wasm builds

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,14 @@ jobs:
         with:
           targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-scout-audit@0.3.16
+      - name: Install Scout system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libssl-dev pkg-config gcc
       - name: Test sep41-token
         run: cargo test -p sep41-token
       - name: Test upgradeable
         run: cargo test -p upgradeable
+      - name: Run Security Audit
+        run: ./scripts/security-audit.sh

--- a/docs/security-audit.md
+++ b/docs/security-audit.md
@@ -1,0 +1,60 @@
+# Soroban Security Audit
+
+Automated security checks for AnchorPoint Soroban contracts run on every Rust CI build.
+
+## What runs
+
+The [`scripts/security-audit.sh`](../scripts/security-audit.sh) script performs:
+
+1. **Wasm build** — `cargo build --target wasm32-unknown-unknown --release` for the root and `contracts/` workspaces.
+2. **Scout static analysis** — [CoinFabrik Scout](https://coinfabrik.github.io/scout-soroban/docs/intro) (`cargo scout-audit`) scans Rust sources for Soroban security detectors.
+3. **Wasm artifact checks** — Validates `.wasm` magic headers and optionally runs `soroban-analyzer` when that binary is available in `PATH`.
+4. **Source pattern review** — Warns on `unsafe` blocks, `env.panic`, and unprotected `update_current_contract_wasm` references.
+
+## Local usage
+
+Install Scout:
+
+```bash
+cargo install cargo-scout-audit
+```
+
+On Linux CI hosts, Scout may also require:
+
+```bash
+sudo apt-get install -y libssl-dev pkg-config gcc
+```
+
+Run the audit from the repository root:
+
+```bash
+./scripts/security-audit.sh
+```
+
+Skip the build step if Wasm artifacts are already present:
+
+```bash
+./scripts/security-audit.sh --skip-build
+```
+
+Treat warnings as non-fatal (Scout failures still fail the run):
+
+```bash
+./scripts/security-audit.sh --warn-only
+```
+
+## CI integration
+
+The [Rust Contracts workflow](../.github/workflows/rust.yml) runs this script after contract tests. A failing audit blocks the workflow.
+
+## Manual QA checklist
+
+1. Install `cargo-scout-audit` locally.
+2. Run `./scripts/security-audit.sh` from the repo root.
+3. Confirm Scout output lists analyzed crates and completes without critical findings.
+4. Open `target/wasm32-unknown-unknown/release/*.wasm` paths printed by the script and verify files exist after a successful build.
+5. Push a branch and confirm the **Run Security Audit** step passes in GitHub Actions.
+
+## Optional: soroban-analyzer
+
+The issue references tools *like* `soroban-analyzer`. If you install a compatible Wasm analyzer binary named `soroban-analyzer`, the script will invoke it on each discovered artifact automatically. Scout remains the primary static analyzer for Rust sources.

--- a/scripts/security-audit.sh
+++ b/scripts/security-audit.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Soroban Security Audit - Issue #274
+# =============================================================================
+# Scans Soroban contract workspaces for security issues:
+#   1. Builds release Wasm artifacts (wasm32-unknown-unknown)
+#   2. Runs Scout static analysis (cargo scout-audit)
+#   3. Audits built .wasm files (optional soroban-analyzer + header checks)
+#   4. Flags suspicious Rust source patterns
+#
+# Usage:
+#   ./scripts/security-audit.sh [--skip-build] [--warn-only]
+#
+# Environment:
+#   SECURITY_AUDIT_SKIP_BUILD=1   Skip wasm build step
+#   SECURITY_AUDIT_WARN_ONLY=1    Never fail on warnings (scout failures still fail)
+# =============================================================================
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WASM_TARGET="wasm32-unknown-unknown"
+SKIP_BUILD=0
+WARN_ONLY=0
+ISSUES=0
+
+if [[ "${1:-}" == "--skip-build" ]]; then
+  SKIP_BUILD=1
+fi
+if [[ "${1:-}" == "--warn-only" ]] || [[ "${2:-}" == "--warn-only" ]]; then
+  WARN_ONLY=1
+fi
+if [[ "${SECURITY_AUDIT_SKIP_BUILD:-}" == "1" ]]; then
+  SKIP_BUILD=1
+fi
+if [[ "${SECURITY_AUDIT_WARN_ONLY:-}" == "1" ]]; then
+  WARN_ONLY=1
+fi
+
+log() { printf '[security-audit] %s\n' "$*"; }
+warn() { printf '[security-audit][WARN] %s\n' "$*" >&2; }
+fail() { printf '[security-audit][ERROR] %s\n' "$*" >&2; ISSUES=$((ISSUES + 1)); }
+
+record_issue() {
+  if [[ "$WARN_ONLY" -eq 1 ]]; then
+    warn "$1"
+  else
+    fail "$1"
+  fi
+}
+
+build_workspace_wasm() {
+  local workspace_dir="$1"
+  local label="$2"
+
+  log "Building release Wasm for ${label}..."
+  if ! (
+    cd "$workspace_dir"
+    cargo build --target "$WASM_TARGET" --release 2>&1
+  ); then
+    record_issue "Wasm build failed for ${label}. Scout analysis may be incomplete."
+    return 1
+  fi
+  return 0
+}
+
+run_scout_audit() {
+  local workspace_dir="$1"
+  local label="$2"
+
+  if ! command -v cargo >/dev/null 2>&1; then
+    record_issue "cargo is required for Scout analysis."
+    return 1
+  fi
+
+  if ! cargo scout-audit --help >/dev/null 2>&1; then
+    record_issue "cargo-scout-audit is not installed. Run: cargo install cargo-scout-audit"
+    return 1
+  fi
+
+  log "Running Scout static analysis on ${label}..."
+  if (
+    cd "$workspace_dir"
+    cargo scout-audit --output-format text
+  ); then
+    log "Scout analysis passed for ${label}."
+    return 0
+  fi
+
+  record_issue "Scout reported security findings in ${label}."
+  return 1
+}
+
+validate_wasm_magic() {
+  local wasm_file="$1"
+  local magic
+  magic="$(dd if="$wasm_file" bs=4 count=1 2>/dev/null | od -An -tx1 | tr -d ' \n')"
+
+  if [[ "$magic" != "0061736d" ]]; then
+    record_issue "Invalid Wasm magic header in ${wasm_file}"
+    return 1
+  fi
+  return 0
+}
+
+scan_wasm_artifacts() {
+  local search_root="$1"
+  local wasm_found=0
+  local analyzed=0
+
+  log "Scanning Wasm artifacts under ${search_root}..."
+
+  while IFS= read -r -d '' wasm_file; do
+    wasm_found=1
+    log "Found Wasm: ${wasm_file}"
+    validate_wasm_magic "$wasm_file" || true
+
+    if command -v soroban-analyzer >/dev/null 2>&1; then
+      log "Running soroban-analyzer on ${wasm_file}..."
+      if soroban-analyzer "$wasm_file"; then
+        analyzed=$((analyzed + 1))
+      else
+        record_issue "soroban-analyzer reported issues for ${wasm_file}"
+      fi
+    fi
+  done < <(find "$search_root" -path '*/target/*' -name '*.wasm' -type f -print0 2>/dev/null)
+
+  if [[ "$wasm_found" -eq 0 ]]; then
+    warn "No Wasm artifacts found under ${search_root}. Build contracts before auditing."
+    return 1
+  fi
+
+  if [[ "$analyzed" -eq 0 ]] && ! command -v soroban-analyzer >/dev/null 2>&1; then
+    log "soroban-analyzer not installed; Wasm header validation completed."
+  fi
+
+  return 0
+}
+
+scan_source_patterns() {
+  local dirs=("$@")
+
+  log "Checking Soroban source patterns..."
+
+  for dir in "${dirs[@]}"; do
+    [[ -d "$dir" ]] || continue
+
+    if grep -RIn --exclude-dir=target --exclude='*.md' 'unsafe[[:space:]]*{' "$dir" >/dev/null 2>&1; then
+      record_issue "'unsafe' blocks found under ${dir}. Review for memory-safety risks."
+    fi
+
+    if grep -RIn --exclude-dir=target --exclude='*.md' 'env\.panic' "$dir" >/dev/null 2>&1; then
+      warn "'env.panic' usage found under ${dir}. Review panic paths and denial-of-service risk."
+    fi
+
+    if grep -RIn --exclude-dir=target --exclude='*.md' 'update_current_contract_wasm' "$dir" >/dev/null 2>&1; then
+      warn "'update_current_contract_wasm' references found under ${dir}. Ensure upgrade paths are access-controlled."
+    fi
+  done
+}
+
+main() {
+  log "Starting Soroban security audit..."
+
+  if [[ "$SKIP_BUILD" -eq 0 ]]; then
+    build_workspace_wasm "$ROOT_DIR" "root workspace" || true
+    build_workspace_wasm "$ROOT_DIR/contracts" "contracts workspace" || true
+  else
+    log "Skipping Wasm build (--skip-build)."
+  fi
+
+  run_scout_audit "$ROOT_DIR" "root workspace" || true
+  run_scout_audit "$ROOT_DIR/contracts" "contracts workspace" || true
+
+  scan_wasm_artifacts "$ROOT_DIR" || true
+  scan_source_patterns "$ROOT_DIR/src" "$ROOT_DIR/contracts"
+
+  if [[ "$ISSUES" -gt 0 ]]; then
+    printf '[security-audit][ERROR] Security audit finished with %s issue(s).\n' "$ISSUES" >&2
+    exit 1
+  fi
+
+  log "Security audit completed successfully."
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
Adds an automated security audit script that runs on every Rust CI build to scan Soroban contracts for vulnerabilities and suspicious patterns.

## Purpose / Motivation
Resolves [#274](https://github.com/ceejaylaboratory/AnchorPoint/issues/274). The backend and contract repos need a repeatable security gate before testnet deployment. This centralizes Wasm builds, static analysis, and source-pattern checks in CI.

## Changes Made
- Added `scripts/security-audit.sh`:
  - Builds release Wasm for root and `contracts/` workspaces
  - Runs [Scout](https://coinfabrik.github.io/scout-soroban/docs/intro) (`cargo scout-audit`) for Soroban static analysis
  - Validates `.wasm` magic headers and optionally invokes `soroban-analyzer` when available
  - Warns on `unsafe`, `env.panic`, and unprotected `update_current_contract_wasm` usage
- Integrated the script into `.github/workflows/rust.yml` after contract tests
- Documented setup and manual QA in `docs/security-audit.md`

## How to Test
1. Install Scout locally: `cargo install cargo-scout-audit`
2. From repo root: `./scripts/security-audit.sh`
3. Confirm Wasm build, Scout output, and audit completion
4. Push this branch and verify the **Run Security Audit** job in GitHub Actions

## Breaking Changes
- None. CI gains a new security audit step after existing contract tests.

## Related Issues
Closes ceejaylaboratory/AnchorPoint#274

## Checklist
- [x] Code builds successfully
- [x] Tests added/updated (audit script + docs)
- [x] Documentation updated