### PR TITLE
feat: resolve prisma connection leak, add sep-10 multi-sig tests, and dashboard transaction filters

### DIFF
--- a/backend/src/lib/prisma.ts
+++ b/backend/src/lib/prisma.ts
@@ -7,7 +7,16 @@ if (!process.env.DATABASE_URL) {
 import { PrismaClient } from '@prisma/client';
 import { metricsService } from '../services/metrics.service';
 
-const prisma = new PrismaClient();
+declare global {
+  // eslint-disable-next-line no-var
+  var __prisma: PrismaClient | undefined;
+}
+
+const prisma = global.__prisma ?? new PrismaClient();
+
+if (process.env.NODE_ENV !== 'production') {
+  global.__prisma = prisma;
+}
 
 type PrismaMiddlewareParams = {
   model?: string;

--- a/backend/src/test/sep10-multisig.test.ts
+++ b/backend/src/test/sep10-multisig.test.ts
@@ -1,0 +1,244 @@
+import request from 'supertest';
+import express, { Request, Response } from 'express';
+import { getChallenge, getToken } from '../api/controllers/auth.controller';
+import { RedisService, RedisClient } from '../services/redis.service';
+
+jest.mock('../api/middleware/rate-limit.middleware', () => ({
+  publicLimiter: (_req: any, _res: any, next: any) => next(),
+  authLimiter: (_req: any, _res: any, next: any) => next(),
+}));
+
+jest.mock('../utils/tracing', () => ({
+  traceAsync: (_name: string, fn: (span: any) => any) => fn({ setAttribute: jest.fn() }),
+  traceSync: (_name: string, fn: (span: any) => any) => fn({ setAttribute: jest.fn() }),
+  SpanKind: { INTERNAL: 0, CLIENT: 1 },
+}));
+
+jest.mock('../services/metrics.service', () => ({
+  metricsService: { observeDbQuery: jest.fn() },
+}));
+
+const store = new Map<string, string>();
+
+const inMemoryRedisClient: RedisClient = {
+  get: async (key: string) => store.get(key) ?? null,
+  set: async (key: string, value: string) => { store.set(key, value); return 'OK'; },
+  del: async (key: string) => { store.delete(key); return 1; },
+  expire: async () => 1,
+};
+
+const redisService = new RedisService(inMemoryRedisClient);
+
+const app = express();
+app.use(express.json());
+app.post('/auth', (req: Request, res: Response) => getChallenge(req, res, redisService));
+app.post('/auth/token', (req: Request, res: Response) => getToken(req, res, redisService));
+
+beforeEach(() => store.clear());
+
+describe('SEP-10 Multi-Signature Integration Tests', () => {
+  const ANCHOR_PUBLIC_KEY = 'GBAD_PUBLIC_KEY';
+  const CLIENT_PUBLIC_KEY = 'GCLIENT1XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
+
+  const SIGNERS = [
+    { publicKey: 'GSIGNER1XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', weight: 2, signed: false },
+    { publicKey: 'GSIGNER2XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', weight: 1, signed: false },
+  ];
+
+  describe('POST /auth — multi-key challenge generation', () => {
+    it('returns a challenge transaction and network passphrase', async () => {
+      const res = await request(app)
+        .post('/auth')
+        .send({ account: CLIENT_PUBLIC_KEY });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveProperty('transaction');
+      expect(res.body).toHaveProperty('network_passphrase');
+      expect(typeof res.body.transaction).toBe('string');
+      expect(res.body.transaction.length).toBeGreaterThan(0);
+    });
+
+    it('returns 400 when account is missing', async () => {
+      const res = await request(app).post('/auth').send({});
+      expect(res.status).toBe(400);
+      expect(res.body).toHaveProperty('error');
+    });
+
+    it('returns multiKeyChallenge when multiKey flag and signers are provided', async () => {
+      const res = await request(app)
+        .post('/auth')
+        .send({ account: CLIENT_PUBLIC_KEY, multiKey: true, signers: SIGNERS, threshold: 'medium' });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveProperty('multiKeyChallenge');
+      const mkc = res.body.multiKeyChallenge;
+      expect(mkc.threshold).toBe('medium');
+      expect(mkc.signers).toHaveLength(2);
+      expect(mkc.requiredSigners).toBeGreaterThan(0);
+    });
+
+    it('does not return multiKeyChallenge when multiKey is false', async () => {
+      const res = await request(app)
+        .post('/auth')
+        .send({ account: CLIENT_PUBLIC_KEY, multiKey: false });
+
+      expect(res.status).toBe(200);
+      expect(res.body.multiKeyChallenge).toBeUndefined();
+    });
+
+    it('stores the challenge in redis for subsequent token validation', async () => {
+      await request(app).post('/auth').send({ account: CLIENT_PUBLIC_KEY });
+      const key = `sep10:challenge:${CLIENT_PUBLIC_KEY}`;
+      expect(store.has(key)).toBe(true);
+    });
+  });
+
+  describe('POST /auth/token — multi-signature token validation', () => {
+    const SIGNER_A = 'GSIGNER1XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
+    const SIGNER_B = 'GSIGNER2XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
+
+    async function seedChallenge(publicKey: string, challengeValue: string) {
+      const key = `sep10:challenge:${publicKey}`;
+      store.set(key, JSON.stringify({
+        challenge: challengeValue,
+        publicKey,
+        createdAt: Date.now(),
+      }));
+    }
+
+    it('returns a JWT for multi-sig request meeting the medium threshold', async () => {
+      const challenge = 'test-challenge-abc123';
+      await seedChallenge(SIGNER_A, challenge);
+
+      const res = await request(app)
+        .post('/auth/token')
+        .send({
+          transaction: challenge,
+          threshold: 'medium',
+          signatures: [
+            { publicKey: SIGNER_A, signature: 'sig-a', weight: 2 },
+          ],
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveProperty('token');
+      expect(res.body.type).toBe('bearer');
+      expect(res.body.authLevel).toBe('full');
+      expect(res.body.signers).toContain(SIGNER_A);
+    });
+
+    it('returns a JWT with partial auth level when weight meets low but not high threshold', async () => {
+      const challenge = 'test-challenge-low';
+      await seedChallenge(SIGNER_A, challenge);
+
+      const res = await request(app)
+        .post('/auth/token')
+        .send({
+          transaction: challenge,
+          threshold: 'low',
+          signatures: [
+            { publicKey: SIGNER_A, signature: 'sig-a', weight: 1 },
+          ],
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveProperty('token');
+      expect(res.body.authLevel).toBe('partial');
+    });
+
+    it('returns a JWT listing all signers when multiple keys sign', async () => {
+      const challenge = 'test-challenge-multisig';
+      await seedChallenge(SIGNER_A, challenge);
+
+      const res = await request(app)
+        .post('/auth/token')
+        .send({
+          transaction: challenge,
+          threshold: 'medium',
+          signatures: [
+            { publicKey: SIGNER_A, signature: 'sig-a', weight: 1 },
+            { publicKey: SIGNER_B, signature: 'sig-b', weight: 1 },
+          ],
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body.signers).toContain(SIGNER_A);
+      expect(res.body.signers).toContain(SIGNER_B);
+    });
+
+    it('returns 400 when cumulative signature weight is below threshold', async () => {
+      const challenge = 'test-challenge-low-weight';
+      await seedChallenge(SIGNER_A, challenge);
+
+      const res = await request(app)
+        .post('/auth/token')
+        .send({
+          transaction: challenge,
+          threshold: 'high',
+          signatures: [
+            { publicKey: SIGNER_A, signature: 'sig-a', weight: 1 },
+          ],
+        });
+
+      expect(res.status).toBe(400);
+      expect(res.body).toHaveProperty('error');
+    });
+
+    it('returns 400 when the challenge does not match the stored value', async () => {
+      await seedChallenge(SIGNER_A, 'stored-challenge');
+
+      const res = await request(app)
+        .post('/auth/token')
+        .send({
+          transaction: 'wrong-challenge',
+          threshold: 'medium',
+          signatures: [
+            { publicKey: SIGNER_A, signature: 'sig-a', weight: 2 },
+          ],
+        });
+
+      expect(res.status).toBe(400);
+      expect(res.body).toHaveProperty('error');
+    });
+
+    it('returns 400 when no stored challenge exists for the signer', async () => {
+      const res = await request(app)
+        .post('/auth/token')
+        .send({
+          transaction: 'any-challenge',
+          threshold: 'medium',
+          signatures: [
+            { publicKey: 'GUNKNOWN', signature: 'sig', weight: 2 },
+          ],
+        });
+
+      expect(res.status).toBe(400);
+      expect(res.body).toHaveProperty('error');
+    });
+
+    it('removes the challenge from redis after successful token issue (replay prevention)', async () => {
+      const challenge = 'test-challenge-replay';
+      await seedChallenge(SIGNER_A, challenge);
+
+      await request(app)
+        .post('/auth/token')
+        .send({
+          transaction: challenge,
+          threshold: 'medium',
+          signatures: [{ publicKey: SIGNER_A, signature: 'sig-a', weight: 2 }],
+        });
+
+      const key = `sep10:challenge:${SIGNER_A}`;
+      expect(store.has(key)).toBe(false);
+    });
+
+    it('returns 400 when transaction field is missing', async () => {
+      const res = await request(app)
+        .post('/auth/token')
+        .send({ signatures: [{ publicKey: SIGNER_A, signature: 'sig', weight: 2 }] });
+
+      expect(res.status).toBe(400);
+      expect(res.body).toHaveProperty('error');
+    });
+  });
+});

--- a/dashboard/src/components/TransactionHistory.tsx
+++ b/dashboard/src/components/TransactionHistory.tsx
@@ -70,6 +70,7 @@ export const TransactionHistory = () => {
     return ALL_TRANSACTIONS.filter((tx) => {
       const matchesQuery =
         !q ||
+        tx.id.toLowerCase().includes(q) ||
         tx.type.toLowerCase().includes(q) ||
         tx.asset.toLowerCase().includes(q) ||
         tx.reference.toLowerCase().includes(q) ||
@@ -115,7 +116,7 @@ export const TransactionHistory = () => {
           <Search size={15} className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-slate-500" aria-hidden="true" />
           <input
             type="search"
-            placeholder="Search by type, asset, reference…"
+            placeholder="Search by ID, type, asset, reference…"
             value={query}
             onChange={(e) => { setQuery(e.target.value); setPage(1); }}
             aria-label="Search transactions"

--- a/dashboard/src/components/TransactionHistory.tsx
+++ b/dashboard/src/components/TransactionHistory.tsx
@@ -54,6 +54,8 @@ const SortIcon = ({ col, sortKey, dir }: { col: SortKey; sortKey: SortKey; dir: 
 export const TransactionHistory = () => {
   const [query, setQuery] = useState('');
   const [statusFilter, setStatusFilter] = useState<TransactionStatus | 'All'>('All');
+  const [dateFrom, setDateFrom] = useState('');
+  const [dateTo, setDateTo] = useState('');
   const [sortKey, setSortKey] = useState<SortKey>('date');
   const [sortDir, setSortDir] = useState<SortDir>('desc');
   const [page, setPage] = useState(1);
@@ -76,9 +78,11 @@ export const TransactionHistory = () => {
         tx.reference.toLowerCase().includes(q) ||
         tx.status.toLowerCase().includes(q);
       const matchesStatus = statusFilter === 'All' || tx.status === statusFilter;
-      return matchesQuery && matchesStatus;
+      const matchesFrom = !dateFrom || tx.date >= dateFrom;
+      const matchesTo = !dateTo || tx.date <= dateTo;
+      return matchesQuery && matchesStatus && matchesFrom && matchesTo;
     });
-  }, [query, statusFilter]);
+  }, [query, statusFilter, dateFrom, dateTo]);
 
   const sorted = useMemo(() => {
     return [...filtered].sort((a, b) => {
@@ -124,7 +128,26 @@ export const TransactionHistory = () => {
           />
         </div>
 
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2">
+          <label htmlFor="date-from" className="sr-only">From date</label>
+          <input
+            id="date-from"
+            type="date"
+            value={dateFrom}
+            onChange={(e) => { setDateFrom(e.target.value); setPage(1); }}
+            aria-label="Filter from date"
+            className="input-field text-sm"
+          />
+          <label htmlFor="date-to" className="sr-only">To date</label>
+          <input
+            id="date-to"
+            type="date"
+            value={dateTo}
+            onChange={(e) => { setDateTo(e.target.value); setPage(1); }}
+            aria-label="Filter to date"
+            className="input-field text-sm"
+          />
+
           <label htmlFor="status-filter" className="sr-only">Filter by status</label>
           <select
             id="status-filter"


### PR DESCRIPTION
## Summary

- Fixes Prisma connection leak during hot-reload by using a global singleton
- Adds integration tests for SEP-10 multi-signature authentication flow
- Adds search-by-ID to the transaction history search bar
- Adds date range filters (from/to) to the transaction history view

## Changes

### fix(backend-db) — closes #639
`backend/src/lib/prisma.ts`: Store the `PrismaClient` instance on `global.__prisma` during non-production runs so hot-reload does not create a fresh connection on every module evaluation.

### feat(backend-sep10) — closes #638
`backend/src/test/sep10-multisig.test.ts`: New integration test suite covering the full multi-sig SEP-10 flow via an in-memory Redis mock and `supertest`:
- Challenge generation with and without `multiKey` flag
- Token issuance for single and multiple signers
- Threshold enforcement (low / medium / high weight)
- Replay-attack prevention (challenge removed after token issue)
- Error cases: missing fields, wrong challenge, unknown signer

### feat(dashboard) — closes #592
`dashboard/src/components/TransactionHistory.tsx`: Search now includes `tx.id` so users can look up a specific transaction by its ID. Placeholder text updated to reflect this.

### feat(dashboard) — closes #591
`dashboard/src/components/TransactionHistory.tsx`: Added `dateFrom` and `dateTo` date inputs to the toolbar. Transactions are filtered client-side to only show entries within the selected date range. The existing status filter remains unchanged.

## Test plan

- [ ] Verify `npm run test:backend` picks up `sep10-multisig.test.ts` and all cases pass
- [ ] Start the dashboard (`npm run dev` in `dashboard/`) and confirm the History tab shows date-from / date-to inputs alongside the status filter
- [ ] Confirm searching by a transaction ID (e.g. `tx-001`) returns the expected row
- [ ] Confirm that running the backend in development mode no longer logs socket/connection warnings on file-save reloads

Closes #638
Closes #639
Closes #591
Closes #592