### PR TITLE
chore: add npm audit step to backend CI

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -87,6 +87,9 @@ jobs:
           path: backend/migration-status.md
           retention-days: 7
 
+      - name: Audit dependencies
+        run: npm audit --audit-level=high
+
       - name: Run Lint
         run: npm run lint
 


### PR DESCRIPTION
## Summary
- Adds `npm audit --audit-level=high` step to `.github/workflows/backend.yml`
- CI fails when any high or critical vulnerabilities are found in backend dependencies

Closes #624