### PR TITLE
feat(backend-sep12): [SEP-12] Implement webhook dispatch on KYC status change

### DIFF
--- a/backend/src/api/controllers/sep12.controller.test.ts
+++ b/backend/src/api/controllers/sep12.controller.test.ts
@@ -29,6 +29,10 @@ const providerMock = {
   parseWebhook: jest.fn(),
 };
 
+const webhookServiceMock = {
+  sendKycStatusChanged: jest.fn(),
+};
+
 const cryptoMock = {
   encrypt: jest.fn((v: string) => ({ encryptedData: `${v}:enc`, iv: 'iv1' })),
   decrypt: jest.fn((v: string) => v),
@@ -47,6 +51,11 @@ jest.mock('../../services/kyc-provider.service', () => ({
     REJECTED: 'REJECTED',
   },
   kycProvider: providerMock,
+}));
+
+jest.mock('../../services/webhook.service', () => ({
+  __esModule: true,
+  defaultWebhookService: webhookServiceMock,
 }));
 
 jest.mock('../../services/crypto.service', () => ({
@@ -77,6 +86,12 @@ const makeRes = (): Response => {
 describe('Sep12Controller', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    webhookServiceMock.sendKycStatusChanged.mockResolvedValue({
+      delivered: true,
+      attempts: 1,
+      statusCode: 200,
+      responseBody: 'ok',
+    });
   });
 
   describe('putCustomer', () => {
@@ -272,7 +287,67 @@ describe('Sep12Controller', () => {
     });
   });
 
-  it('updates customer KYC status via webhook providerRef lookup', async () => {
+  it('updates customer KYC status via webhook providerRef lookup and dispatches a partner webhook', async () => {
+    const req = {
+      headers: { 'x-kyc-signature': 'mock-valid-signature' },
+      body: { providerRef: 'mock_abc', status: 'accepted' },
+    } as unknown as Request;
+    const res = makeRes();
+    const existingCustomer = {
+      id: 'k1',
+      userId: 'u1',
+      provider: 'mock',
+      providerRef: 'mock_abc',
+      status: 'PENDING',
+      createdAt: new Date('2026-03-30T10:00:00.000Z'),
+      updatedAt: new Date('2026-03-30T10:00:00.000Z'),
+      user: { publicKey: VALID_ACCOUNT },
+    };
+    const updatedCustomer = {
+      ...existingCustomer,
+      status: 'ACCEPTED',
+      updatedAt: new Date('2026-03-30T10:05:00.000Z'),
+    };
+
+    providerMock.verifyWebhookSignature.mockReturnValue(true);
+    providerMock.parseWebhook.mockReturnValue({
+      providerRef: 'mock_abc',
+      status: 'ACCEPTED',
+    });
+    prismaMock.kycCustomer.findFirst.mockResolvedValue(existingCustomer);
+    prismaMock.kycCustomer.update.mockResolvedValue(updatedCustomer);
+
+    await sep12Controller.handleWebhook(req, res);
+
+    expect(prismaMock.kycCustomer.findFirst).toHaveBeenCalledWith({
+      where: {
+        provider: 'mock',
+        providerRef: 'mock_abc',
+      },
+      include: {
+        user: {
+          select: {
+            publicKey: true,
+          },
+        },
+      },
+    });
+    expect(prismaMock.kycCustomer.update).toHaveBeenCalledWith({
+      where: { id: 'k1' },
+      data: { status: 'ACCEPTED' },
+      include: {
+        user: {
+          select: {
+            publicKey: true,
+          },
+        },
+      },
+    });
+    expect(webhookServiceMock.sendKycStatusChanged).toHaveBeenCalledWith(updatedCustomer, 'PENDING');
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('does not dispatch a partner webhook when provider status is unchanged', async () => {
     const req = {
       headers: { 'x-kyc-signature': 'mock-valid-signature' },
       body: { providerRef: 'mock_abc', status: 'accepted' },
@@ -284,14 +359,21 @@ describe('Sep12Controller', () => {
       providerRef: 'mock_abc',
       status: 'ACCEPTED',
     });
-    prismaMock.kycCustomer.findFirst.mockResolvedValue({ id: 'k1' });
+    prismaMock.kycCustomer.findFirst.mockResolvedValue({
+      id: 'k1',
+      userId: 'u1',
+      provider: 'mock',
+      providerRef: 'mock_abc',
+      status: 'ACCEPTED',
+      createdAt: new Date('2026-03-30T10:00:00.000Z'),
+      updatedAt: new Date('2026-03-30T10:05:00.000Z'),
+      user: { publicKey: VALID_ACCOUNT },
+    });
 
     await sep12Controller.handleWebhook(req, res);
 
-    expect(prismaMock.kycCustomer.update).toHaveBeenCalledWith({
-      where: { id: 'k1' },
-      data: { status: 'ACCEPTED' },
-    });
+    expect(prismaMock.kycCustomer.update).not.toHaveBeenCalled();
+    expect(webhookServiceMock.sendKycStatusChanged).not.toHaveBeenCalled();
     expect(res.status).toHaveBeenCalledWith(200);
   });
 

--- a/backend/src/api/controllers/sep12.controller.ts
+++ b/backend/src/api/controllers/sep12.controller.ts
@@ -3,6 +3,7 @@ import { StrKey } from '@stellar/stellar-sdk';
 import prisma from '../../lib/prisma';
 import { cryptoService } from '../../services/crypto.service';
 import { kycProvider, KycStatus } from '../../services/kyc-provider.service';
+import { defaultWebhookService } from '../../services/webhook.service';
 import { KYCStatus } from '@prisma/client';
 import { AuthRequest } from '../middleware/auth.middleware';
 import logger from '../../utils/logger';
@@ -236,6 +237,13 @@ export class Sep12Controller {
             provider: kycProvider.providerName,
             providerRef: event.providerRef,
           },
+          include: {
+            user: {
+              select: {
+                publicKey: true,
+              },
+            },
+          },
         });
       }
 
@@ -244,14 +252,37 @@ export class Sep12Controller {
           where: { publicKey: event.account },
           include: { kycCustomer: true },
         });
-        targetCustomer = user?.kycCustomer ?? null;
+        targetCustomer = user?.kycCustomer
+          ? { ...user.kycCustomer, user: { publicKey: user.publicKey } }
+          : null;
       }
 
       if (!targetCustomer) return res.status(404).json({ error: 'Customer not found' });
 
-      await prisma.kycCustomer.update({
+      const nextStatus = this.toDbStatus(event.status);
+      const previousStatus = targetCustomer.status;
+
+      if (previousStatus === nextStatus) {
+        return res.status(200).send('OK');
+      }
+
+      const updatedCustomer = await prisma.kycCustomer.update({
         where: { id: targetCustomer.id },
-        data: { status: this.toDbStatus(event.status) },
+        data: { status: nextStatus },
+        include: {
+          user: {
+            select: {
+              publicKey: true,
+            },
+          },
+        },
+      });
+
+      defaultWebhookService.sendKycStatusChanged(updatedCustomer, previousStatus).catch((error) => {
+        logger.error('SEP-12 KYC status updated but webhook delivery failed', {
+          customerId: updatedCustomer.id,
+          error: error instanceof Error ? error.message : String(error),
+        });
       });
 
       res.status(200).send('OK');

--- a/backend/src/services/webhook.service.test.ts
+++ b/backend/src/services/webhook.service.test.ts
@@ -1,9 +1,11 @@
 import {
+  buildKycStatusChangedPayload,
   buildTransactionStatusChangedPayload,
   signWebhookPayload,
   updateTransactionStatusAndNotify,
   verifyWebhookSignature,
   WebhookService,
+  type KycWebhookRecord,
   type TransactionWebhookRecord,
 } from './webhook.service';
 
@@ -16,6 +18,19 @@ const baseTransaction: TransactionWebhookRecord = {
   status: 'COMPLETED',
   externalId: 'ext_123',
   stellarTxId: 'stellar_123',
+  createdAt: new Date('2026-03-30T10:00:00.000Z'),
+  updatedAt: new Date('2026-03-30T10:05:00.000Z'),
+  user: {
+    publicKey: 'GBPUBLICKEY123',
+  },
+};
+
+const baseKycCustomer: KycWebhookRecord = {
+  id: 'kyc_123',
+  userId: 'user_123',
+  provider: 'mock',
+  providerRef: 'mock_123',
+  status: 'ACCEPTED',
   createdAt: new Date('2026-03-30T10:00:00.000Z'),
   updatedAt: new Date('2026-03-30T10:05:00.000Z'),
   user: {
@@ -46,6 +61,26 @@ describe('Webhook Service', () => {
         status: 'COMPLETED',
         externalId: 'ext_123',
         stellarTxId: 'stellar_123',
+        createdAt: '2026-03-30T10:00:00.000Z',
+        updatedAt: '2026-03-30T10:05:00.000Z',
+      },
+    });
+  });
+
+  it('builds a KYC status changed payload with provider identifiers', () => {
+    const payload = buildKycStatusChangedPayload(baseKycCustomer, 'PENDING');
+
+    expect(payload).toEqual({
+      event: 'kyc.status_changed',
+      occurredAt: expect.any(String),
+      previousStatus: 'PENDING',
+      customer: {
+        id: 'kyc_123',
+        userId: 'user_123',
+        account: 'GBPUBLICKEY123',
+        provider: 'mock',
+        providerRef: 'mock_123',
+        status: 'ACCEPTED',
         createdAt: '2026-03-30T10:00:00.000Z',
         updatedAt: '2026-03-30T10:05:00.000Z',
       },
@@ -120,6 +155,55 @@ describe('Webhook Service', () => {
     ).toBe(true);
   });
 
+  it('sends signed KYC status changed webhook events', async () => {
+    const httpClient = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => 'ok',
+    });
+
+    const service = new WebhookService(
+      {
+        url: 'https://example.com/webhooks',
+        secret: 'super-secret',
+        timeoutMs: 1000,
+        maxRetries: 2,
+        retryDelayMs: 50,
+      },
+      {
+        httpClient,
+        sleep: jest.fn(),
+        logger: {
+          info: jest.fn(),
+          warn: jest.fn(),
+          error: jest.fn(),
+        },
+      }
+    );
+
+    const result = await service.sendKycStatusChanged(baseKycCustomer, 'PENDING');
+
+    expect(result).toEqual({
+      delivered: true,
+      attempts: 1,
+      statusCode: 200,
+      responseBody: 'ok',
+    });
+    expect(httpClient).toHaveBeenCalledTimes(1);
+
+    const [, request] = httpClient.mock.calls[0] as [string, { headers: Record<string, string>; body: string }];
+    expect(request.headers['x-anchorpoint-event']).toBe('kyc.status_changed');
+    expect(request.body).toContain('"event":"kyc.status_changed"');
+    expect(
+      verifyWebhookSignature(
+        request.body,
+        'super-secret',
+        request.headers['x-anchorpoint-timestamp'],
+        request.headers['x-anchorpoint-signature']
+      )
+    ).toBe(true);
+  });
+
   it('does not retry permanent client errors', async () => {
     const httpClient = jest.fn().mockResolvedValue({
       ok: false,
@@ -179,6 +263,11 @@ describe('Webhook Service', () => {
     );
 
     await expect(service.sendTransactionStatusChanged(baseTransaction, 'COMPLETED')).resolves.toEqual({
+      delivered: false,
+      attempts: 0,
+      skipped: true,
+    });
+    await expect(service.sendKycStatusChanged(baseKycCustomer, 'ACCEPTED')).resolves.toEqual({
       delivered: false,
       attempts: 0,
       skipped: true,

--- a/backend/src/services/webhook.service.ts
+++ b/backend/src/services/webhook.service.ts
@@ -20,7 +20,19 @@ export interface TransactionWebhookRecord {
   } | null;
 }
 
-// ... (rest of types)
+export interface KycWebhookRecord {
+  id: string;
+  userId: string;
+  provider?: string | null;
+  providerRef?: string | null;
+  status: string;
+  createdAt: Date;
+  updatedAt: Date;
+  user?: {
+    publicKey: string;
+  } | null;
+}
+
 export interface TransactionStatusChangedPayload {
   event: 'transaction.status_changed';
   occurredAt: string;
@@ -39,6 +51,24 @@ export interface TransactionStatusChangedPayload {
     updatedAt: string;
   };
 }
+
+export interface KycStatusChangedPayload {
+  event: 'kyc.status_changed';
+  occurredAt: string;
+  previousStatus: string;
+  customer: {
+    id: string;
+    userId: string;
+    account?: string;
+    provider?: string;
+    providerRef?: string;
+    status: string;
+    createdAt: string;
+    updatedAt: string;
+  };
+}
+
+type WebhookPayload = TransactionStatusChangedPayload | KycStatusChangedPayload;
 
 export interface WebhookConfig {
   url?: string;
@@ -148,6 +178,25 @@ export const buildTransactionStatusChangedPayload = (
   },
 });
 
+export const buildKycStatusChangedPayload = (
+  customer: KycWebhookRecord,
+  previousStatus: string
+): KycStatusChangedPayload => ({
+  event: 'kyc.status_changed',
+  occurredAt: new Date().toISOString(),
+  previousStatus,
+  customer: {
+    id: customer.id,
+    userId: customer.userId,
+    ...(customer.user?.publicKey ? { account: customer.user.publicKey } : {}),
+    ...(customer.provider ? { provider: customer.provider } : {}),
+    ...(customer.providerRef ? { providerRef: customer.providerRef } : {}),
+    status: customer.status,
+    createdAt: customer.createdAt.toISOString(),
+    updatedAt: customer.updatedAt.toISOString(),
+  },
+});
+
 export const signWebhookPayload = (payload: string, secret: string, timestamp: string): string => {
   const digest = createHmac('sha256', secret)
     .update(`${timestamp}.${payload}`)
@@ -235,20 +284,47 @@ export class WebhookService {
     return this.deliver(payload, transaction.id);
   }
 
+  async sendKycStatusChanged(
+    customer: KycWebhookRecord,
+    previousStatus: string
+  ): Promise<WebhookDeliveryResult> {
+    if (customer.status === previousStatus) {
+      return {
+        delivered: false,
+        attempts: 0,
+        skipped: true,
+      };
+    }
+
+    if (!this.isEnabled()) {
+      this.log.info('Skipping KYC webhook delivery because webhook configuration is incomplete', {
+        customerId: customer.id,
+      });
+      return {
+        delivered: false,
+        attempts: 0,
+        skipped: true,
+      };
+    }
+
+    const payload = buildKycStatusChangedPayload(customer, previousStatus);
+    return this.deliver(payload, customer.id);
+  }
+
   private async deliver(
-    payload: TransactionStatusChangedPayload,
-    transactionId: string
+    payload: WebhookPayload,
+    entityId: string
   ): Promise<WebhookDeliveryResult> {
     const config = this.getConfig();
     
     return traceAsync(
       'webhook.deliver',
       async (span) => {
-        span.setAttribute('webhook.transaction_id', transactionId);
+        span.setAttribute('webhook.entity_id', entityId);
         span.setAttribute('webhook.event_type', payload.event);
         span.setAttribute('webhook.url', config.url || 'unknown');
 
-        return this.executeDeliveryLoop(payload, transactionId, config);
+        return this.executeDeliveryLoop(payload, entityId, config);
       },
       SpanKind.CLIENT,
       {
@@ -259,8 +335,8 @@ export class WebhookService {
   }
 
   private async executeDeliveryLoop(
-    payload: TransactionStatusChangedPayload,
-    transactionId: string,
+    payload: WebhookPayload,
+    entityId: string,
     config: WebhookConfig
   ): Promise<WebhookDeliveryResult> {
     const requestBody = JSON.stringify(payload);
@@ -270,7 +346,7 @@ export class WebhookService {
 
     for (let attempt = 1; attempt <= config.maxRetries + 1; attempt += 1) {
       const { result, error, statusCode, responseBody } = await this.performRequestAttempt(
-        payload, requestBody, config, attempt, transactionId
+        payload, requestBody, config, attempt, entityId
       );
 
       if (result) return result;
@@ -292,11 +368,11 @@ export class WebhookService {
   }
 
   private async performRequestAttempt(
-    payload: TransactionStatusChangedPayload,
+    payload: WebhookPayload,
     requestBody: string,
     config: WebhookConfig,
     attempt: number,
-    transactionId: string
+    entityId: string
   ): Promise<{ result?: WebhookDeliveryResult; error?: unknown; statusCode?: number; responseBody?: string }> {
     const timestamp = new Date().toISOString();
     const signature = signWebhookPayload(requestBody, config.secret!, timestamp);
@@ -322,12 +398,12 @@ export class WebhookService {
       const responseBody = await response.text();
 
       if (response.ok) {
-        this.log.info('Webhook delivered successfully', { transactionId, attempts: attempt, statusCode });
+        this.log.info('Webhook delivered successfully', { entityId, attempts: attempt, statusCode });
         return { result: { delivered: true, attempts: attempt, statusCode, responseBody } };
       }
 
       if (!RETRYABLE_STATUS_CODES.has(statusCode) || attempt > config.maxRetries) {
-        this.log.warn('Webhook delivery failed without further retries', { transactionId, attempts: attempt, statusCode });
+        this.log.warn('Webhook delivery failed without further retries', { entityId, attempts: attempt, statusCode });
         return { result: { delivered: false, attempts: attempt, statusCode, responseBody, error: `Webhook responded with status ${statusCode}` } };
       }
 
@@ -336,7 +412,7 @@ export class WebhookService {
       clearTimeout(timeout);
       
       if (attempt > config.maxRetries) {
-        this.log.error('Webhook delivery exhausted retries after request error', { transactionId, attempts: attempt, error: error instanceof Error ? error.message : String(error) });
+        this.log.error('Webhook delivery exhausted retries after request error', { entityId, attempts: attempt, error: error instanceof Error ? error.message : String(error) });
         return { result: { delivered: false, attempts: attempt, error: error instanceof Error ? error.message : 'Unknown webhook error' } };
       }
       
@@ -449,4 +525,3 @@ export const updateTransactionStatusAndNotify = async ({
 };
 
 export default defaultWebhookService;
-

--- a/backend/src/test/sep12.test.ts
+++ b/backend/src/test/sep12.test.ts
@@ -105,12 +105,22 @@ const prismaMock = {
       kycById.set(created.id, created);
       return created;
     }),
-    update: jest.fn(async ({ where, data }: { where: { id: string }; data: Partial<StoredKycCustomer> }) => {
+    update: jest.fn(async ({ where, data, include }: { where: { id: string }; data: Partial<StoredKycCustomer>; include?: { user?: { select: { publicKey: boolean } } } }) => {
       const existing = kycById.get(where.id);
       if (!existing) throw new Error('KycCustomer not found');
       const updated: StoredKycCustomer = { ...existing, ...data };
       kycByUserId.set(updated.userId, updated);
       kycById.set(updated.id, updated);
+
+      if (include?.user) {
+        const user = usersById.get(updated.userId);
+        return {
+          ...updated,
+          updatedAt: new Date(),
+          user: user ? { publicKey: user.publicKey } : null,
+        };
+      }
+
       return updated;
     }),
     findFirst: jest.fn(async ({ where }: { where: { provider?: string; providerRef?: string } }) => {


### PR DESCRIPTION
## Summary

Closes #622.

Dispatches signed outbound webhooks to partner interfaces when a customer’s KYC status changes via the SEP-12 provider callback flow (`POST /sep12/webhook`).

## Changes

- Extend `WebhookService` with `sendKycStatusChanged()` and a `kyc.status_changed` partner payload
- Dispatch partner webhooks from `Sep12Controller.handleWebhook` after a successful status update
- Skip DB updates and partner dispatch when the provider callback does not change status
- Reuse existing webhook delivery behavior: signed POST, retry policy, and `x-anchorpoint-*` headers
- Add unit and integration coverage for payload shape, delivery, skip conditions, and controller dispatch

## Partner webhook payload

```json
{
  "event": "kyc.status_changed",
  "occurredAt": "2026-03-30T10:05:00.000Z",
  "previousStatus": "PENDING",
  "customer": {
    "id": "kyc-1",
    "userId": "user-1",
    "account": "G...",
    "provider": "mock",
    "providerRef": "mock_abc",
    "status": "ACCEPTED",
    "createdAt": "2026-03-30T10:00:00.000Z",
    "updatedAt": "2026-03-30T10:05:00.000Z"
  }
}