### PR TITLE
feat(dashboard-design): [dashboard] create responsive view layout for mobile screens

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -201,14 +201,22 @@ const App = () => {
         } as React.CSSProperties
       }
     >
+      {sidebarOpen && (
+        <button
+          type="button"
+          aria-label="Close navigation menu overlay"
+          className="fixed inset-0 z-40 bg-slate-950/70 backdrop-blur-sm lg:hidden"
+          onClick={() => setSidebarOpen(false)}
+        />
+      )}
       <aside
         data-testid="sidebar"
         id="main-sidebar"
         aria-label="Main navigation"
-        className={`fixed inset-y-0 left-0 z-50 w-64 transform border-r border-slate-600 bg-card transition-transform duration-300 ${sidebarOpen ? 'translate-x-0' : '-translate-x-full'} lg:relative lg:translate-x-0`}
+        className={`fixed inset-y-0 left-0 z-50 w-[min(18rem,calc(100vw-2rem))] transform border-r border-slate-800 bg-card transition-transform duration-300 ${sidebarOpen ? 'translate-x-0' : '-translate-x-full'} lg:relative lg:w-64 lg:translate-x-0`}
       >
-        <div className="p-6">
-          <div className="mb-10 flex items-center gap-3">
+        <div className="p-5 sm:p-6">
+          <div className="mb-8 flex items-center gap-3 sm:mb-10">
             <LogoMark uiConfig={uiConfig} />
             <div className="min-w-0">
               <h1 className="truncate font-display text-xl font-bold tracking-tight">
@@ -225,7 +233,10 @@ const App = () => {
               {menuItems.map((item) => (
                 <li key={item.id}>
                   <button
-                    onClick={() => setActiveTab(item.id)}
+                    onClick={() => {
+                      setActiveTab(item.id);
+                      setSidebarOpen(false);
+                    }}
                     aria-current={activeTab === item.id ? 'page' : undefined}
                     className={`flex w-full items-center gap-3 rounded-lg px-4 py-3 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-text ${
                       activeTab === item.id
@@ -242,7 +253,7 @@ const App = () => {
           </nav>
         </div>
 
-        <div className="absolute bottom-0 w-full border-t border-slate-600 p-6">
+        <div className="absolute bottom-0 w-full border-t border-slate-800 p-5 sm:p-6">
           <div className="flex items-center gap-3">
             <div className="h-8 w-8 rounded-full bg-slate-800" aria-hidden="true" />
             <div className="flex-1 overflow-hidden">
@@ -260,21 +271,21 @@ const App = () => {
       </aside>
 
       <main className="flex min-w-0 flex-1 flex-col">
-        <header className="sticky top-0 z-40 flex h-16 items-center justify-between border-b border-slate-600 bg-background/50 px-4 sm:px-6 lg:px-8 backdrop-blur-md">
+        <header className="sticky top-0 z-30 flex min-h-16 items-center justify-between gap-3 border-b border-slate-800 bg-background/80 px-3 py-3 backdrop-blur-md sm:px-6 lg:px-8">
           <button
             aria-label={sidebarOpen ? 'Close navigation menu' : 'Open navigation menu'}
             aria-expanded={sidebarOpen}
             aria-controls="main-sidebar"
-            className="lg:hidden rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-text"
+            className="rounded p-2 -ml-2 lg:hidden focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
             onClick={() => setSidebarOpen(!sidebarOpen)}
           >
             {sidebarOpen ? <X aria-hidden="true" /> : <Menu aria-hidden="true" />}
           </button>
 
-          <div className="flex items-center gap-4">
+          <div className="flex min-w-0 flex-1 items-center justify-end gap-2 sm:gap-4">
             <div
               data-testid="backend-status"
-              className="hidden items-center gap-2 rounded-full border border-slate-500 bg-slate-900 px-3 py-1.5 md:flex"
+              className="hidden items-center gap-2 rounded-full border border-slate-700 bg-slate-900 px-3 py-1.5 md:flex"
               role="status"
               aria-live="polite"
               aria-label={
@@ -305,10 +316,10 @@ const App = () => {
                   type="button"
                   onClick={handleConnectWallet}
                   disabled={walletStatus === 'connecting'}
-                  className="flex items-center gap-2 rounded-lg border border-slate-700 bg-slate-900 px-4 py-2 transition-all hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
+                  className="flex min-w-0 items-center gap-2 rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 transition-all hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 sm:px-4"
                 >
                   <Wallet size={18} aria-hidden="true" />
-                  <span className="text-sm font-medium">
+                  <span className="hidden text-sm font-medium sm:inline">
                     {walletStatus === 'connecting' ? 'Connecting...' : 'Connect Wallet'}
                   </span>
                 </button>
@@ -323,15 +334,15 @@ const App = () => {
         </header>
 
         <section
-          className="mx-auto w-full max-w-7xl px-4 py-8 sm:px-6 lg:px-8"
+          className="mx-auto w-full max-w-7xl px-3 py-5 sm:px-6 sm:py-8 lg:px-8"
           aria-label={menuItems.find((m) => m.id === activeTab)?.label}
         >
-          <div className="mb-8 flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
-            <div>
-              <h2 className="font-display text-3xl font-bold">
+          <div className="mb-6 flex flex-col gap-3 sm:mb-8 md:flex-row md:items-start md:justify-between">
+            <div className="min-w-0">
+              <h2 className="font-display text-2xl font-bold sm:text-3xl">
                 {menuItems.find((m) => m.id === activeTab)?.label}
               </h2>
-              <p className="mt-1 text-slate-400">
+              <p className="mt-1 max-w-3xl text-sm leading-6 text-slate-400 sm:text-base">
                 {activeTab === 'dashboard' &&
                   'Manage anchor operations, branding, and flow requirements from a single backend-driven surface.'}
                 {activeTab === 'deposit' && 'Initiate a new on-ramp transaction via SEP-24.'}
@@ -346,7 +357,7 @@ const App = () => {
             {loadingState === 'error' ? (
               <div
                 data-testid="config-warning"
-                className="flex items-center gap-2 rounded-lg border border-amber-500/20 bg-amber-500/10 px-4 py-2 text-sm text-amber-200"
+                className="flex items-start gap-2 rounded-lg border border-amber-500/20 bg-amber-500/10 px-4 py-2 text-sm text-amber-200"
                 role="alert"
               >
                 <AlertCircle size={16} aria-hidden="true" />
@@ -380,9 +391,9 @@ const App = () => {
                 )}
                 {activeTab === 'kyc' && <KycStatusView uiConfig={uiConfig} />}
                 {activeTab === 'settings' && (
-                  <div className="grid grid-cols-1 gap-6 xl:grid-cols-[0.95fr_1.05fr]">
+                  <div className="grid grid-cols-1 gap-5 sm:gap-6 xl:grid-cols-[0.95fr_1.05fr]">
                     <div className="space-y-6">
-                      <div className="glass-card p-8">
+                      <div className="glass-card p-5 sm:p-8">
                         <h3 className="mb-4 text-xl font-bold">Branding Configuration</h3>
                         <div className="space-y-6">
                           <div>
@@ -416,7 +427,7 @@ const App = () => {
                               <label htmlFor="primary-color-hex" className="mb-2 block text-sm font-medium text-slate-400">
                                 Primary Color
                               </label>
-                              <div className="flex gap-2">
+                              <div className="flex min-w-0 gap-2">
                                 <input
                                   type="color"
                                   value={uiConfig.primaryColor}
@@ -430,7 +441,7 @@ const App = () => {
                                   value={uiConfig.primaryColor}
                                   readOnly
                                   aria-readonly="true"
-                                  className="input-field flex-1"
+                                  className="input-field min-w-0 flex-1"
                                 />
                               </div>
                             </div>
@@ -438,7 +449,7 @@ const App = () => {
                               <label htmlFor="accent-color-hex" className="mb-2 block text-sm font-medium text-slate-400">
                                 Accent Color
                               </label>
-                              <div className="flex gap-2">
+                              <div className="flex min-w-0 gap-2">
                                 <input
                                   type="color"
                                   value={uiConfig.accentColor}
@@ -452,7 +463,7 @@ const App = () => {
                                   value={uiConfig.accentColor}
                                   readOnly
                                   aria-readonly="true"
-                                  className="input-field flex-1"
+                                  className="input-field min-w-0 flex-1"
                                 />
                               </div>
                             </div>

--- a/dashboard/src/components/TransactionHistory.tsx
+++ b/dashboard/src/components/TransactionHistory.tsx
@@ -119,12 +119,6 @@ export const TransactionHistory = () => {
   const safePage = Math.min(page, totalPages);
   const paginated = sorted.slice((safePage - 1) * pageSize, safePage * pageSize);
 
-  const HEADERS: { key: SortKey; label: string }[] = [
-    { key: 'type', label: 'Type' },
-    { key: 'asset', label: 'Asset' },
-    { key: 'amount', label: 'Amount' },
-    { key: 'status', label: 'Status' },
-    { key: 'date', label: 'Date' },
   const HEADERS: { key: SortKey; label: string; align: ColumnAlign }[] = [
     { key: 'type', label: 'Type', align: 'left' },
     { key: 'asset', label: 'Asset', align: 'left' },
@@ -224,7 +218,7 @@ export const TransactionHistory = () => {
       </div>
 
       <div className="glass-card overflow-x-auto">
-        <table className="w-full text-left" aria-label="Transaction history">
+        <table className="responsive-table w-full text-left" aria-label="Transaction history">
           <caption className="sr-only">
             Transaction history — {sorted.length} result{sorted.length !== 1 ? 's' : ''}
           </caption>
@@ -238,7 +232,6 @@ export const TransactionHistory = () => {
                 >
                   <button
                     onClick={() => handleSort(key)}
-                    className="rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-text inline-flex items-center gap-1 hover:text-slate-200"
                     className={`inline-flex items-center gap-1 rounded hover:text-slate-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-text ${
                       align === 'right' ? 'justify-end' : 'justify-start'
                     }`}
@@ -287,7 +280,7 @@ export const TransactionHistory = () => {
             ) : (
               paginated.map((tx) => (
                 <tr key={tx.id} className="transition-colors hover:bg-slate-900/50">
-                  <td className="flex items-center gap-2 p-4">
+                  <td className="flex items-center gap-2 p-4" data-label="Type">
                     {tx.type === 'Deposit' ? (
                       <ArrowDownLeft size={16} className="text-emerald-400" aria-hidden="true" />
                     ) : (
@@ -295,15 +288,15 @@ export const TransactionHistory = () => {
                     )}
                     {tx.type}
                   </td>
-                  <td className="p-4">{tx.asset}</td>
-                  <td className="p-4 text-right font-mono">${fmtAmount(tx.amount)}</td>
-                  <td className="p-4">
+                  <td className="p-4" data-label="Asset">{tx.asset}</td>
+                  <td className="p-4 font-mono" data-label="Amount">${fmtAmount(tx.amount)}</td>
+                  <td className="p-4" data-label="Status">
                     <TransactionStatusBadge status={tx.status} />
                   </td>
-                  <td className="p-4 text-sm text-slate-400">
+                  <td className="p-4 text-sm text-slate-400" data-label="Date">
                     <time dateTime={tx.date}>{tx.date}</time>
                   </td>
-                  <td className="p-4 font-mono text-xs text-slate-400">{tx.reference}</td>
+                  <td className="p-4 font-mono text-xs text-slate-500" data-label="Reference">{tx.reference}</td>
                 </tr>
               ))
             )}

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -21,6 +21,10 @@
 }
 
 @layer base {
+  html {
+    @apply overflow-x-hidden;
+  }
+
   * {
     scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
     scrollbar-width: thin;
@@ -54,7 +58,7 @@
   }
 
   body {
-    @apply bg-background text-slate-50 font-sans;
+    @apply bg-background text-slate-50 font-sans overflow-x-hidden;
   }
 
   @media (forced-colors: active) {
@@ -75,5 +79,66 @@
   
   .input-field {
     @apply bg-slate-900 border border-slate-600 text-slate-100 rounded-lg px-4 py-2 focus:outline-none focus:ring-2 focus:ring-primary-text transition-all;
+  }
+}
+
+@media (max-width: 640px) {
+  .responsive-table,
+  .responsive-table thead,
+  .responsive-table tbody,
+  .responsive-table tr,
+  .responsive-table th,
+  .responsive-table td {
+    display: block;
+  }
+
+  .responsive-table thead {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  .responsive-table tbody {
+    display: grid;
+    gap: 0.75rem;
+    padding: 0.75rem;
+  }
+
+  .responsive-table tbody tr {
+    border: 1px solid rgb(30 41 59);
+    border-radius: 0.75rem;
+    background: rgb(15 23 42 / 0.55);
+    overflow: hidden;
+  }
+
+  .responsive-table tbody td {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.75rem 1rem;
+    border-bottom: 1px solid rgb(30 41 59 / 0.75);
+    text-align: right;
+    overflow-wrap: anywhere;
+  }
+
+  .responsive-table tbody td:last-child {
+    border-bottom: 0;
+  }
+
+  .responsive-table tbody td::before {
+    content: attr(data-label);
+    flex: 0 0 auto;
+    font-size: 0.75rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: rgb(100 116 139);
   }
 }


### PR DESCRIPTION
closes #590

## Summary: Improves dashboard responsiveness for mobile viewport widths. Adds mobile-safe spacing, stacking, and wrapping across dashboard shell, cards, controls, forms, and workflow panels. Converts the transaction history table into labeled mobile row cards under small viewport widths.

## Reason: This resolves issue #590 by optimizing dashboard styling rules for mobile screens and reducing horizontal overflow on narrow devices.