### PR TITLE
#625 Configure Docker Compose for Production Deployments

### DIFF
--- a/docker-compose.testnet.yml
+++ b/docker-compose.testnet.yml
@@ -55,6 +55,8 @@ services:
   jaeger:
     image: jaegertracing/all-in-one:latest
     container_name: anchorpoint-jaeger-testnet
+    profiles:
+      - monitoring
     ports:
       - "16686:16686"
       - "14268:14268"
@@ -70,6 +72,8 @@ services:
   prometheus:
     image: prom/prometheus:latest
     container_name: anchorpoint-prometheus-testnet
+    profiles:
+      - monitoring
     ports:
       - "9090:9090"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,6 +99,8 @@ services:
   jaeger:
     image: jaegertracing/all-in-one:latest
     container_name: anchorpoint-jaeger
+    profiles:
+      - monitoring
     ports:
       - "16686:16686"  # Jaeger UI
       - "14268:14268"  # HTTP collector
@@ -114,6 +116,8 @@ services:
   prometheus:
     image: prom/prometheus:latest
     container_name: anchorpoint-prometheus
+    profiles:
+      - monitoring
     ports:
       - "9090:9090"
     volumes:
@@ -134,6 +138,8 @@ services:
   alertmanager:
     image: prom/alertmanager:latest
     container_name: anchorpoint-alertmanager
+    profiles:
+      - monitoring
     ports:
       - "9093:9093"
     volumes:
@@ -150,6 +156,8 @@ services:
   blackbox-exporter:
     image: prom/blackbox-exporter:latest
     container_name: anchorpoint-blackbox-exporter
+    profiles:
+      - monitoring
     ports:
       - "9115:9115"
     volumes:


### PR DESCRIPTION
Closes #625

---


This PR addresses #625  by configuring Docker Compose profiles for production and testnet environments. Optional monitoring and observability services are now placed under the `monitoring` profile so they do not start by default during standard deployments.

 Key Changes

- **Standard Compose**: Added `profiles: [monitoring]` to `jaeger`, `prometheus`, `alertmanager`, and `blackbox-exporter` in `docker-compose.yml`.
- **Testnet Compose**: Applied the `monitoring` profile to `jaeger` and `prometheus` in `docker-compose.testnet.yml`.
- **Core Optimization**: Ensures only core services (`backend`, `postgres`, `redis`, and `dashboard`) start by default, reducing deployment overhead.
