### PR TITLE
feat: resolve issues #542, #554, #563, #569 - reentrancy guard, clean script, SEP-12 auth, revenue tests

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -28,7 +28,8 @@
     "migrate:rollback": "ts-node scripts/generate-rollback.ts",
     "migrate:status": "prisma migrate status",
     "migrate:validate-env": "node scripts/validate-migration-env.js",
-    "migrate:bootstrap": "bash scripts/bootstrap-db.sh"
+    "migrate:bootstrap": "bash scripts/bootstrap-db.sh",
+    "clean": "rm -rf logs coverage && find . -name '*.db-journal' -delete && find . -name '*.sqlite-journal' -delete"
   },
   "dependencies": {
     "@aws-sdk/client-kms": "^3.500.0",

--- a/backend/src/api/controllers/sep12.controller.ts
+++ b/backend/src/api/controllers/sep12.controller.ts
@@ -335,6 +335,10 @@ export class Sep12Controller {
         return res.status(400).json({ error: 'upload_id and account are required' });
       }
 
+      if (req.user && req.user.publicKey !== account) {
+        return res.status(403).json({ error: 'Forbidden: session account does not match request account' });
+      }
+
       const record = uploadStore.get(upload_id);
 
       if (!record || record.status === 'EXPIRED') {

--- a/contracts/revenue_distributor/src/lib.rs
+++ b/contracts/revenue_distributor/src/lib.rs
@@ -157,4 +157,106 @@ mod tests {
         let (_, _, gov_share) = distributor_client.get_config();
         assert_eq!(gov_share, 8000);
     }
+
+    #[test]
+    fn test_zero_balance_distribute() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let treasury = Address::generate(&env);
+        let gov_stakers = Address::generate(&env);
+
+        let token_admin = Address::generate(&env);
+        let token_id = env.register_stellar_asset_contract_v2(token_admin.clone());
+        let token_client = token::Client::new(&env, &token_id.address());
+
+        let distributor_id = env.register_contract(None, RevenueDistributor);
+        let distributor_client = RevenueDistributorClient::new(&env, &distributor_id);
+        distributor_client.initialize(&admin, &treasury, &gov_stakers, &6000);
+
+        // Distributor has no balance — distribute should be a no-op
+        distributor_client.distribute(&token_id.address());
+
+        assert_eq!(token_client.balance(&gov_stakers), 0);
+        assert_eq!(token_client.balance(&treasury), 0);
+    }
+
+    #[test]
+    fn test_full_gov_share() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let treasury = Address::generate(&env);
+        let gov_stakers = Address::generate(&env);
+
+        let token_admin = Address::generate(&env);
+        let token_id = env.register_stellar_asset_contract_v2(token_admin.clone());
+        let token_client = token::Client::new(&env, &token_id.address());
+
+        let distributor_id = env.register_contract(None, RevenueDistributor);
+        let distributor_client = RevenueDistributorClient::new(&env, &distributor_id);
+        // 100% to gov_stakers, 0% to treasury
+        distributor_client.initialize(&admin, &treasury, &gov_stakers, &10000);
+
+        token::StellarAssetClient::new(&env, &token_id.address()).mint(&distributor_id, &1000);
+        distributor_client.distribute(&token_id.address());
+
+        assert_eq!(token_client.balance(&gov_stakers), 1000);
+        assert_eq!(token_client.balance(&treasury), 0);
+        assert_eq!(token_client.balance(&distributor_id), 0);
+    }
+
+    #[test]
+    fn test_zero_gov_share() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let treasury = Address::generate(&env);
+        let gov_stakers = Address::generate(&env);
+
+        let token_admin = Address::generate(&env);
+        let token_id = env.register_stellar_asset_contract_v2(token_admin.clone());
+        let token_client = token::Client::new(&env, &token_id.address());
+
+        let distributor_id = env.register_contract(None, RevenueDistributor);
+        let distributor_client = RevenueDistributorClient::new(&env, &distributor_id);
+        // 0% to gov_stakers, 100% to treasury
+        distributor_client.initialize(&admin, &treasury, &gov_stakers, &0);
+
+        token::StellarAssetClient::new(&env, &token_id.address()).mint(&distributor_id, &1000);
+        distributor_client.distribute(&token_id.address());
+
+        assert_eq!(token_client.balance(&gov_stakers), 0);
+        assert_eq!(token_client.balance(&treasury), 1000);
+        assert_eq!(token_client.balance(&distributor_id), 0);
+    }
+
+    #[test]
+    fn test_weight_precision_with_odd_amounts() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let treasury = Address::generate(&env);
+        let gov_stakers = Address::generate(&env);
+
+        let token_admin = Address::generate(&env);
+        let token_id = env.register_stellar_asset_contract_v2(token_admin.clone());
+        let token_client = token::Client::new(&env, &token_id.address());
+
+        let distributor_id = env.register_contract(None, RevenueDistributor);
+        let distributor_client = RevenueDistributorClient::new(&env, &distributor_id);
+        // 30% gov, 70% treasury
+        distributor_client.initialize(&admin, &treasury, &gov_stakers, &3000);
+
+        token::StellarAssetClient::new(&env, &token_id.address()).mint(&distributor_id, &1000);
+        distributor_client.distribute(&token_id.address());
+
+        assert_eq!(token_client.balance(&gov_stakers), 300);
+        assert_eq!(token_client.balance(&treasury), 700);
+        assert_eq!(token_client.balance(&distributor_id), 0);
+    }
 }

--- a/contracts/yield/src/lib.rs
+++ b/contracts/yield/src/lib.rs
@@ -98,14 +98,7 @@ impl YieldDistribution {
             .get(&DataKey::TotalStaked)
             .unwrap_or(0);
 
-        // Transfer reward tokens into the contract
-        let reward_token: Address = env.storage().instance().get(&DataKey::RewardToken).unwrap();
-        token::Client::new(&env, &reward_token).transfer(
-            &from,
-            &env.current_contract_address(),
-            &amount,
-        );
-
+        // Update state before external token transfer (reentrancy guard pattern).
         // If nobody is staking yet, rewards accumulate but can't be distributed —
         // they will be claimable once the first stake occurs (reward_per_token
         // stays 0 until then, so the deposited tokens sit idle).
@@ -123,6 +116,14 @@ impl YieldDistribution {
                 .instance()
                 .set(&DataKey::RewardPerTokenStored, &rpt);
         }
+
+        // Transfer reward tokens into the contract after state is updated
+        let reward_token: Address = env.storage().instance().get(&DataKey::RewardToken).unwrap();
+        token::Client::new(&env, &reward_token).transfer(
+            &from,
+            &env.current_contract_address(),
+            &amount,
+        );
 
         // Topic: event name only; from + amount in data.
         env.events()
@@ -147,13 +148,7 @@ impl YieldDistribution {
         // Settle any pending rewards before changing the stake
         Self::_update_reward(&env, &user);
 
-        let stake_token: Address = env.storage().instance().get(&DataKey::StakeToken).unwrap();
-        token::Client::new(&env, &stake_token).transfer(
-            &user,
-            &env.current_contract_address(),
-            &amount,
-        );
-
+        // Update state before external token transfer (reentrancy guard pattern)
         let prev: i128 = Self::_stake_of(&env, &user);
         env.storage()
             .persistent()
@@ -167,6 +162,13 @@ impl YieldDistribution {
         env.storage()
             .instance()
             .set(&DataKey::TotalStaked, &total.checked_add(amount).expect("total staked overflow"));
+
+        let stake_token: Address = env.storage().instance().get(&DataKey::StakeToken).unwrap();
+        token::Client::new(&env, &stake_token).transfer(
+            &user,
+            &env.current_contract_address(),
+            &amount,
+        );
 
         // Topic: event name only; user + amount in data.
         env.events()


### PR DESCRIPTION
## Summary

- **#563 (yield-contract):** Move state updates before external token transfers in `stake()` and `deposit_rewards()` — follows checks-effects-interactions pattern to guard against reentrancy.
- **#542 (devops):** Add `clean` script to `backend/package.json` that deletes SQLite journal files, `logs/`, and `coverage/` directories.
- **#554 (backend-sep12):** In `confirmUpload`, verify active session token (`req.user.publicKey`) matches the `account` field before processing — reject mismatches with `403 Forbidden`.
- **#569 (revenue-distributor):** Add unit tests for `revenue_distributor` covering zero balance, 100% gov share, 0% gov share, and weight precision with odd amounts.

## Closes

Closes #542, closes #554, closes #563, closes #569

## Test plan

- [ ] `cargo check --manifest-path contracts/Cargo.toml` passes
- [ ] `cargo test --manifest-path contracts/Cargo.toml` — all yield and revenue_distributor tests pass
- [ ] `npm run clean` runs without error and reduces workspace file count
- [ ] `npm run test:backend` — SEP-12 upload-confirm 403 path covered