### PR TITLE
fix: Resolve multiple issues (#524, #535, #526, #520)

### DIFF
--- a/backend/src/api/routes/auth.route.test.ts
+++ b/backend/src/api/routes/auth.route.test.ts
@@ -1,0 +1,19 @@
+import request from 'supertest';
+import express from 'express';
+import authRouter from './auth.route';
+import { authLimiter } from '../middleware/rate-limit.middleware';
+
+const app = express();
+app.use(express.json());
+app.use('/sep10', authLimiter, authRouter);
+
+describe('Auth Route Rate Limiting', () => {
+  it('should return 429 when rate limit is exceeded', async () => {
+    // authLimiter max is 10, let's send 11 requests
+    for (let i = 0; i < 10; i++) {
+      await request(app).post('/sep10').send({ account: 'GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX' });
+    }
+    const response = await request(app).post('/sep10').send({ account: 'GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX' });
+    expect(response.status).toBe(429);
+  });
+});

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -17,6 +17,7 @@ import relayerRouter from './api/routes/relayer.route';
 import recurringPaymentsRouter from './api/routes/recurring-payments.route';
 import configRouter from './api/routes/config.route';
 import sep31Router from './api/routes/sep31.route';
+import authRouter from './api/routes/auth.route';
 import { errorHandler } from './api/middleware/error.middleware';
 import { metricsMiddleware, connectionTracker } from './api/middleware/metrics.middleware';
 import { securityHeadersMiddleware } from './api/middleware/security-headers.middleware';
@@ -25,7 +26,7 @@ import feeReportRouter from './api/routes/fee-report.route';
 import { feeReportScheduler } from './workers/fee-report.scheduler';
 import eventRouter from './api/routes/event.route';
 import notificationsRouter from './api/routes/notifications.route';
-import { publicLimiter } from './api/middleware/rate-limit.middleware';
+import { publicLimiter, authLimiter } from './api/middleware/rate-limit.middleware';
 import { notificationService } from './services/notification.service';
 import { createEmailProvider, ConsoleSmsProvider, ConsolePushProvider } from './lib/notifications/providers';
 import { NotificationType } from './services/notification.service';
@@ -143,6 +144,9 @@ app.use('/api/relayer', relayerRouter);
 
 // SEP-40 Swap Rates API
 app.use('/sep40', sep40Router);
+
+// SEP-10 Auth routes
+app.use('/sep10', authLimiter, authRouter);
 
 // SEP-12 KYC routes
 app.use('/sep12', sep12Router);

--- a/contracts/liquid_staking/src/lib.rs
+++ b/contracts/liquid_staking/src/lib.rs
@@ -1,8 +1,28 @@
 #![no_std]
 
 use soroban_sdk::{
-    contract, contractimpl, contracttype, symbol_short, token, Address, Env, String, Vec, IntoVal, Map, Symbol
+    contract, contracterror, contractimpl, contracttype, panic_with_error, symbol_short, token, Address, Env, String, Vec, IntoVal, Map, Symbol
 };
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum Error {
+    AlreadyInitialized = 1,
+    AmountNotPositive = 2,
+    RptOverflow = 3,
+    ContractPaused = 4,
+    LockTimeOverflow = 5,
+    NotTokenOwner = 6,
+    StakeLocked = 7,
+    NoStakeFound = 8,
+    TotalStakedUnderflow = 9,
+    TotalStakedOverflow = 10,
+    RewardsOverflow = 11,
+    AdminNotFound = 12,
+    OnlyAdmin = 13,
+}
+
 
 const PRECISION: i128 = 1_000_000_000_000_000_000;
 
@@ -68,7 +88,7 @@ impl LiquidStaking {
         nft_contract: Address,
     ) {
         if env.storage().instance().has(&DataKey::Admin) {
-            panic!("already initialized");
+            panic_with_error!(env, Error::AlreadyInitialized);
         }
         admin.require_auth();
         env.storage().instance().set(&DataKey::Admin, &admin);
@@ -90,7 +110,9 @@ impl LiquidStaking {
 
     pub fn deposit_rewards(env: Env, from: Address, amount: i128) {
         from.require_auth();
-        assert!(amount > 0, "amount must be positive");
+        if amount <= 0 {
+            panic_with_error!(env, Error::AmountNotPositive);
+        }
 
         let total_staked: i128 = env
             .storage()
@@ -112,8 +134,8 @@ impl LiquidStaking {
                 .get(&DataKey::RewardPerTokenStored)
                 .unwrap_or(0);
             rpt = rpt.checked_add(
-                amount.checked_mul(PRECISION).expect("rpt overflow") / total_staked
-            ).expect("rpt overflow");
+                amount.checked_mul(PRECISION).unwrap_or_else(|| panic_with_error!(env, Error::RptOverflow)) / total_staked
+            ).unwrap_or_else(|| panic_with_error!(env, Error::RptOverflow));
             env.storage()
                 .instance()
                 .set(&DataKey::RewardPerTokenStored, &rpt);
@@ -126,11 +148,12 @@ impl LiquidStaking {
     pub fn stake(env: Env, user: Address, amount: i128, lock_duration: u64) -> u64 {
         user.require_auth();
         // Emergency pause check: block staking when the contract is paused.
-        assert!(
-            !env.storage().instance().get::<DataKey, bool>(&DataKey::Paused).unwrap_or(false),
-            "contract is paused"
-        );
-        assert!(amount > 0, "amount must be positive");
+        if env.storage().instance().get::<DataKey, bool>(&DataKey::Paused).unwrap_or(false) {
+            panic_with_error!(env, Error::ContractPaused);
+        }
+        if amount <= 0 {
+            panic_with_error!(env, Error::AmountNotPositive);
+        }
 
         let stake_token: Address = env.storage().instance().get(&DataKey::StakeToken).unwrap();
         token::Client::new(&env, &stake_token).transfer(
@@ -160,7 +183,7 @@ impl LiquidStaking {
         );
 
         env.storage().persistent().set(&DataKey::StakeAmount(token_id), &amount);
-        let lock_time = env.ledger().timestamp().checked_add(lock_duration).expect("lock time overflow");
+        let lock_time = env.ledger().timestamp().checked_add(lock_duration).unwrap_or_else(|| panic_with_error!(env, Error::LockTimeOverflow));
         let lock_time = env.ledger().timestamp() + lock_duration;
         
         // Populate attributes
@@ -198,7 +221,7 @@ impl LiquidStaking {
         env.storage().persistent().set(&DataKey::NftRewards(token_id), &0_i128);
 
         let total: i128 = env.storage().instance().get(&DataKey::TotalStaked).unwrap_or(0);
-        env.storage().instance().set(&DataKey::TotalStaked, &total.checked_add(amount).expect("total staked overflow"));
+        env.storage().instance().set(&DataKey::TotalStaked, &total.checked_add(amount).unwrap_or_else(|| panic_with_error!(env, Error::TotalStakedOverflow)));
 
         // Topic: event name only; user + token_id + amount + lock_time in data.
         env.events().publish((symbol_short!("staked"),), (user, token_id, amount, lock_time));
@@ -209,10 +232,9 @@ impl LiquidStaking {
     pub fn unstake(env: Env, user: Address, token_id: u64) {
         user.require_auth();
         // Emergency pause check: block unstaking when the contract is paused.
-        assert!(
-            !env.storage().instance().get::<DataKey, bool>(&DataKey::Paused).unwrap_or(false),
-            "contract is paused"
-        );
+        if env.storage().instance().get::<DataKey, bool>(&DataKey::Paused).unwrap_or(false) {
+            panic_with_error!(env, Error::ContractPaused);
+        }
 
         let nft_contract: Address = env.storage().instance().get(&DataKey::NftContract).unwrap();
         let owner: Address = env.invoke_contract(
@@ -220,13 +242,19 @@ impl LiquidStaking {
             &symbol_short!("owner_of"),
             (token_id,).into_val(&env),
         );
-        assert_eq!(user, owner, "not token owner");
+        if user != owner {
+            panic_with_error!(env, Error::NotTokenOwner);
+        }
 
         let lock_time: u64 = env.storage().persistent().get(&DataKey::StakeLockTime(token_id)).unwrap_or(0);
-        assert!(env.ledger().timestamp() >= lock_time, "stake is locked");
+        if env.ledger().timestamp() < lock_time {
+            panic_with_error!(env, Error::StakeLocked);
+        }
 
         let amount: i128 = env.storage().persistent().get(&DataKey::StakeAmount(token_id)).unwrap_or(0);
-        assert!(amount > 0, "no stake found for token");
+        if amount <= 0 {
+            panic_with_error!(env, Error::NoStakeFound);
+        }
 
         Self::_update_reward(&env, token_id);
 
@@ -241,7 +269,7 @@ impl LiquidStaking {
         }
 
         let total: i128 = env.storage().instance().get(&DataKey::TotalStaked).unwrap_or(0);
-        env.storage().instance().set(&DataKey::TotalStaked, &total.checked_sub(amount).expect("total staked underflow"));
+        env.storage().instance().set(&DataKey::TotalStaked, &total.checked_sub(amount).unwrap_or_else(|| panic_with_error!(env, Error::TotalStakedUnderflow)));
 
         let stake_token: Address = env.storage().instance().get(&DataKey::StakeToken).unwrap();
         token::Client::new(&env, &stake_token).transfer(
@@ -275,7 +303,9 @@ impl LiquidStaking {
             &symbol_short!("owner_of"),
             (token_id,).into_val(&env),
         );
-        assert_eq!(user, owner, "not token owner");
+        if user != owner {
+            panic_with_error!(env, Error::NotTokenOwner);
+        }
 
         Self::_update_reward(&env, token_id);
 
@@ -311,8 +341,8 @@ impl LiquidStaking {
         let accrued: i128 = env.storage().persistent().get(&DataKey::NftRewards(token_id)).unwrap_or(0);
         
         let pending = accrued.checked_add(
-            amount.checked_mul(rpt - nft_rpt).expect("rewards overflow") / PRECISION
-        ).expect("rewards overflow");
+            amount.checked_mul(rpt - nft_rpt).unwrap_or_else(|| panic_with_error!(env, Error::RewardsOverflow)) / PRECISION
+        ).unwrap_or_else(|| panic_with_error!(env, Error::RewardsOverflow));
         let lock_time: u64 = env.storage().persistent().get(&DataKey::StakeLockTime(token_id)).unwrap_or(0);
 
         StakeInfo {
@@ -332,8 +362,10 @@ impl LiquidStaking {
             .storage()
             .instance()
             .get(&DataKey::Admin)
-            .expect("admin not found");
-        assert!(caller == admin, "only admin can pause");
+            .unwrap_or_else(|| panic_with_error!(env, Error::AdminNotFound));
+        if caller != admin {
+            panic_with_error!(env, Error::OnlyAdmin);
+        }
 
         env.storage().instance().set(&DataKey::Paused, &true);
         env.events().publish((symbol_short!("paused"),), caller);
@@ -346,8 +378,10 @@ impl LiquidStaking {
             .storage()
             .instance()
             .get(&DataKey::Admin)
-            .expect("admin not found");
-        assert!(caller == admin, "only admin can unpause");
+            .unwrap_or_else(|| panic_with_error!(env, Error::AdminNotFound));
+        if caller != admin {
+            panic_with_error!(env, Error::OnlyAdmin);
+        }
 
         env.storage().instance().set(&DataKey::Paused, &false);
         env.events().publish((symbol_short!("unpaused"),), caller);
@@ -386,8 +420,10 @@ impl LiquidStaking {
             .storage()
             .instance()
             .get(&DataKey::Admin)
-            .expect("admin not found");
-        assert!(caller == admin, "only admin can update contract metadata");
+            .unwrap_or_else(|| panic_with_error!(env, Error::AdminNotFound));
+        if caller != admin {
+            panic_with_error!(env, Error::OnlyAdmin);
+        }
 
         let meta = ContractMetadata { description, icon_url, website };
         env.storage().instance().set(&DataKey::ContractMeta, &meta);
@@ -400,18 +436,18 @@ impl LiquidStaking {
         env.storage()
             .instance()
             .get(&DataKey::ContractMeta)
-            .expect("contract metadata not initialised")
+            .unwrap_or_else(|| panic_with_error!(env, Error::AlreadyInitialized))
     }
 
     fn _update_reward(env: &Env, token_id: u64) {
         let rpt: i128 = env.storage().instance().get(&DataKey::RewardPerTokenStored).unwrap_or(0);
         let nft_rpt: i128 = env.storage().persistent().get(&DataKey::NftRewardPerTokenPaid(token_id)).unwrap_or(0);
         let amount: i128 = env.storage().persistent().get(&DataKey::StakeAmount(token_id)).unwrap_or(0);
-        let earned = amount.checked_mul(rpt - nft_rpt).expect("rewards overflow") / PRECISION;
+        let earned = amount.checked_mul(rpt - nft_rpt).unwrap_or_else(|| panic_with_error!(env, Error::RewardsOverflow)) / PRECISION;
 
         if earned > 0 {
             let prev: i128 = env.storage().persistent().get(&DataKey::NftRewards(token_id)).unwrap_or(0);
-            env.storage().persistent().set(&DataKey::NftRewards(token_id), &prev.checked_add(earned).expect("rewards overflow"));
+            env.storage().persistent().set(&DataKey::NftRewards(token_id), &prev.checked_add(earned).unwrap_or_else(|| panic_with_error!(env, Error::RewardsOverflow)));
         }
 
         env.storage().persistent().set(&DataKey::NftRewardPerTokenPaid(token_id), &rpt);
@@ -581,7 +617,7 @@ mod tests {
     }
     
     #[test]
-    #[should_panic(expected = "stake is locked")]
+    #[should_panic(expected = "HostError: Error(Contract, 7)")]
     fn test_unstake_locked() {
         let (env, ls_id, _, _, alice, _, _) = setup();
         let client = LiquidStakingClient::new(&env, &ls_id);
@@ -618,7 +654,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "only admin can update contract metadata")]
+    #[should_panic(expected = "HostError: Error(Contract, 13)")]
     fn test_update_contract_meta_non_admin() {
         let (env, ls_id, _, _, alice, _, _) = setup();
         let client = LiquidStakingClient::new(&env, &ls_id);
@@ -646,7 +682,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "contract is paused")]
+    #[should_panic(expected = "HostError: Error(Contract, 4)")]
     fn test_stake_blocked_when_paused() {
         let (env, ls_id, _, admin, alice, _, _) = setup();
         let client = LiquidStakingClient::new(&env, &ls_id);
@@ -657,7 +693,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "contract is paused")]
+    #[should_panic(expected = "HostError: Error(Contract, 4)")]
     fn test_unstake_blocked_when_paused() {
         let (env, ls_id, _, admin, alice, _, _) = setup();
         let client = LiquidStakingClient::new(&env, &ls_id);
@@ -688,7 +724,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "only admin can pause")]
+    #[should_panic(expected = "HostError: Error(Contract, 13)")]
     fn test_non_admin_cannot_pause() {
         let (env, ls_id, _, _, alice, _, _) = setup();
         let client = LiquidStakingClient::new(&env, &ls_id);

--- a/contracts/registry/src/lib.rs
+++ b/contracts/registry/src/lib.rs
@@ -92,7 +92,7 @@ impl Registry {
                 contract_type: contract_type.clone(),
                 deployed_at: timestamp,
                 active: true,
-                previous_version: Some(existing_info.address),
+                previous_version: Some(existing_info.address.clone()),
             };
             
             env.storage().instance().set(&contract_key, &updated_info);


### PR DESCRIPTION
This PR resolves multiple outstanding issues in a single batch:

- **Issue #524**: Replaced generic panics with a structured `#[contracterror]` enum in the `liquid_staking` contract. Also fixed a minor compilation issue in the `registry` contract.
- **Issue #535**: Applied the `authLimiter` rate-limiting middleware to the `/sep10` auth routes and added a test asserting a 429 status response.
- **Issue #526**: Audited the `swap` contract and verified that all `env.events().publish` calls are already properly wrapped in tuples for v22 SDK compatibility.
- **Issue #520**: Audited the `xlm_wrapper` contract and verified that the `amm_address.clone()` fix is already in place in the `revoke_amm` function.

Closes #524
Closes #535
Closes #526
Closes #520