### PR TITLE
feat(backend-sep24): add security validation for sep-24 callback urls…

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -29,7 +29,6 @@
     "migrate:status": "prisma migrate status",
     "migrate:validate-env": "node scripts/validate-migration-env.js",
     "migrate:bootstrap": "bash scripts/bootstrap-db.sh",
-    "clean": "rm -rf logs coverage && find . -name '*.db-journal' -delete && find . -name '*.sqlite-journal' -delete"
     "clean": "node -e \"const fs=require('fs'),path=require('path');function walk(dir){if(!fs.existsSync(dir))return;for(const f of fs.readdirSync(dir)){const fp=path.join(dir,f);if(fs.statSync(fp).isDirectory())walk(fp);else if(['.db-journal','.db-wal','.db-shm'].some(e=>f.endsWith(e))){fs.unlinkSync(fp);console.log('Removed:',fp)}}};walk('.');['logs','coverage'].forEach(d=>{if(fs.existsSync(d)){fs.rmSync(d,{recursive:true,force:true});console.log('Removed:',d)}});console.log('Clean complete');\""
   },
   "dependencies": {

--- a/backend/src/api/routes/sep24.route.test.ts
+++ b/backend/src/api/routes/sep24.route.test.ts
@@ -36,6 +36,7 @@ describe('SEP-24 Routes', () => {
 
   afterEach(() => {
     delete process.env.INTERACTIVE_URL;
+    delete process.env.SEP24_ALLOWED_CALLBACK_DOMAINS;
   });
 
   describe('POST /transactions/deposit/interactive', () => {
@@ -110,6 +111,26 @@ describe('SEP-24 Routes', () => {
       const parsed = new URL(res.body.url);
       expect(parsed.searchParams.get('lang')).toBe('en');
     });
+
+    it('returns 400 when redirect_url is not in whitelist', async () => {
+      process.env.SEP24_ALLOWED_CALLBACK_DOMAINS = 'example.com';
+      const res = await request(app)
+        .post('/transactions/deposit/interactive')
+        .send({ asset_code: 'USDC', redirect_url: 'https://malicious.com/callback' });
+
+      expect(res.statusCode).toBe(400);
+      expect(res.body.error).toBe('invalid redirect_url domain');
+    });
+
+    it('returns 400 when on_change_callback is not in whitelist', async () => {
+      process.env.SEP24_ALLOWED_CALLBACK_DOMAINS = 'example.com';
+      const res = await request(app)
+        .post('/transactions/deposit/interactive')
+        .send({ asset_code: 'USDC', on_change_callback: 'https://malicious.com/hook' });
+
+      expect(res.statusCode).toBe(400);
+      expect(res.body.error).toBe('invalid on_change_callback domain');
+    });
   });
 
   describe('POST /transactions/withdraw/interactive', () => {
@@ -165,6 +186,26 @@ describe('SEP-24 Routes', () => {
       expect(res.statusCode).toBe(400);
       expect(res.body.error).toBe('account must be a valid Stellar public key');
       expect(res.body.error).not.toContain(account);
+    });
+
+    it('returns 400 when redirect_url is not in whitelist', async () => {
+      process.env.SEP24_ALLOWED_CALLBACK_DOMAINS = 'example.com';
+      const res = await request(app)
+        .post('/transactions/withdraw/interactive')
+        .send({ asset_code: 'USDC', redirect_url: 'https://malicious.com/callback' });
+
+      expect(res.statusCode).toBe(400);
+      expect(res.body.error).toBe('invalid redirect_url domain');
+    });
+
+    it('returns 400 when on_change_callback is not in whitelist', async () => {
+      process.env.SEP24_ALLOWED_CALLBACK_DOMAINS = 'example.com';
+      const res = await request(app)
+        .post('/transactions/withdraw/interactive')
+        .send({ asset_code: 'USDC', on_change_callback: 'https://malicious.com/hook' });
+
+      expect(res.statusCode).toBe(400);
+      expect(res.body.error).toBe('invalid on_change_callback domain');
     });
   });
 });

--- a/backend/src/api/routes/sep24.route.ts
+++ b/backend/src/api/routes/sep24.route.ts
@@ -9,6 +9,7 @@ import {
 } from '../../services/kyc.service';
 import prisma from '../../lib/prisma';
 import { isValidStellarPublicKey } from '../../utils/stellar-address';
+import { Sep24Service } from '../../services/sep24.service';
 
 const router = Router();
 
@@ -18,6 +19,8 @@ interface InteractiveRequest {
   amount?: string;
   lang?: string;
   quote_id?: string;
+  redirect_url?: string;
+  on_change_callback?: string;
 }
 
 interface InteractiveResponse {
@@ -90,7 +93,19 @@ const hasInvalidAccount = (account: unknown): boolean =>
  *         description: Invalid request parameters
  */
 router.post('/transactions/deposit/interactive', async (req: Request, res: Response) => {
-  const { asset_code, account, amount, lang = 'en', quote_id }: InteractiveRequest = req.body;
+  const { asset_code, account, amount, lang = 'en', quote_id, redirect_url, on_change_callback }: InteractiveRequest = req.body;
+
+  const allowedDomains = process.env.SEP24_ALLOWED_CALLBACK_DOMAINS
+    ? process.env.SEP24_ALLOWED_CALLBACK_DOMAINS.split(',').filter(Boolean)
+    : [];
+
+  if (redirect_url && allowedDomains.length > 0 && !Sep24Service.validateCallbackUrl(redirect_url, allowedDomains)) {
+    return res.status(400).json({ error: 'invalid redirect_url domain' });
+  }
+
+  if (on_change_callback && allowedDomains.length > 0 && !Sep24Service.validateCallbackUrl(on_change_callback, allowedDomains)) {
+    return res.status(400).json({ error: 'invalid on_change_callback domain' });
+  }
 
   if (!asset_code) {
     return res.status(400).json({
@@ -185,7 +200,19 @@ router.post('/transactions/deposit/interactive', async (req: Request, res: Respo
  *         description: Invalid request parameters
  */
 router.post('/transactions/withdraw/interactive', async (req: Request, res: Response) => {
-  const { asset_code, account, amount, lang = 'en', quote_id }: InteractiveRequest = req.body;
+  const { asset_code, account, amount, lang = 'en', quote_id, redirect_url, on_change_callback }: InteractiveRequest = req.body;
+
+  const allowedDomains = process.env.SEP24_ALLOWED_CALLBACK_DOMAINS
+    ? process.env.SEP24_ALLOWED_CALLBACK_DOMAINS.split(',').filter(Boolean)
+    : [];
+
+  if (redirect_url && allowedDomains.length > 0 && !Sep24Service.validateCallbackUrl(redirect_url, allowedDomains)) {
+    return res.status(400).json({ error: 'invalid redirect_url domain' });
+  }
+
+  if (on_change_callback && allowedDomains.length > 0 && !Sep24Service.validateCallbackUrl(on_change_callback, allowedDomains)) {
+    return res.status(400).json({ error: 'invalid on_change_callback domain' });
+  }
 
   if (!asset_code) {
     return res.status(400).json({

--- a/backend/src/services/sep24.service.test.ts
+++ b/backend/src/services/sep24.service.test.ts
@@ -1,0 +1,42 @@
+import { Sep24Service } from './sep24.service';
+
+describe('Sep24Service', () => {
+  describe('validateCallbackUrl', () => {
+    it('returns false for empty url', () => {
+      expect(Sep24Service.validateCallbackUrl('', ['example.com'])).toBe(false);
+    });
+
+    it('returns false for invalid url string', () => {
+      expect(Sep24Service.validateCallbackUrl('not-a-url', ['example.com'])).toBe(false);
+    });
+
+    it('returns false for non http/https protocols', () => {
+      expect(Sep24Service.validateCallbackUrl('ftp://example.com', ['example.com'])).toBe(false);
+      expect(Sep24Service.validateCallbackUrl('javascript:alert(1)', ['example.com'])).toBe(false);
+    });
+
+    it('returns true if allowedDomains is empty', () => {
+      expect(Sep24Service.validateCallbackUrl('https://malicious.com', [])).toBe(true);
+    });
+
+    it('returns true if domain exactly matches a whitelist entry', () => {
+      expect(Sep24Service.validateCallbackUrl('https://example.com/callback', ['example.com'])).toBe(true);
+    });
+
+    it('returns true if domain is a subdomain of a whitelist entry', () => {
+      expect(Sep24Service.validateCallbackUrl('https://sub.example.com/callback', ['example.com'])).toBe(true);
+    });
+
+    it('returns false if domain does not match whitelist', () => {
+      expect(Sep24Service.validateCallbackUrl('https://malicious.com/callback', ['example.com'])).toBe(false);
+      expect(Sep24Service.validateCallbackUrl('https://example.com.malicious.com/callback', ['example.com'])).toBe(false);
+    });
+
+    it('handles multiple allowed domains and case insensitivity', () => {
+      const allowed = ['example.com', 'Wallet.org'];
+      expect(Sep24Service.validateCallbackUrl('https://Example.COM/cb', allowed)).toBe(true);
+      expect(Sep24Service.validateCallbackUrl('https://my.wallet.ORG/cb', allowed)).toBe(true);
+      expect(Sep24Service.validateCallbackUrl('https://other.org/cb', allowed)).toBe(false);
+    });
+  });
+});

--- a/backend/src/services/sep24.service.ts
+++ b/backend/src/services/sep24.service.ts
@@ -1,0 +1,36 @@
+import { URL } from 'url';
+
+export class Sep24Service {
+  /**
+   * Validates a callback or redirect URL against a whitelist of allowed domains.
+   *
+   * @param url The URL to validate.
+   * @param allowedDomains Array of allowed hostnames (e.g., ['example.com']).
+   * @returns boolean true if valid, false if invalid or not allowed.
+   */
+  public static validateCallbackUrl(url: string, allowedDomains: string[]): boolean {
+    if (!url) return false;
+
+    try {
+      const parsedUrl = new URL(url);
+
+      if (parsedUrl.protocol !== 'https:' && parsedUrl.protocol !== 'http:') {
+        return false;
+      }
+
+      if (!allowedDomains || allowedDomains.length === 0) {
+        return true; // If no whitelist is defined, allow (or you can restrict default)
+      }
+
+      const hostname = parsedUrl.hostname.toLowerCase();
+
+      return allowedDomains.some((domain) => {
+        const d = domain.trim().toLowerCase();
+        if (!d) return false;
+        return hostname === d || hostname.endsWith(`.${d}`);
+      });
+    } catch {
+      return false; // Invalid URL format
+    }
+  }
+}


### PR DESCRIPTION
## Description
Closes #536

This PR addresses the security requirements for SEP-24 callback URLs by implementing strict URL parsing and whitelist-based domain validation. It prevents malicious or unauthorized domains from being passed via SEP-24 `redirect_url` or `on_change_callback` parameters.

### Changes Made
- **Created Validation Service**: Added `backend/src/services/sep24.service.ts` with logic to properly parse URLs, verify `http/https` protocols, and match domains/subdomains against a configured whitelist (`SEP24_ALLOWED_CALLBACK_DOMAINS`).
- **Endpoint Integration**: Updated `backend/src/api/routes/sep24.route.ts` to capture `redirect_url` and `on_change_callback` payloads in both `deposit` and `withdraw` interactive endpoints.
- **Error Handling**: Incoming requests containing non-whitelisted URLs are now safely intercepted and blocked with a `400 Bad Request` and an explicit error message.
- **Test Coverage**:
  - Added unit tests for `Sep24Service` (`sep24.service.test.ts`) validating various URL structures, subdomains, and invalid formats.
  - Added integration tests to `sep24.route.test.ts` asserting that invalid callback URLs explicitly result in a `400 Bad Request`.
- **Maintenance**: Fixed a duplicated `clean` script definition in `backend/package.json` that was causing `npm test` parsing failures.

Closes #533
Closes #536 
Closes #537 
Closes #538 