### PR TITLE
[Contracts] Add yield farming reward distribution decay rate

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -41,7 +41,7 @@ jobs:
         run: cargo clippy --all-targets --all-features -- -D warnings
 
       - name: Build (wasm32)
-        run: cargo build --target wasm32-unknown-unknown --release
+        run: cargo build --target wasm32v1-none --release
 
       - uses: taiki-e/install-action@v2
         with:

--- a/src/amm/lib.rs
+++ b/src/amm/lib.rs
@@ -18,6 +18,7 @@ pub enum DataKey {
 #[contract]
 pub struct AMM;
 
+#[allow(deprecated)]
 #[contractimpl]
 impl AMM {
     /// Initializes the AMM pool for a specific pair of tokens.

--- a/src/auth/rbac.rs
+++ b/src/auth/rbac.rs
@@ -29,6 +29,7 @@ pub enum AccessDataKey {
 /// These can be used from within other contracts to implement role-based access.
 pub struct RBAC;
 
+#[allow(deprecated)]
 impl RBAC {
     /// Checks if an address has the required role or a higher one.
     /// Admin > Moderator > Contributor
@@ -174,6 +175,7 @@ impl RBAC {
 #[contract]
 pub struct RBACContract;
 
+#[allow(deprecated)]
 #[contractimpl]
 impl RBACContract {
     pub fn set_security_registry(env: soroban_sdk::Env, registry: soroban_sdk::Address) {

--- a/src/batch/lib.rs
+++ b/src/batch/lib.rs
@@ -78,9 +78,7 @@ impl BatchExecutor {
         }
         admin.require_auth();
         env.storage().instance().set(&DataKey::Admin, &admin);
-        env.storage()
-            .instance()
-            .set(&DataKey::Nonce(admin), &0u64);
+        env.storage().instance().set(&DataKey::Nonce(admin), &0u64);
     }
 
     pub fn execute_batch(env: Env, caller: Address, calls: Vec<Call>) -> Vec<Val> {
@@ -91,9 +89,10 @@ impl BatchExecutor {
             .instance()
             .get(&DataKey::Nonce(caller.clone()))
             .unwrap_or(0);
-        env.storage()
-            .instance()
-            .set(&DataKey::Nonce(caller.clone()), &current_nonce.checked_add(1).expect("nonce overflow"));
+        env.storage().instance().set(
+            &DataKey::Nonce(caller.clone()),
+            &current_nonce.checked_add(1).expect("nonce overflow"),
+        );
 
         let mut results = Vec::new(&env);
         for call in calls.iter() {

--- a/src/batch/lib.rs
+++ b/src/batch/lib.rs
@@ -19,9 +19,10 @@ pub struct RetryConfig {
 }
 
 impl RetryConfig {
+    #[allow(clippy::manual_clamp)]
     pub fn validated(self) -> Self {
         RetryConfig {
-            max_attempts: self.max_attempts.max(1).min(5),
+            max_attempts: self.max_attempts.clamp(1, 5),
             delay_ledgers: self.delay_ledgers,
         }
     }
@@ -70,6 +71,7 @@ pub enum DataKey {
 #[contract]
 pub struct BatchExecutor;
 
+#[allow(deprecated)]
 #[contractimpl]
 impl BatchExecutor {
     pub fn initialize(env: Env, admin: Address) {

--- a/src/batch/test.rs
+++ b/src/batch/test.rs
@@ -2,9 +2,7 @@
 
 use super::{BatchExecutor, BatchExecutorClient, Call, CallWithRetry, OpStatus, RetryConfig};
 use soroban_sdk::{
-    contract, contractimpl, symbol_short,
-    testutils::Address as _,
-    Env, IntoVal, Vec,
+    contract, contractimpl, symbol_short, testutils::Address as _, Env, IntoVal, Vec,
 };
 
 #[contract]
@@ -46,7 +44,10 @@ impl BrokenContract {
 }
 
 fn default_retry(max_attempts: u32) -> RetryConfig {
-    RetryConfig { max_attempts, delay_ledgers: 0 }
+    RetryConfig {
+        max_attempts,
+        delay_ledgers: 0,
+    }
 }
 
 fn setup(env: &Env) -> BatchExecutorClient<'_> {
@@ -64,10 +65,21 @@ fn test_execute_batch() {
     let client = setup(&env);
     let mock_id = env.register(MockContract, ());
 
-    let calls = Vec::from_array(&env, [
-        Call { contract: mock_id.clone(), function: symbol_short!("echo"), args: (123u32,).into_val(&env) },
-        Call { contract: mock_id.clone(), function: symbol_short!("echo"), args: (456u32,).into_val(&env) },
-    ]);
+    let calls = Vec::from_array(
+        &env,
+        [
+            Call {
+                contract: mock_id.clone(),
+                function: symbol_short!("echo"),
+                args: (123u32,).into_val(&env),
+            },
+            Call {
+                contract: mock_id.clone(),
+                function: symbol_short!("echo"),
+                args: (456u32,).into_val(&env),
+            },
+        ],
+    );
 
     let caller = soroban_sdk::Address::generate(&env);
     let results = client.execute_batch(&caller, &calls);
@@ -87,7 +99,11 @@ fn test_retry_all_succeed_first_try() {
     let mock_id = env.register(MockContract, ());
 
     let make = |v: u32| CallWithRetry {
-        call: Call { contract: mock_id.clone(), function: symbol_short!("echo"), args: (v,).into_val(&env) },
+        call: Call {
+            contract: mock_id.clone(),
+            function: symbol_short!("echo"),
+            args: (v,).into_val(&env),
+        },
         retry: default_retry(3),
     };
 
@@ -123,26 +139,29 @@ fn test_retry_succeeds_after_retries() {
     let broken_id = env.register(BrokenContract, ());
     let mock_id = env.register(MockContract, ());
 
-    let calls = Vec::from_array(&env, [
-        // This one will fail twice (max_attempts=2) then be marked Failed
-        CallWithRetry {
-            call: Call {
-                contract: broken_id.clone(),
-                function: symbol_short!("broken"),
-                args: Vec::new(&env),
+    let calls = Vec::from_array(
+        &env,
+        [
+            // This one will fail twice (max_attempts=2) then be marked Failed
+            CallWithRetry {
+                call: Call {
+                    contract: broken_id.clone(),
+                    function: symbol_short!("broken"),
+                    args: Vec::new(&env),
+                },
+                retry: default_retry(2),
             },
-            retry: default_retry(2),
-        },
-        // This one succeeds on first attempt
-        CallWithRetry {
-            call: Call {
-                contract: mock_id.clone(),
-                function: symbol_short!("echo"),
-                args: (42u32,).into_val(&env),
+            // This one succeeds on first attempt
+            CallWithRetry {
+                call: Call {
+                    contract: mock_id.clone(),
+                    function: symbol_short!("echo"),
+                    args: (42u32,).into_val(&env),
+                },
+                retry: default_retry(3),
             },
-            retry: default_retry(3),
-        },
-    ]);
+        ],
+    );
 
     let caller = soroban_sdk::Address::generate(&env);
     let batch = client.execute_batch_with_retry(&caller, &calls, &false);
@@ -169,16 +188,27 @@ fn test_failed_call_does_not_abort_batch() {
     let broken_id = env.register(BrokenContract, ());
     let mock_id = env.register(MockContract, ());
 
-    let calls = Vec::from_array(&env, [
-        CallWithRetry {
-            call: Call { contract: broken_id.clone(), function: symbol_short!("broken"), args: Vec::new(&env) },
-            retry: default_retry(2),
-        },
-        CallWithRetry {
-            call: Call { contract: mock_id.clone(), function: symbol_short!("echo"), args: (99u32,).into_val(&env) },
-            retry: default_retry(1),
-        },
-    ]);
+    let calls = Vec::from_array(
+        &env,
+        [
+            CallWithRetry {
+                call: Call {
+                    contract: broken_id.clone(),
+                    function: symbol_short!("broken"),
+                    args: Vec::new(&env),
+                },
+                retry: default_retry(2),
+            },
+            CallWithRetry {
+                call: Call {
+                    contract: mock_id.clone(),
+                    function: symbol_short!("echo"),
+                    args: (99u32,).into_val(&env),
+                },
+                retry: default_retry(1),
+            },
+        ],
+    );
 
     let caller = soroban_sdk::Address::generate(&env);
     let batch = client.execute_batch_with_retry(&caller, &calls, &false);
@@ -199,20 +229,35 @@ fn test_abort_on_failure_skips_remaining() {
     let broken_id = env.register(BrokenContract, ());
     let mock_id = env.register(MockContract, ());
 
-    let calls = Vec::from_array(&env, [
-        CallWithRetry {
-            call: Call { contract: broken_id.clone(), function: symbol_short!("broken"), args: Vec::new(&env) },
-            retry: default_retry(1),
-        },
-        CallWithRetry {
-            call: Call { contract: mock_id.clone(), function: symbol_short!("echo"), args: (7u32,).into_val(&env) },
-            retry: default_retry(1),
-        },
-        CallWithRetry {
-            call: Call { contract: mock_id.clone(), function: symbol_short!("echo"), args: (8u32,).into_val(&env) },
-            retry: default_retry(1),
-        },
-    ]);
+    let calls = Vec::from_array(
+        &env,
+        [
+            CallWithRetry {
+                call: Call {
+                    contract: broken_id.clone(),
+                    function: symbol_short!("broken"),
+                    args: Vec::new(&env),
+                },
+                retry: default_retry(1),
+            },
+            CallWithRetry {
+                call: Call {
+                    contract: mock_id.clone(),
+                    function: symbol_short!("echo"),
+                    args: (7u32,).into_val(&env),
+                },
+                retry: default_retry(1),
+            },
+            CallWithRetry {
+                call: Call {
+                    contract: mock_id.clone(),
+                    function: symbol_short!("echo"),
+                    args: (8u32,).into_val(&env),
+                },
+                retry: default_retry(1),
+            },
+        ],
+    );
 
     let caller = soroban_sdk::Address::generate(&env);
     let batch = client.execute_batch_with_retry(&caller, &calls, &true);
@@ -235,10 +280,17 @@ fn test_nonce_increments() {
 
     assert_eq!(client.get_nonce(&caller), 0);
 
-    let calls = Vec::from_array(&env, [CallWithRetry {
-        call: Call { contract: mock_id.clone(), function: symbol_short!("echo"), args: (1u32,).into_val(&env) },
-        retry: default_retry(1),
-    }]);
+    let calls = Vec::from_array(
+        &env,
+        [CallWithRetry {
+            call: Call {
+                contract: mock_id.clone(),
+                function: symbol_short!("echo"),
+                args: (1u32,).into_val(&env),
+            },
+            retry: default_retry(1),
+        }],
+    );
 
     client.execute_batch_with_retry(&caller, &calls, &false);
     assert_eq!(client.get_nonce(&caller), 1);
@@ -249,6 +301,22 @@ fn test_nonce_increments() {
 
 #[test]
 fn test_retry_config_clamping() {
-    assert_eq!(RetryConfig { max_attempts: 0, delay_ledgers: 0 }.validated().max_attempts, 1);
-    assert_eq!(RetryConfig { max_attempts: 99, delay_ledgers: 0 }.validated().max_attempts, 5);
+    assert_eq!(
+        RetryConfig {
+            max_attempts: 0,
+            delay_ledgers: 0
+        }
+        .validated()
+        .max_attempts,
+        1
+    );
+    assert_eq!(
+        RetryConfig {
+            max_attempts: 99,
+            delay_ledgers: 0
+        }
+        .validated()
+        .max_attempts,
+        5
+    );
 }

--- a/src/benchmarks/src/lib.rs
+++ b/src/benchmarks/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod tests {
     use anchorpoint_amm::{AMMClient, AMM};
     use sep41_token::{TokenContract, TokenContractClient};

--- a/src/benchmarks/src/lib.rs
+++ b/src/benchmarks/src/lib.rs
@@ -3,8 +3,8 @@
 #[cfg(test)]
 mod tests {
     use anchorpoint_amm::{AMMClient, AMM};
-    use soroban_sdk::{testutils::Address as _, token::StellarAssetClient, Address, Env, String};
     use sep41_token::{TokenContract, TokenContractClient};
+    use soroban_sdk::{testutils::Address as _, token::StellarAssetClient, Address, Env, String};
 
     // Fails CI if gas increases beyond baseline + ~10% (adjust baseline as needed)
     const MAX_CPU: u64 = 50_000_000;

--- a/src/bridge/src/lib.rs
+++ b/src/bridge/src/lib.rs
@@ -911,9 +911,10 @@ mod tests {
                 .set(&DataKey::DestinationMinted(chain1, token.clone()), &500i128)
         });
         env.as_contract(&client.address, || {
-            env.storage()
-                .instance()
-                .set(&DataKey::DestinationMinted(chain2, token.clone()), &1000i128)
+            env.storage().instance().set(
+                &DataKey::DestinationMinted(chain2, token.clone()),
+                &1000i128,
+            )
         });
 
         assert_eq!(client.get_collateralization_ratio(&chain1, &token), 20000); // 200%

--- a/src/bridge/src/lib.rs
+++ b/src/bridge/src/lib.rs
@@ -60,6 +60,7 @@ pub enum DataKey {
 #[contract]
 pub struct Bridge;
 
+#[allow(deprecated)]
 #[contractimpl]
 impl Bridge {
     // -----------------------------------------------------------------------
@@ -560,8 +561,8 @@ mod tests {
         amount: i128,
         op: BridgeOp,
     ) -> BridgeMessage {
-        let message_hash = BytesN::from_array(&env, &[0u8; 32]);
-        let signature = BytesN::from_array(&env, &[0u8; 64]);
+        let message_hash = BytesN::from_array(env, &[0u8; 32]);
+        let signature = BytesN::from_array(env, &[0u8; 64]);
 
         BridgeMessage {
             source_chain,

--- a/src/circuit_breaker/Cargo.toml
+++ b/src/circuit_breaker/Cargo.toml
@@ -4,9 +4,12 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
-soroban-sdk = { version = "26.0.1", features = ["alloc", "testutils"] }
+soroban-sdk = { version = "26.0.1", features = ["alloc"] }
 
 [lib]
 name = "circuit_breaker"
 path = "lib.rs"
 crate-type = ["cdylib", "rlib"]
+
+[dev-dependencies]
+soroban-sdk = { version = "26.0.1", features = ["testutils"] }

--- a/src/circuit_breaker/lib.rs
+++ b/src/circuit_breaker/lib.rs
@@ -67,6 +67,7 @@ pub enum TriggerSource {
 #[contract]
 pub struct CircuitBreaker;
 
+#[allow(deprecated)]
 #[contractimpl]
 impl CircuitBreaker {
     // ── Initialization ────────────────────────────────────────────────────────
@@ -130,7 +131,7 @@ impl CircuitBreaker {
             .get(&DataKey::AuthorizedBots)
             .unwrap_or_else(|| Vec::new(&env));
 
-        assert!((bots.len() as u32) < MAX_BOTS, "bot list is full");
+        assert!(bots.len() < MAX_BOTS, "bot list is full");
 
         for i in 0..bots.len() {
             if bots.get(i).unwrap() == bot {

--- a/src/escrow_timelock/lib.rs
+++ b/src/escrow_timelock/lib.rs
@@ -94,7 +94,7 @@ impl EscrowTimelock {
 
         // Transfer tokens from sender to this contract
         let token_client = token::Client::new(&e, &details.token);
-        token_client.transfer(&sender, &e.current_contract_address(), &amount);
+        token_client.transfer(&sender, e.current_contract_address(), &amount);
     }
 
     /// Mark conditions as met (can only be called by sender)

--- a/src/event_hub/lib.rs
+++ b/src/event_hub/lib.rs
@@ -75,8 +75,6 @@ impl EventHub {
             .instance()
             .set(&DataKey::RegisteredContracts, &contracts);
 
-
-
         env.events()
             .publish((symbol_short!("hub"), symbol_short!("init")), admin);
     }
@@ -313,7 +311,6 @@ impl EventHub {
 
         contracts.keys()
     }
-
 
     fn is_registered_source(env: &Env, contract: &Address) -> bool {
         let contracts: Map<Address, bool> = env
@@ -632,26 +629,26 @@ mod tests {
 
         client.capture_event(&source, &event_type, &event_data);
         assert_eq!(client.get_event_count(), 3);
-     }
+    }
 
-     // ── Pagination ────────────────────────────────────────────────────────────
+    // ── Pagination ────────────────────────────────────────────────────────────
 
-     #[test]
-     fn test_get_events_pagination() {
-         let env = Env::default();
-         env.mock_all_auths();
+    #[test]
+    fn test_get_events_pagination() {
+        let env = Env::default();
+        env.mock_all_auths();
 
-         let contract_id = env.register(EventHub, ());
-         let client = EventHubClient::new(&env, &contract_id);
+        let contract_id = env.register(EventHub, ());
+        let client = EventHubClient::new(&env, &contract_id);
 
-         let admin = Address::generate(&env);
-         client.initialize(&admin);
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
 
-         let source = Address::generate(&env);
-         client.register_contract(&admin, &source);
+        let source = Address::generate(&env);
+        client.register_contract(&admin, &source);
 
-         let event_type = SorobanString::from_str(&env, "evt");
-         let event_data = Bytes::from_slice(&env, b"data");
+        let event_type = SorobanString::from_str(&env, "evt");
+        let event_data = Bytes::from_slice(&env, b"data");
 
         for _ in 0..5 {
             client.capture_event(&source, &event_type, &event_data);

--- a/src/event_hub/lib.rs
+++ b/src/event_hub/lib.rs
@@ -55,6 +55,7 @@ pub struct EventLogEntry {
 #[contract]
 pub struct EventHub;
 
+#[allow(deprecated)]
 #[contractimpl]
 impl EventHub {
     /// Initialize the Event Hub contract

--- a/src/flash_loan/lib.rs
+++ b/src/flash_loan/lib.rs
@@ -59,6 +59,7 @@ pub trait FlashLoanBatchReceiver {
 #[contract]
 pub struct FlashLoanProvider;
 
+#[allow(deprecated)]
 #[contractimpl]
 impl FlashLoanProvider {
     pub fn set_security_registry(env: soroban_sdk::Env, registry: soroban_sdk::Address) {

--- a/src/flash_loan/lib.rs
+++ b/src/flash_loan/lib.rs
@@ -192,9 +192,7 @@ impl FlashLoanProvider {
             if balance_after < expected_repayment {
                 panic!(
                     "Flash loan not repaid for token {:?}: expected {}, got {}",
-                    loan.token,
-                    expected_repayment,
-                    balance_after
+                    loan.token, expected_repayment, balance_after
                 );
             }
         }

--- a/src/flash_loan/tests.rs
+++ b/src/flash_loan/tests.rs
@@ -2,7 +2,8 @@
 mod tests {
     use crate::{FlashLoanProvider, FlashLoanProviderClient, LoanDetail};
     use soroban_sdk::{
-        contract, contractimpl, symbol_short, testutils::Address as _,
+        contract, contractimpl, symbol_short,
+        testutils::Address as _,
         token::{Client as TokenClient, StellarAssetClient},
         Address, Env, Vec,
     };
@@ -19,9 +20,15 @@ mod tests {
             pub fn execute_loan(env: Env, token: Address, amount: i128, fee: i128) {
                 let token_client = TokenClient::new(&env, &token);
                 let total_due = amount + fee;
-                env.storage().instance().set(&symbol_short!("last_tok"), &token);
-                env.storage().instance().set(&symbol_short!("last_amt"), &amount);
-                env.storage().instance().set(&symbol_short!("last_fee"), &fee);
+                env.storage()
+                    .instance()
+                    .set(&symbol_short!("last_tok"), &token);
+                env.storage()
+                    .instance()
+                    .set(&symbol_short!("last_amt"), &amount);
+                env.storage()
+                    .instance()
+                    .set(&symbol_short!("last_fee"), &fee);
 
                 // Transfer back the amount + fee to the provider
                 token_client.transfer(

--- a/src/flash_loan/tests.rs
+++ b/src/flash_loan/tests.rs
@@ -1,4 +1,5 @@
 #[cfg(test)]
+#[allow(clippy::module_inception)]
 mod tests {
     use crate::{FlashLoanProvider, FlashLoanProviderClient, LoanDetail};
     use soroban_sdk::{
@@ -33,7 +34,7 @@ mod tests {
                 // Transfer back the amount + fee to the provider
                 token_client.transfer(
                     &env.current_contract_address(),
-                    &env.storage()
+                    env.storage()
                         .instance()
                         .get::<_, Address>(&symbol_short!("provider"))
                         .unwrap(),
@@ -100,7 +101,7 @@ mod tests {
                 let token_client = TokenClient::new(&env, &token);
                 token_client.transfer(
                     &env.current_contract_address(),
-                    &env.storage()
+                    env.storage()
                         .instance()
                         .get::<_, Address>(&symbol_short!("provider"))
                         .unwrap(),
@@ -222,7 +223,7 @@ mod tests {
                     .unwrap();
 
                 // Only repay the first loan
-                if loans.len() > 0 {
+                if !loans.is_empty() {
                     let loan = loans.get(0).unwrap();
                     let token_client = TokenClient::new(&env, &loan.token);
                     let total_due = loan.amount + loan.fee;

--- a/src/governance/lib.rs
+++ b/src/governance/lib.rs
@@ -101,6 +101,7 @@ pub struct VoteRecord {
 #[contract]
 pub struct GovernanceContract;
 
+#[allow(deprecated)]
 #[contractimpl]
 impl GovernanceContract {
     /// Initialize the governance contract
@@ -222,10 +223,7 @@ impl GovernanceContract {
             .expect("admin not found");
 
         assert!(caller == admin, "only admin can set quorum");
-        assert!(
-            percentage >= 0 && percentage <= 100,
-            "invalid quorum percentage"
-        );
+        assert!((0..=100).contains(&percentage), "invalid quorum percentage");
 
         env.storage()
             .instance()
@@ -1087,7 +1085,7 @@ mod quadratic_voting_tests {
         let record = record.unwrap();
         assert_eq!(record.votes, 15);
         assert_eq!(record.quadratic_cost, 225); // 15^2
-        assert_eq!(record.support, false); // voted against
+        assert!(!record.support); // voted against
     }
 
     #[test]
@@ -1133,7 +1131,12 @@ pub struct MockToken;
 #[cfg(test)]
 #[contractimpl]
 impl MockToken {
-    pub fn get_past_balance(env: Env, owner: Address, token_id: u64, ledger: u32) -> i128 {
+    pub fn get_past_balance(
+        _env: Env,
+        _owner: Address,
+        _token_id: u64,
+        _ledger: u32,
+    ) -> i128 {
         1_000_000i128
     }
 }

--- a/src/governance/lib.rs
+++ b/src/governance/lib.rs
@@ -1131,12 +1131,7 @@ pub struct MockToken;
 #[cfg(test)]
 #[contractimpl]
 impl MockToken {
-    pub fn get_past_balance(
-        _env: Env,
-        _owner: Address,
-        _token_id: u64,
-        _ledger: u32,
-    ) -> i128 {
+    pub fn get_past_balance(_env: Env, _owner: Address, _token_id: u64, _ledger: u32) -> i128 {
         1_000_000i128
     }
 }

--- a/src/indexing/lib.rs
+++ b/src/indexing/lib.rs
@@ -64,7 +64,10 @@ impl IndexingContract {
         env.storage()
             .persistent()
             .set(&DataKey::AddrToId(user), &id);
-        env.storage().instance().set(&DataKey::Counter, &(id.checked_add(1).expect("counter overflow")));
+        env.storage().instance().set(
+            &DataKey::Counter,
+            &(id.checked_add(1).expect("counter overflow")),
+        );
 
         id
     }

--- a/src/kyc/src/lib.rs
+++ b/src/kyc/src/lib.rs
@@ -52,8 +52,10 @@ impl KycVerifier {
             .persistent()
             .set(&DataKey::UserKyc(user.clone()), &expires_at);
         // Topic: event name only; user + expires_at in data.
-        env.events()
-            .publish((symbol_short!("kyc"), symbol_short!("kyc_set")), (user, expires_at));
+        env.events().publish(
+            (symbol_short!("kyc"), symbol_short!("kyc_set")),
+            (user, expires_at),
+        );
     }
 
     pub fn is_kyc_valid(env: Env, user: Address) -> bool {
@@ -88,8 +90,7 @@ impl KycVerifier {
 
         env.storage().persistent().remove(&key);
 
-        env.events()
-            .publish((symbol_short!("kyc_rev"), user), ());
+        env.events().publish((symbol_short!("kyc_rev"), user), ());
     }
 }
 

--- a/src/kyc/src/lib.rs
+++ b/src/kyc/src/lib.rs
@@ -13,6 +13,7 @@ pub enum DataKey {
 #[contract]
 pub struct KycVerifier;
 
+#[allow(deprecated)]
 #[contractimpl]
 impl KycVerifier {
     pub fn initialize(env: Env, admin: Address, verifier_pubkey: BytesN<32>) {

--- a/src/kyc/src/tests.rs
+++ b/src/kyc/src/tests.rs
@@ -49,11 +49,17 @@ fn test_revoke_kyc_removes_record() {
     let user = Address::generate(&env);
     inject_kyc(&env, &contract_id, &user, 999_999);
 
-    assert!(client.is_kyc_valid(&user), "KYC should be valid before revocation");
+    assert!(
+        client.is_kyc_valid(&user),
+        "KYC should be valid before revocation"
+    );
 
     client.revoke_kyc(&user);
 
-    assert!(!client.is_kyc_valid(&user), "KYC should be invalid after revocation");
+    assert!(
+        !client.is_kyc_valid(&user),
+        "KYC should be invalid after revocation"
+    );
 
     // Confirm the key is truly gone from storage, not just expired
     let still_exists = env.as_contract(&contract_id, || {
@@ -91,9 +97,10 @@ fn test_revoke_kyc_rejects_non_admin() {
     // Bootstrap state directly, bypassing auth entirely
     env.as_contract(&contract_id, || {
         env.storage().instance().set(&DataKey::Admin, &admin);
-        env.storage()
-            .instance()
-            .set(&DataKey::VerifierPubKey, &BytesN::from_array(&env, &[1u8; 32]));
+        env.storage().instance().set(
+            &DataKey::VerifierPubKey,
+            &BytesN::from_array(&env, &[1u8; 32]),
+        );
         env.storage()
             .persistent()
             .set(&DataKey::UserKyc(user.clone()), &999_999_u64);

--- a/src/kyc/src/tests.rs
+++ b/src/kyc/src/tests.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use super::*;
 use soroban_sdk::{
     testutils::{Address as _, Ledger},
@@ -41,7 +43,7 @@ fn inject_kyc(env: &Env, contract_id: &Address, user: &Address, expires_at: u64)
 /// and the storage entry is fully removed.
 #[test]
 fn test_revoke_kyc_removes_record() {
-    let (env, contract_id, admin) = setup(true);
+    let (env, contract_id, _admin) = setup(true);
     let client = KycVerifierClient::new(&env, &contract_id);
 
     env.ledger().with_mut(|li| li.timestamp = 1_000);

--- a/src/liquidation/src/lib.rs
+++ b/src/liquidation/src/lib.rs
@@ -18,6 +18,7 @@ pub enum DataKey {
 #[contract]
 pub struct LiquidationEngine;
 
+#[allow(deprecated)]
 #[contractimpl]
 impl LiquidationEngine {
     pub fn initialize(env: Env, oracle_id: Address) {

--- a/src/liquidation/src/lib.rs
+++ b/src/liquidation/src/lib.rs
@@ -38,7 +38,7 @@ impl LiquidationEngine {
             debt_amount: debt,
         };
         env.storage().persistent().set(&DataKey::Vaults(id), &vault);
-        
+
         id = id.checked_add(1).expect("vault id overflow");
 
         id += 1;
@@ -56,23 +56,40 @@ impl LiquidationEngine {
 
         let oracle_id: Address = env.storage().instance().get(&DataKey::OracleId).unwrap();
 
-        let collateral_price: u128 = env.invoke_contract(&oracle_id, &symbol_short!("get_price"), soroban_sdk::vec![&env]);
-        
-        let collateral_value = vault.collateral_amount.checked_mul(collateral_price).expect("value overflow");
+        let collateral_price: u128 = env.invoke_contract(
+            &oracle_id,
+            &symbol_short!("get_price"),
+            soroban_sdk::vec![&env],
+        );
+
+        let collateral_value = vault
+            .collateral_amount
+            .checked_mul(collateral_price)
+            .expect("value overflow");
         // Assume debt is represented in same base units. Health factor * 100
-        let health_factor = collateral_value.checked_mul(100).expect("health factor overflow") / vault.debt_amount;
-        
+        let health_factor = collateral_value
+            .checked_mul(100)
+            .expect("health factor overflow")
+            / vault.debt_amount;
+
         assert!(health_factor < 120, "vault is healthy"); // 120% min health factor
 
         // Liquidator incentive: 5% spread + 10 units fixed fee
-        let incentive = vault.collateral_amount.checked_mul(5).expect("incentive overflow") / 100 + 10;
+        let incentive = vault
+            .collateral_amount
+            .checked_mul(5)
+            .expect("incentive overflow")
+            / 100
+            + 10;
         let _liquidated_collateral = vault.collateral_amount;
 
         vault.collateral_amount = 0;
         vault.debt_amount = 0; // Assume debt fully cleared by liquidation
-        
-        env.storage().persistent().set(&DataKey::Vaults(vault_id), &vault);
-        
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Vaults(vault_id), &vault);
+
         // Topic: event name only; vault_id (u32) + liquidator + incentive in data.
         env.events().publish(
             (symbol_short!("amm"), symbol_short!("liquidate")),
@@ -84,39 +101,55 @@ impl LiquidationEngine {
     /// liquidate_amount: The amount of debt to repay through partial liquidation.
     pub fn partial_liquidate(env: Env, liquidator: Address, vault_id: u32, liquidate_amount: u128) {
         liquidator.require_auth();
-        let mut vault: Vault = env.storage().persistent().get(&DataKey::Vaults(vault_id)).expect("vault not found");
-        
+        let mut vault: Vault = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Vaults(vault_id))
+            .expect("vault not found");
+
         assert!(liquidate_amount > 0, "liquidate amount must be positive");
-        assert!(liquidate_amount <= vault.debt_amount, "cannot liquidate more than debt");
-        
+        assert!(
+            liquidate_amount <= vault.debt_amount,
+            "cannot liquidate more than debt"
+        );
+
         let oracle_id: Address = env.storage().instance().get(&DataKey::OracleId).unwrap();
-        
+
         // Fetch collateral price from oracle
-        let collateral_price: u128 = env.invoke_contract(&oracle_id, &symbol_short!("get_price"), soroban_sdk::vec![&env]);
-        
+        let collateral_price: u128 = env.invoke_contract(
+            &oracle_id,
+            &symbol_short!("get_price"),
+            soroban_sdk::vec![&env],
+        );
+
         let collateral_value = vault.collateral_amount * collateral_price;
         let health_factor = (collateral_value * 100) / vault.debt_amount;
-        
+
         // Allow partial liquidation for vaults below 150% health factor (less strict than full liquidation)
-        assert!(health_factor < 150, "vault is healthy for partial liquidation");
-        
+        assert!(
+            health_factor < 150,
+            "vault is healthy for partial liquidation"
+        );
+
         // Calculate collateral to liquidate proportional to debt being repaid
         let collateral_ratio = vault.collateral_amount / vault.debt_amount;
         let collateral_to_liquidate = liquidate_amount * collateral_ratio;
-        
+
         // Liquidator incentive: 3% spread for partial liquidations (lower incentive than full)
         let incentive = (collateral_to_liquidate * 3) / 100;
-        
+
         // Update vault
         vault.collateral_amount -= collateral_to_liquidate + incentive;
         vault.debt_amount -= liquidate_amount;
-        
-        env.storage().persistent().set(&DataKey::Vaults(vault_id), &vault);
-        
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Vaults(vault_id), &vault);
+
         // Emit partial liquidation event
         env.events().publish(
-            (symbol_short!("p_liquid"), vault_id, liquidator), 
-            (liquidate_amount, collateral_to_liquidate, incentive)
+            (symbol_short!("p_liquid"), vault_id, liquidator),
+            (liquidate_amount, collateral_to_liquidate, incentive),
         );
     }
 }

--- a/src/oracle_consumer/lib.rs
+++ b/src/oracle_consumer/lib.rs
@@ -29,6 +29,7 @@ pub enum DataKey {
 #[contract]
 pub struct OracleConsumer;
 
+#[allow(deprecated)]
 #[contractimpl]
 impl OracleConsumer {
     /// Initializes the consumer with an admin and the initial oracle source.
@@ -286,7 +287,7 @@ impl OracleConsumer {
             .unwrap_or(DEFAULT_MAX_OBSERVATIONS);
 
         let mut history = Self::get_price_history(env, asset.clone());
-        let last_timestamp = if history.len() > 0 {
+        let last_timestamp = if !history.is_empty() {
             Some(history.get(history.len() - 1).unwrap().timestamp)
         } else {
             None

--- a/src/oracle_consumer/lib.rs
+++ b/src/oracle_consumer/lib.rs
@@ -68,7 +68,10 @@ impl OracleConsumer {
             (asset.clone(),).into_val(&env),
         );
 
-        assert!(price_info.asset == asset, "oracle returned mismatched asset");
+        assert!(
+            price_info.asset == asset,
+            "oracle returned mismatched asset"
+        );
         assert!(price_info.price > 0, "oracle returned non-positive price");
 
         env.storage()
@@ -77,8 +80,10 @@ impl OracleConsumer {
         Self::store_observation(&env, asset.clone(), price_info.clone());
 
         // Topic: event name only; asset + price in data.
-        env.events()
-            .publish((symbol_short!("oracle"), symbol_short!("price_upd")), (asset, price_info.price));
+        env.events().publish(
+            (symbol_short!("oracle"), symbol_short!("price_upd")),
+            (asset, price_info.price),
+        );
 
         price_info
     }
@@ -359,7 +364,12 @@ mod tests {
         env.ledger().set(ledger);
     }
 
-    fn setup() -> (Env, OracleConsumerClient<'static>, Address, MockOracleClient<'static>) {
+    fn setup() -> (
+        Env,
+        OracleConsumerClient<'static>,
+        Address,
+        MockOracleClient<'static>,
+    ) {
         let env = Env::default();
         env.mock_all_auths();
 
@@ -378,7 +388,10 @@ mod tests {
     fn test_initialization() {
         let (_env, client, _admin, oracle) = setup();
         assert_eq!(client.get_oracle(), oracle.address.clone());
-        assert_eq!(client.get_default_twap_window(), DEFAULT_TWAP_WINDOW_SECONDS);
+        assert_eq!(
+            client.get_default_twap_window(),
+            DEFAULT_TWAP_WINDOW_SECONDS
+        );
         assert_eq!(client.get_max_price_age(), DEFAULT_MAX_PRICE_AGE_SECONDS);
         assert_eq!(client.get_max_observations(), DEFAULT_MAX_OBSERVATIONS);
     }

--- a/src/oracle_medianizer/lib.rs
+++ b/src/oracle_medianizer/lib.rs
@@ -300,7 +300,10 @@ impl OracleMedianizer {
             }
         }
 
-        assert!(prices.len() >= min_sources, "insufficient valid price feeds");
+        assert!(
+            prices.len() >= min_sources,
+            "insufficient valid price feeds"
+        );
 
         // Sort prices for median calculation
         prices = Self::sort_prices(&env, prices);
@@ -338,7 +341,10 @@ impl OracleMedianizer {
             }
         }
 
-        assert!(filtered_prices.len() >= min_sources, "too many outliers removed");
+        assert!(
+            filtered_prices.len() >= min_sources,
+            "too many outliers removed"
+        );
 
         // Sort filtered prices
         filtered_prices = Self::sort_prices(&env, filtered_prices);

--- a/src/oracle_medianizer/lib.rs
+++ b/src/oracle_medianizer/lib.rs
@@ -56,6 +56,7 @@ pub enum DataKey {
 #[contract]
 pub struct OracleMedianizer;
 
+#[allow(deprecated)]
 #[contractimpl]
 impl OracleMedianizer {
     /// Initialize the oracle medianizer
@@ -299,10 +300,7 @@ impl OracleMedianizer {
             }
         }
 
-        assert!(
-            prices.len() >= min_sources as u32,
-            "insufficient valid price feeds"
-        );
+        assert!(prices.len() >= min_sources, "insufficient valid price feeds");
 
         // Sort prices for median calculation
         prices = Self::sort_prices(&env, prices);
@@ -340,17 +338,14 @@ impl OracleMedianizer {
             }
         }
 
-        assert!(
-            filtered_prices.len() >= min_sources as u32,
-            "too many outliers removed"
-        );
+        assert!(filtered_prices.len() >= min_sources, "too many outliers removed");
 
         // Sort filtered prices
         filtered_prices = Self::sort_prices(&env, filtered_prices);
 
         // Calculate median
         let len = filtered_prices.len();
-        let median = if len % 2 == 0 {
+        let median = if len.is_multiple_of(2) {
             // Even number: average of two middle values
             let mid1 = filtered_prices.get_unchecked(len / 2 - 1);
             let mid2 = filtered_prices.get_unchecked(len / 2);
@@ -478,11 +473,7 @@ impl OracleMedianizer {
         }
 
         // If no previous price, always update
-        if env.storage().instance().has(&DataKey::MedianPrice(asset)) {
-            false
-        } else {
-            true
-        }
+        !env.storage().instance().has(&DataKey::MedianPrice(asset))
     }
 
     /// Sort prices in ascending order (bubble sort for simplicity)

--- a/src/oracle_medianizer/lib.rs
+++ b/src/oracle_medianizer/lib.rs
@@ -115,7 +115,10 @@ impl OracleMedianizer {
             .get(&DataKey::OracleCount)
             .unwrap_or(0);
 
-        env.storage().instance().set(&DataKey::OracleCount, &count.checked_add(1).expect("oracle count overflow"));
+        env.storage().instance().set(
+            &DataKey::OracleCount,
+            &count.checked_add(1).expect("oracle count overflow"),
+        );
 
         // Topic: event name + oracle Address (needed for indexing source changes).
         env.events().publish(
@@ -163,10 +166,8 @@ impl OracleMedianizer {
         }
 
         // Topic: event name only; oracle Address in data.
-        env.events().publish(
-            (symbol_short!("orcl_rm"),),
-            oracle.clone(),
-        );
+        env.events()
+            .publish((symbol_short!("orcl_rm"),), oracle.clone());
         env.events()
             .publish((symbol_short!("oracle"), oracle), symbol_short!("removed"));
     }
@@ -307,13 +308,16 @@ impl OracleMedianizer {
         prices = Self::sort_prices(&env, prices);
 
         // Calculate mean for outlier detection
-        let sum: i128 = prices.iter().fold(0i128, |acc, p| acc.checked_add(p).expect("sum overflow"));
+        let sum: i128 = prices
+            .iter()
+            .fold(0i128, |acc, p| acc.checked_add(p).expect("sum overflow"));
         let mean = sum / prices.len() as i128;
 
         // Calculate standard deviation
         let variance_sum: i128 = prices.iter().fold(0i128, |acc, p| {
             let diff = p - mean;
-            acc.checked_add(diff.checked_mul(diff).expect("variance overflow")).expect("variance overflow")
+            acc.checked_add(diff.checked_mul(diff).expect("variance overflow"))
+                .expect("variance overflow")
         });
         let variance = variance_sum / prices.len() as i128;
 
@@ -364,9 +368,10 @@ impl OracleMedianizer {
             env.storage()
                 .instance()
                 .set(&DataKey::MedianPrice(asset.clone()), &median);
-            env.storage()
-                .instance()
-                .set(&DataKey::LastUpdate(asset.clone()), &env.ledger().timestamp());
+            env.storage().instance().set(
+                &DataKey::LastUpdate(asset.clone()),
+                &env.ledger().timestamp(),
+            );
 
             // Topic: event name only; asset + median in data.
             env.events().publish(
@@ -435,7 +440,11 @@ impl OracleMedianizer {
                 .get(&DataKey::LastUpdate(asset.clone()))
                 .unwrap_or(0);
 
-            if current_time > last_update.checked_add(heartbeat).expect("heartbeat overflow") {
+            if current_time
+                > last_update
+                    .checked_add(heartbeat)
+                    .expect("heartbeat overflow")
+            {
                 return true; // Heartbeat exceeded
             }
         }
@@ -458,7 +467,8 @@ impl OracleMedianizer {
                         old_price - new_price
                     };
 
-                    let deviation_bps = deviation.checked_mul(10000).expect("deviation overflow") / old_price;
+                    let deviation_bps =
+                        deviation.checked_mul(10000).expect("deviation overflow") / old_price;
 
                     if deviation_bps >= deviation_threshold_bps as i128 {
                         return true; // Deviation threshold exceeded

--- a/src/proxy/lib.rs
+++ b/src/proxy/lib.rs
@@ -40,6 +40,7 @@ pub enum DataKey {
 #[contract]
 pub struct ProxyContract;
 
+#[allow(deprecated)]
 #[contractimpl]
 impl ProxyContract {
     // ── Initialisation ────────────────────────────────────────────────────────
@@ -171,7 +172,7 @@ mod tests {
 
     // ── Helpers ───────────────────────────────────────────────────────────────
 
-    fn setup(env: &Env) -> (ProxyContractClient, Address, Address) {
+    fn setup(env: &Env) -> (ProxyContractClient<'_>, Address, Address) {
         env.mock_all_auths();
         let admin = Address::generate(env);
         let impl_id = env.register(MockImpl, ());

--- a/src/random/lib.rs
+++ b/src/random/lib.rs
@@ -57,6 +57,7 @@ pub enum DataKey {
 #[contract]
 pub struct RandomNumberGenerator;
 
+#[allow(deprecated)]
 #[contractimpl]
 impl RandomNumberGenerator {
     /// Initialize the random number generator contract

--- a/src/random/lib.rs
+++ b/src/random/lib.rs
@@ -191,9 +191,10 @@ impl RandomNumberGenerator {
             .get(&DataKey::CommitCount(round_id))
             .unwrap_or(0);
 
-        env.storage()
-            .instance()
-            .set(&DataKey::CommitCount(round_id), &commit_count.checked_add(1).expect("commit count overflow"));
+        env.storage().instance().set(
+            &DataKey::CommitCount(round_id),
+            &commit_count.checked_add(1).expect("commit count overflow"),
+        );
 
         // Topic: event name + round_id (u32 scalar); user Address in data.
         env.events().publish(
@@ -323,15 +324,14 @@ impl RandomNumberGenerator {
             .get(&DataKey::RevealCount(round_id))
             .unwrap_or(0);
 
-        env.storage()
-            .instance()
-            .set(&DataKey::RevealCount(round_id), &reveal_count.checked_add(1).expect("reveal count overflow"));
+        env.storage().instance().set(
+            &DataKey::RevealCount(round_id),
+            &reveal_count.checked_add(1).expect("reveal count overflow"),
+        );
 
         // Topic: event name + round_id (u32 scalar); user Address in data.
-        env.events().publish(
-            (symbol_short!("reveal"), round_id),
-            user,
-        );
+        env.events()
+            .publish((symbol_short!("reveal"), round_id), user);
     }
 
     /// Compute the final random seed by hashing all revealed secrets

--- a/src/security_registry/lib.rs
+++ b/src/security_registry/lib.rs
@@ -69,13 +69,13 @@ mod tests {
         let client = SecurityRegistryClient::new(&env, &contract_id);
 
         client.initialize(&admin);
-        assert_eq!(client.is_paused(), false);
+        assert!(!client.is_paused());
 
         env.mock_all_auths();
         client.pause(&admin);
-        assert_eq!(client.is_paused(), true);
+        assert!(client.is_paused());
 
         client.unpause(&admin);
-        assert_eq!(client.is_paused(), false);
+        assert!(!client.is_paused());
     }
 }

--- a/src/staking/lib.rs
+++ b/src/staking/lib.rs
@@ -1,12 +1,14 @@
 #![no_std]
-use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, token, vec, Address, Env, Vec};
+use soroban_sdk::{
+    contract, contractimpl, contracttype, symbol_short, token, vec, Address, Env, Vec,
+};
 
 #[contracttype]
 pub enum DataKey {
     Admin,
     Token,
-    BaseRate,   // Base rewards per second per token (scaled by 1e7)
-    Tiers,      // Vec<LockTier>
+    BaseRate, // Base rewards per second per token (scaled by 1e7)
+    Tiers,    // Vec<LockTier>
     PenaltyBps,
     Stake(Address),
 }
@@ -62,17 +64,33 @@ impl StakingContract {
         env.storage().instance().set(&DataKey::Admin, &admin);
         env.storage().instance().set(&DataKey::Token, &token);
         env.storage().instance().set(&DataKey::BaseRate, &base_rate);
-        env.storage().instance().set(&DataKey::PenaltyBps, &penalty_bps);
+        env.storage()
+            .instance()
+            .set(&DataKey::PenaltyBps, &penalty_bps);
 
         // Default tiers: 1 month (1x), 3 months (1.25x), 6 months (1.5x), 12 months (2x)
         let default_tiers: Vec<LockTier> = vec![
             &env,
-            LockTier { lock_seconds: 30 * 24 * 3600,  rate_multiplier: 100 },
-            LockTier { lock_seconds: 90 * 24 * 3600,  rate_multiplier: 125 },
-            LockTier { lock_seconds: 180 * 24 * 3600, rate_multiplier: 150 },
-            LockTier { lock_seconds: 365 * 24 * 3600, rate_multiplier: 200 },
+            LockTier {
+                lock_seconds: 30 * 24 * 3600,
+                rate_multiplier: 100,
+            },
+            LockTier {
+                lock_seconds: 90 * 24 * 3600,
+                rate_multiplier: 125,
+            },
+            LockTier {
+                lock_seconds: 180 * 24 * 3600,
+                rate_multiplier: 150,
+            },
+            LockTier {
+                lock_seconds: 365 * 24 * 3600,
+                rate_multiplier: 200,
+            },
         ];
-        env.storage().instance().set(&DataKey::Tiers, &default_tiers);
+        env.storage()
+            .instance()
+            .set(&DataKey::Tiers, &default_tiers);
     }
 
     pub fn set_tiers(env: Env, tiers: Vec<LockTier>) {
@@ -87,9 +105,16 @@ impl StakingContract {
     }
 
     pub fn stake(env: Env, user: Address, amount: i128, tier_index: u32) {
-
-        if let Some(registry) = env.storage().instance().get::<_, soroban_sdk::Address>(&soroban_sdk::symbol_short!("sec_reg")) {
-            let is_paused: bool = env.invoke_contract(&registry, &soroban_sdk::Symbol::new(&env, "is_paused"), soroban_sdk::vec![&env]);
+        if let Some(registry) = env
+            .storage()
+            .instance()
+            .get::<_, soroban_sdk::Address>(&soroban_sdk::symbol_short!("sec_reg"))
+        {
+            let is_paused: bool = env.invoke_contract(
+                &registry,
+                &soroban_sdk::Symbol::new(&env, "is_paused"),
+                soroban_sdk::vec![&env],
+            );
             if is_paused {
                 panic!("contract is paused");
             }
@@ -120,8 +145,13 @@ impl StakingContract {
             info.rate_multiplier = tier.rate_multiplier;
         }
 
-        env.storage().persistent().set(&DataKey::Stake(user.clone()), &info);
-        env.events().publish((symbol_short!("staking"), symbol_short!("stake")), (user, amount, info.lock_end, info.rate_multiplier));
+        env.storage()
+            .persistent()
+            .set(&DataKey::Stake(user.clone()), &info);
+        env.events().publish(
+            (symbol_short!("staking"), symbol_short!("stake")),
+            (user, amount, info.lock_end, info.rate_multiplier),
+        );
     }
 
     pub fn withdraw(env: Env, user: Address) {
@@ -146,7 +176,8 @@ impl StakingContract {
 
         let current_time = env.ledger().timestamp();
         let base_rate: i128 = env.storage().instance().get(&DataKey::BaseRate).unwrap();
-        let rewards = info.accumulated_rewards + Self::calc_new_rewards(base_rate, &info, current_time);
+        let rewards =
+            info.accumulated_rewards + Self::calc_new_rewards(base_rate, &info, current_time);
         let mut amount_to_return = info.amount;
 
         if current_time < info.lock_end {
@@ -157,15 +188,22 @@ impl StakingContract {
             // Or just lost.
         }
 
-        let total_to_send = amount_to_return.checked_add(rewards).expect("total overflow");
+        let total_to_send = amount_to_return
+            .checked_add(rewards)
+            .expect("total overflow");
 
-        env.storage().persistent().remove(&DataKey::Stake(user.clone()));
+        env.storage()
+            .persistent()
+            .remove(&DataKey::Stake(user.clone()));
 
         let token_addr: Address = env.storage().instance().get(&DataKey::Token).unwrap();
         let token_client = token::Client::new(&env, &token_addr);
         token_client.transfer(&env.current_contract_address(), &user, &total_to_send);
 
-        env.events().publish((symbol_short!("staking"), symbol_short!("withdraw")), (user, amount_to_return, rewards));
+        env.events().publish(
+            (symbol_short!("staking"), symbol_short!("withdraw")),
+            (user, amount_to_return, rewards),
+        );
     }
 
     pub fn claim_rewards(env: Env, user: Address) {
@@ -188,18 +226,24 @@ impl StakingContract {
         let mut info = Self::get_stake_info(env.clone(), user.clone());
         let current_time = env.ledger().timestamp();
         let base_rate: i128 = env.storage().instance().get(&DataKey::BaseRate).unwrap();
-        let rewards = info.accumulated_rewards + Self::calc_new_rewards(base_rate, &info, current_time);
+        let rewards =
+            info.accumulated_rewards + Self::calc_new_rewards(base_rate, &info, current_time);
         assert!(rewards > 0, "no rewards to claim");
 
         info.accumulated_rewards = 0;
         info.last_updated = current_time;
-        env.storage().persistent().set(&DataKey::Stake(user.clone()), &info);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Stake(user.clone()), &info);
 
         let token_addr: Address = env.storage().instance().get(&DataKey::Token).unwrap();
         let token_client = token::Client::new(&env, &token_addr);
         token_client.transfer(&env.current_contract_address(), &user, &rewards);
 
-        env.events().publish((symbol_short!("staking"), symbol_short!("claim")), (user, rewards));
+        env.events().publish(
+            (symbol_short!("staking"), symbol_short!("claim")),
+            (user, rewards),
+        );
     }
 
     pub fn get_stake_info(env: Env, user: Address) -> StakeInfo {
@@ -236,17 +280,27 @@ impl StakingContract {
 mod tests {
     extern crate std;
     use super::*;
-    use soroban_sdk::{testutils::{Address as _, Ledger}, Env, Address, symbol_short, token::{self, StellarAssetClient}};
+    use soroban_sdk::{
+        symbol_short,
+        testutils::{Address as _, Ledger},
+        token::{self, StellarAssetClient},
+        Address, Env,
+    };
 
     #[contract]
     pub struct MockRegistry;
     #[contractimpl]
     impl MockRegistry {
         pub fn is_paused(env: Env) -> bool {
-            env.storage().instance().get(&symbol_short!("paused")).unwrap_or(false)
+            env.storage()
+                .instance()
+                .get(&symbol_short!("paused"))
+                .unwrap_or(false)
         }
         pub fn set_paused(env: Env, paused: bool) {
-            env.storage().instance().set(&symbol_short!("paused"), &paused);
+            env.storage()
+                .instance()
+                .set(&symbol_short!("paused"), &paused);
         }
     }
 
@@ -256,17 +310,22 @@ mod tests {
         env.ledger().set_timestamp(12345);
         let id = env.register(StakingContract, ());
         let client = StakingContractClient::new(&env, &id);
-        
+
         let admin = Address::generate(&env);
         let token_admin = Address::generate(&env);
-        let token_id = env.register_stellar_asset_contract_v2(token_admin).address();
-        
+        let token_id = env
+            .register_stellar_asset_contract_v2(token_admin)
+            .address();
+
         client.initialize(&admin, &token_id, &1000, &1000); // 10% penalty, 1hr lock
-        
+
         // Define tiers matching the test expectations!
         let test_tiers = vec![
             &env,
-            LockTier { lock_seconds: 3600, rate_multiplier: 100 },
+            LockTier {
+                lock_seconds: 3600,
+                rate_multiplier: 100,
+            },
         ];
         client.set_tiers(&test_tiers);
 
@@ -286,18 +345,18 @@ mod tests {
     fn test_stake() {
         let (env, client, _admin, token_id) = setup();
         let user = Address::generate(&env);
-        
+
         let token_client = token::Client::new(&env, &token_id);
         let stellar_asset_client = StellarAssetClient::new(&env, &token_id);
         stellar_asset_client.mint(&user, &10000);
-        
+
         client.stake(&user, &1000, &0);
-        
+
         let info = client.get_stake_info(&user);
         assert_eq!(info.amount, 1000);
         assert_eq!(info.accumulated_rewards, 0);
         assert_eq!(info.lock_end, env.ledger().timestamp() + 3600);
-        
+
         assert_eq!(token_client.balance(&user), 9000);
         assert_eq!(token_client.balance(&client.address), 1000);
     }
@@ -309,12 +368,12 @@ mod tests {
         let token_client = token::Client::new(&env, &token_id);
         let stellar_asset_client = StellarAssetClient::new(&env, &token_id);
         stellar_asset_client.mint(&user, &10000);
-        
+
         client.stake(&user, &1000, &0);
-        
+
         // Withdraw immediately (before lock_end)
         client.withdraw(&user);
-        
+
         // 10% penalty on 1000 = 100. Should get 900 back.
         assert_eq!(token_client.balance(&user), 9900);
         let info = client.get_stake_info(&user);
@@ -328,17 +387,17 @@ mod tests {
         let token_client = token::Client::new(&env, &token_id);
         let stellar_asset_client = StellarAssetClient::new(&env, &token_id);
         stellar_asset_client.mint(&user, &10000);
-        
+
         client.stake(&user, &1000, &0);
-        
+
         // Advance time 4000s (> 3600s lock)
         env.ledger().set_timestamp(env.ledger().timestamp() + 4000);
-        
+
         // Fund contract with extra reward tokens so it can pay out rewards
         stellar_asset_client.mint(&client.address, &400);
 
         client.withdraw(&user);
-        
+
         // rewards = (1000 * 1000 * 4000) / 10,000,000 = 400
         assert_eq!(token_client.balance(&user), 9000 + 1000 + 400);
     }
@@ -350,16 +409,16 @@ mod tests {
         let token_client = token::Client::new(&env, &token_id);
         let stellar_asset_client = StellarAssetClient::new(&env, &token_id);
         stellar_asset_client.mint(&user, &10000);
-        
+
         client.stake(&user, &1000, &0);
-        
+
         env.ledger().set_timestamp(env.ledger().timestamp() + 1000);
-        
+
         client.claim_rewards(&user);
-        
+
         // rewards = 100
         assert_eq!(token_client.balance(&user), 9000 + 100);
-        
+
         let info = client.get_stake_info(&user);
         assert_eq!(info.amount, 1000);
         assert_eq!(info.accumulated_rewards, 0);
@@ -370,13 +429,13 @@ mod tests {
     fn test_pause_functionality() {
         let (env, client, _admin, _token_id) = setup();
         let user = Address::generate(&env);
-        
+
         let registry_id = env.register(MockRegistry, ());
         let registry_client = MockRegistryClient::new(&env, &registry_id);
         registry_client.set_paused(&true);
-        
+
         client.set_security_registry(&registry_id);
-        
+
         client.stake(&user, &100, &0);
     }
 
@@ -416,4 +475,3 @@ mod tests {
         client.claim_rewards(&user);
     }
 }
-

--- a/src/staking/lib.rs
+++ b/src/staking/lib.rs
@@ -35,6 +35,7 @@ const REWARD_PRECISION: i128 = 10_000_000;
 #[contract]
 pub struct StakingContract;
 
+#[allow(deprecated)]
 #[contractimpl]
 impl StakingContract {
     pub fn set_security_registry(env: soroban_sdk::Env, registry: soroban_sdk::Address) {
@@ -96,7 +97,7 @@ impl StakingContract {
     pub fn set_tiers(env: Env, tiers: Vec<LockTier>) {
         let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
         admin.require_auth();
-        assert!(tiers.len() > 0, "need at least one tier");
+        assert!(!tiers.is_empty(), "need at least one tier");
         env.storage().instance().set(&DataKey::Tiers, &tiers);
     }
 
@@ -124,12 +125,12 @@ impl StakingContract {
         assert!(amount > 0, "amount must be positive");
 
         let tiers: Vec<LockTier> = env.storage().instance().get(&DataKey::Tiers).unwrap();
-        assert!((tier_index as u32) < tiers.len(), "invalid tier");
+        assert!(tier_index < tiers.len(), "invalid tier");
         let tier = tiers.get(tier_index).unwrap();
 
         let token_addr: Address = env.storage().instance().get(&DataKey::Token).unwrap();
         let token_client = token::Client::new(&env, &token_addr);
-        token_client.transfer(&user, &env.current_contract_address(), &amount);
+        token_client.transfer(&user, env.current_contract_address(), &amount);
 
         let mut info = Self::get_stake_info(env.clone(), user.clone());
         let current_time = env.ledger().timestamp();

--- a/src/token/lib.rs
+++ b/src/token/lib.rs
@@ -24,6 +24,7 @@ pub enum DataKey {
 #[contract]
 pub struct TokenContract;
 
+#[allow(deprecated)]
 #[contractimpl]
 impl TokenContract {
     pub fn initialize(env: Env, admin: Address, decimals: u32, name: String, symbol: String) {

--- a/src/token/lib.rs
+++ b/src/token/lib.rs
@@ -2,7 +2,8 @@
 //! SEP-41 Compatible Token Wrapper
 
 use soroban_sdk::{
-    contract, contractimpl, contracttype, symbol_short, Address, Env, IntoVal, String,};
+    contract, contractimpl, contracttype, symbol_short, Address, Env, IntoVal, String,
+};
 
 #[contracttype]
 pub enum DataKey {
@@ -17,7 +18,8 @@ pub enum DataKey {
     Decimals,
     PermitNonce(u64, Address, Address),
     UserLastLedger(u64, Address),
-    BalanceSnapshot(u64, Address, u32),}
+    BalanceSnapshot(u64, Address, u32),
+}
 
 #[contract]
 pub struct TokenContract;
@@ -366,13 +368,17 @@ impl TokenContract {
                 &current_ledger,
             );
         }
-    }}
+    }
+}
 
 #[cfg(test)]
 mod tests {
     extern crate std;
     use super::*;
-    use soroban_sdk::{testutils::{Address as _, Ledger}, Env, String};
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger},
+        Env, String,
+    };
 
     fn setup() -> (Env, TokenContractClient<'static>, Address) {
         let env = Env::default();
@@ -593,447 +599,448 @@ mod tests {
         assert_eq!(client.get_token_metadata(&token_id), uri);
     }
 
-/// ============================================================================
-/// Formal Verification Invariants
-/// ============================================================================
-/// These tests verify critical invariants that must hold for all valid states
-/// and operations of the token contract. They use property-based testing
-/// patterns to ensure mathematical correctness.
-#[cfg(test)]
-mod invariants {
-    extern crate std;
-    use super::*;
-    use soroban_sdk::{Env, String};
+    /// ============================================================================
+    /// Formal Verification Invariants
+    /// ============================================================================
+    /// These tests verify critical invariants that must hold for all valid states
+    /// and operations of the token contract. They use property-based testing
+    /// patterns to ensure mathematical correctness.
+    #[cfg(test)]
+    mod invariants {
+        extern crate std;
+        use super::*;
+        use soroban_sdk::{Env, String};
 
-    /// Helper to set up a fresh contract instance
-    fn setup_fresh() -> (Env, TokenContractClient<'static>, Address) {
-        let env = Env::default();
-        env.mock_all_auths();
-        let id = env.register(TokenContract, ());
-        let client = TokenContractClient::new(&env, &id);
-        let admin = Address::generate(&env);
-        client.initialize(
-            &admin,
-            &7u32,
-            &String::from_str(&env, "AnchorToken"),
-            &String::from_str(&env, "ANCT"),
-        );
-        (env, client, admin)
+        /// Helper to set up a fresh contract instance
+        fn setup_fresh() -> (Env, TokenContractClient<'static>, Address) {
+            let env = Env::default();
+            env.mock_all_auths();
+            let id = env.register(TokenContract, ());
+            let client = TokenContractClient::new(&env, &id);
+            let admin = Address::generate(&env);
+            client.initialize(
+                &admin,
+                &7u32,
+                &String::from_str(&env, "AnchorToken"),
+                &String::from_str(&env, "ANCT"),
+            );
+            (env, client, admin)
+        }
+
+        // =========================================================================
+        // INVARIANT 1: Conservation of Supply
+        // =========================================================================
+        /// After any operation, the sum of all user balances must equal total_supply.
+        /// This is the fundamental invariant of any token contract.
+        #[test]
+        fn invariant_supply_conservation_after_mint() {
+            let (env, client, _) = setup_fresh();
+            let user1 = Address::generate(&env);
+            let user2 = Address::generate(&env);
+            let user3 = Address::generate(&env);
+            let token_id = 1u64;
+
+            // Mint to multiple users
+            client.mint(&user1, &token_id, &1000);
+            client.mint(&user2, &token_id, &500);
+            client.mint(&user3, &token_id, &250);
+
+            let balance_sum = client.balance_of(&user1, &token_id)
+                + client.balance_of(&user2, &token_id)
+                + client.balance_of(&user3, &token_id);
+
+            // Invariant: sum of balances equals total supply
+            assert_eq!(
+                client.total_supply(&token_id),
+                balance_sum,
+                "INVARIANT VIOLATION: Supply conservation failed after mint"
+            );
+        }
+
+        #[test]
+        fn invariant_supply_conservation_after_transfer() {
+            let (env, client, _) = setup_fresh();
+            let alice = Address::generate(&env);
+            let bob = Address::generate(&env);
+            let carol = Address::generate(&env);
+            let token_id = 1u64;
+
+            client.mint(&alice, &token_id, &1000);
+
+            let supply_before = client.total_supply(&token_id);
+
+            // Multiple transfers
+            client.transfer(&alice, &bob, &token_id, &300);
+            client.transfer(&bob, &carol, &token_id, &150);
+            client.transfer(&alice, &carol, &token_id, &100);
+
+            let supply_after = client.total_supply(&token_id);
+
+            // Invariant: transfers do not change total supply
+            assert_eq!(
+                supply_before, supply_after,
+                "INVARIANT VIOLATION: Supply changed during transfers"
+            );
+
+            // Invariant: sum of balances still equals supply
+            let balance_sum = client.balance_of(&alice, &token_id)
+                + client.balance_of(&bob, &token_id)
+                + client.balance_of(&carol, &token_id);
+            assert_eq!(
+                supply_after, balance_sum,
+                "INVARIANT VIOLATION: Balance sum doesn't match supply after transfers"
+            );
+        }
+
+        #[test]
+        fn invariant_supply_conservation_after_burn() {
+            let (env, client, _) = setup_fresh();
+            let user = Address::generate(&env);
+            let token_id = 1u64;
+
+            client.mint(&user, &token_id, &1000);
+            let supply_before_burn = client.total_supply(&token_id);
+
+            client.burn(&user, &token_id, &300);
+
+            // Invariant: supply decreases by exactly the burned amount
+            assert_eq!(
+                client.total_supply(&token_id),
+                supply_before_burn - 300,
+                "INVARIANT VIOLATION: Supply not reduced correctly after burn"
+            );
+
+            // Invariant: balance equals remaining supply
+            assert_eq!(
+                client.balance_of(&user, &token_id),
+                client.total_supply(&token_id),
+                "INVARIANT VIOLATION: Balance doesn't match supply after burn"
+            );
+        }
+
+        // =========================================================================
+        // INVARIANT 2: Non-Negative Balances
+        // =========================================================================
+        /// All balances must always be non-negative (>= 0).
+        /// This is enforced by the contract logic, but we verify it holds.
+        #[test]
+        fn invariant_non_negative_balances() {
+            let (env, client, _) = setup_fresh();
+            let user = Address::generate(&env);
+            let token_id = 1u64;
+
+            // Initial balance is 0 (non-negative)
+            assert!(
+                client.balance_of(&user, &token_id) >= 0,
+                "INVARIANT VIOLATION: Initial balance is negative"
+            );
+
+            client.mint(&user, &token_id, &100);
+            assert!(
+                client.balance_of(&user, &token_id) >= 0,
+                "INVARIANT VIOLATION: Balance negative after mint"
+            );
+
+            client.burn(&user, &token_id, &100);
+            assert!(
+                client.balance_of(&user, &token_id) >= 0,
+                "INVARIANT VIOLATION: Balance negative after burn"
+            );
+        }
+
+        // =========================================================================
+        // INVARIANT 3: Conservation of Value in Transfer
+        // =========================================================================
+        /// In any transfer, the sum of sender and receiver balances before
+        /// must equal the sum after the transfer.
+        #[test]
+        fn invariant_transfer_value_conservation() {
+            let (env, client, _) = setup_fresh();
+            let alice = Address::generate(&env);
+            let bob = Address::generate(&env);
+            let token_id = 1u64;
+
+            client.mint(&alice, &token_id, &1000);
+
+            let alice_before = client.balance_of(&alice, &token_id);
+            let bob_before = client.balance_of(&bob, &token_id);
+            let sum_before = alice_before + bob_before;
+
+            client.transfer(&alice, &bob, &token_id, &400);
+
+            let alice_after = client.balance_of(&alice, &token_id);
+            let bob_after = client.balance_of(&bob, &token_id);
+            let sum_after = alice_after + bob_after;
+
+            // Invariant: total value is conserved
+            assert_eq!(
+                sum_before, sum_after,
+                "INVARIANT VIOLATION: Value not conserved in transfer"
+            );
+
+            // Additional checks: exact changes
+            assert_eq!(
+                alice_before - alice_after,
+                400,
+                "INVARIANT VIOLATION: Sender balance not reduced correctly"
+            );
+            assert_eq!(
+                bob_after - bob_before,
+                400,
+                "INVARIANT VIOLATION: Receiver balance not increased correctly"
+            );
+        }
+
+        // =========================================================================
+        // INVARIANT 4: Allowance Accounting
+        // =========================================================================
+        /// After transfer_from, the allowance must decrease by exactly the
+        /// transferred amount.
+        #[test]
+        fn invariant_allowance_decrease_on_transfer_from() {
+            let (env, client, _) = setup_fresh();
+            let owner = Address::generate(&env);
+            let spender = Address::generate(&env);
+            let recipient = Address::generate(&env);
+            let token_id = 1u64;
+
+            client.mint(&owner, &token_id, &1000);
+            client.approve(&owner, &spender, &token_id, &500);
+
+            let allowance_before = client.allowance(&owner, &spender, &token_id);
+
+            client.transfer_from(&spender, &owner, &recipient, &token_id, &200);
+
+            let allowance_after = client.allowance(&owner, &spender, &token_id);
+
+            // Invariant: allowance decreased by exactly the spent amount
+            assert_eq!(
+                allowance_before - allowance_after,
+                200,
+                "INVARIANT VIOLATION: Allowance not reduced correctly"
+            );
+        }
+
+        #[test]
+        #[should_panic]
+        fn invariant_allowance_cannot_exceed_approval() {
+            let (env, client, _) = setup_fresh();
+            let owner = Address::generate(&env);
+            let spender = Address::generate(&env);
+            let recipient = Address::generate(&env);
+            let token_id = 1u64;
+
+            client.mint(&owner, &token_id, &1000);
+            client.approve(&owner, &spender, &token_id, &100);
+
+            // Attempting to spend more than approved should fail
+            client.transfer_from(&spender, &owner, &recipient, &token_id, &150);
+        }
+
+        // =========================================================================
+        // INVARIANT 5: No Double Spend
+        // =========================================================================
+        /// A user cannot spend the same tokens twice (either directly or via approval).
+        #[test]
+        #[should_panic]
+        fn invariant_no_double_spend_direct() {
+            let (env, client, _) = setup_fresh();
+            let alice = Address::generate(&env);
+            let bob = Address::generate(&env);
+            let carol = Address::generate(&env);
+            let token_id = 1u64;
+
+            client.mint(&alice, &token_id, &100);
+
+            // First transfer succeeds
+            client.transfer(&alice, &bob, &token_id, &60);
+
+            // Alice now has 40, trying to spend 60 more should fail
+            client.transfer(&alice, &carol, &token_id, &60);
+        }
+
+        // =========================================================================
+        // INVARIANT 6: Total Supply Monotonicity
+        // =========================================================================
+        /// Total supply only increases via mint and only decreases via burn.
+        /// Transfers do not affect total supply.
+        #[test]
+        fn invariant_supply_only_changes_via_mint_burn() {
+            let (env, client, _) = setup_fresh();
+            let alice = Address::generate(&env);
+            let bob = Address::generate(&env);
+            let token_id = 1u64;
+
+            let initial_supply = client.total_supply(&token_id);
+            assert_eq!(initial_supply, 0);
+
+            // Mint increases supply
+            client.mint(&alice, &token_id, &500);
+            assert_eq!(client.total_supply(&token_id), 500);
+
+            // Transfer does not change supply
+            client.transfer(&alice, &bob, &token_id, &200);
+            assert_eq!(
+                client.total_supply(&token_id),
+                500,
+                "INVARIANT VIOLATION: Transfer changed total supply"
+            );
+
+            // Approve does not change supply
+            client.approve(&alice, &bob, &token_id, &100);
+            assert_eq!(
+                client.total_supply(&token_id),
+                500,
+                "INVARIANT VIOLATION: Approve changed total supply"
+            );
+
+            // Burn decreases supply
+            client.burn(&alice, &token_id, &100);
+            assert_eq!(client.total_supply(&token_id), 400);
+        }
+
+        // =========================================================================
+        // INVARIANT 7: Zero Address Handling
+        // =========================================================================
+        /// The contract should handle zero amounts appropriately.
+        #[test]
+        #[should_panic]
+        fn invariant_mint_zero_rejected() {
+            let (env, client, _) = setup_fresh();
+            let user = Address::generate(&env);
+            let token_id = 1u64;
+
+            client.mint(&user, &token_id, &0);
+        }
+
+        #[test]
+        #[should_panic]
+        fn invariant_burn_zero_rejected() {
+            let (env, client, _) = setup_fresh();
+            let user = Address::generate(&env);
+            let token_id = 1u64;
+
+            client.mint(&user, &token_id, &100);
+            client.burn(&user, &token_id, &0);
+        }
+
+        // =========================================================================
+        // INVARIANT 8: Idempotency Properties
+        // =========================================================================
+        /// Certain operations should have predictable idempotent-like behavior.
+        #[test]
+        fn invariant_approve_overwrites() {
+            let (env, client, _) = setup_fresh();
+            let owner = Address::generate(&env);
+            let spender = Address::generate(&env);
+            let token_id = 1u64;
+
+            client.approve(&owner, &spender, &token_id, &100);
+            assert_eq!(client.allowance(&owner, &spender, &token_id), 100);
+
+            // New approval should overwrite, not add
+            client.approve(&owner, &spender, &token_id, &200);
+            assert_eq!(
+                client.allowance(&owner, &spender, &token_id),
+                200,
+                "INVARIANT VIOLATION: Approve did not overwrite previous allowance"
+            );
+        }
+
+        // =========================================================================
+        // PROPERTY-BASED INVARIANT TESTS
+        // =========================================================================
+        /// These tests verify invariants across sequences of random-ish operations.
+
+        #[test]
+        fn property_sequence_invariant() {
+            let (env, client, _) = setup_fresh();
+            let alice = Address::generate(&env);
+            let bob = Address::generate(&env);
+            let carol = Address::generate(&env);
+            let token_id = 1u64;
+
+            // Sequence of operations that should maintain invariants
+            client.mint(&alice, &token_id, &1000); // Alice: 1000
+            client.mint(&bob, &token_id, &500); // Bob: 500
+            client.transfer(&alice, &bob, &token_id, &200); // Alice: 800, Bob: 700
+            client.approve(&bob, &carol, &token_id, &300);
+            client.transfer_from(&carol, &bob, &alice, &token_id, &150); // Alice: 950, Bob: 550
+            client.burn(&alice, &token_id, &100); // Total supply reduced by 100
+
+            // Verify final invariants
+            let total_balance = client.balance_of(&alice, &token_id)
+                + client.balance_of(&bob, &token_id)
+                + client.balance_of(&carol, &token_id);
+
+            assert_eq!(
+                client.total_supply(&token_id),
+                total_balance,
+                "PROPERTY VIOLATION: Supply invariant broken after operation sequence"
+            );
+
+            assert!(
+                client.balance_of(&alice, &token_id) >= 0
+                    && client.balance_of(&bob, &token_id) >= 0
+                    && client.balance_of(&carol, &token_id) >= 0,
+                "PROPERTY VIOLATION: Negative balance detected"
+            );
+        }
+
+        #[test]
+        fn property_mint_burn_symmetry() {
+            let (env, client, _) = setup_fresh();
+            let user = Address::generate(&env);
+            let token_id = 1u64;
+
+            // Mint then burn same amount should return to initial state
+            let initial_supply = client.total_supply(&token_id);
+            let initial_balance = client.balance_of(&user, &token_id);
+
+            client.mint(&user, &token_id, &500);
+            client.burn(&user, &token_id, &500);
+
+            assert_eq!(
+                client.total_supply(&token_id),
+                initial_supply,
+                "PROPERTY VIOLATION: Mint-burn symmetry broken for supply"
+            );
+            assert_eq!(
+                client.balance_of(&user, &token_id),
+                initial_balance,
+                "PROPERTY VIOLATION: Mint-burn symmetry broken for balance"
+            );
+        }
+
+        #[test]
+        fn property_transfer_reversibility_check() {
+            let (env, client, _) = setup_fresh();
+            let alice = Address::generate(&env);
+            let bob = Address::generate(&env);
+            let token_id = 1u64;
+
+            client.mint(&alice, &token_id, &1000);
+
+            let alice_initial = client.balance_of(&alice, &token_id);
+            let bob_initial = client.balance_of(&bob, &token_id);
+
+            // Transfer A -> B
+            client.transfer(&alice, &bob, &token_id, &300);
+
+            // Transfer B -> A (reverse)
+            client.transfer(&bob, &alice, &token_id, &300);
+
+            // After round-trip, balances should be back to original
+            assert_eq!(
+                client.balance_of(&alice, &token_id),
+                alice_initial,
+                "PROPERTY VIOLATION: Round-trip transfer didn't restore sender balance"
+            );
+            assert_eq!(
+                client.balance_of(&bob, &token_id),
+                bob_initial,
+                "PROPERTY VIOLATION: Round-trip transfer didn't restore receiver balance"
+            );
+        }
     }
-
-    // =========================================================================
-    // INVARIANT 1: Conservation of Supply
-    // =========================================================================
-    /// After any operation, the sum of all user balances must equal total_supply.
-    /// This is the fundamental invariant of any token contract.
-    #[test]
-    fn invariant_supply_conservation_after_mint() {
-        let (env, client, _) = setup_fresh();
-        let user1 = Address::generate(&env);
-        let user2 = Address::generate(&env);
-        let user3 = Address::generate(&env);
-        let token_id = 1u64;
-
-        // Mint to multiple users
-        client.mint(&user1, &token_id, &1000);
-        client.mint(&user2, &token_id, &500);
-        client.mint(&user3, &token_id, &250);
-
-        let balance_sum = client.balance_of(&user1, &token_id)
-            + client.balance_of(&user2, &token_id)
-            + client.balance_of(&user3, &token_id);
-
-        // Invariant: sum of balances equals total supply
-        assert_eq!(
-            client.total_supply(&token_id),
-            balance_sum,
-            "INVARIANT VIOLATION: Supply conservation failed after mint"
-        );
-    }
-
-    #[test]
-    fn invariant_supply_conservation_after_transfer() {
-        let (env, client, _) = setup_fresh();
-        let alice = Address::generate(&env);
-        let bob = Address::generate(&env);
-        let carol = Address::generate(&env);
-        let token_id = 1u64;
-
-        client.mint(&alice, &token_id, &1000);
-
-        let supply_before = client.total_supply(&token_id);
-
-        // Multiple transfers
-        client.transfer(&alice, &bob, &token_id, &300);
-        client.transfer(&bob, &carol, &token_id, &150);
-        client.transfer(&alice, &carol, &token_id, &100);
-
-        let supply_after = client.total_supply(&token_id);
-
-        // Invariant: transfers do not change total supply
-        assert_eq!(
-            supply_before, supply_after,
-            "INVARIANT VIOLATION: Supply changed during transfers"
-        );
-
-        // Invariant: sum of balances still equals supply
-        let balance_sum = client.balance_of(&alice, &token_id)
-            + client.balance_of(&bob, &token_id)
-            + client.balance_of(&carol, &token_id);
-        assert_eq!(
-            supply_after, balance_sum,
-            "INVARIANT VIOLATION: Balance sum doesn't match supply after transfers"
-        );
-    }
-
-    #[test]
-    fn invariant_supply_conservation_after_burn() {
-        let (env, client, _) = setup_fresh();
-        let user = Address::generate(&env);
-        let token_id = 1u64;
-
-        client.mint(&user, &token_id, &1000);
-        let supply_before_burn = client.total_supply(&token_id);
-
-        client.burn(&user, &token_id, &300);
-
-        // Invariant: supply decreases by exactly the burned amount
-        assert_eq!(
-            client.total_supply(&token_id),
-            supply_before_burn - 300,
-            "INVARIANT VIOLATION: Supply not reduced correctly after burn"
-        );
-
-        // Invariant: balance equals remaining supply
-        assert_eq!(
-            client.balance_of(&user, &token_id),
-            client.total_supply(&token_id),
-            "INVARIANT VIOLATION: Balance doesn't match supply after burn"
-        );
-    }
-
-    // =========================================================================
-    // INVARIANT 2: Non-Negative Balances
-    // =========================================================================
-    /// All balances must always be non-negative (>= 0).
-    /// This is enforced by the contract logic, but we verify it holds.
-    #[test]
-    fn invariant_non_negative_balances() {
-        let (env, client, _) = setup_fresh();
-        let user = Address::generate(&env);
-        let token_id = 1u64;
-
-        // Initial balance is 0 (non-negative)
-        assert!(
-            client.balance_of(&user, &token_id) >= 0,
-            "INVARIANT VIOLATION: Initial balance is negative"
-        );
-
-        client.mint(&user, &token_id, &100);
-        assert!(
-            client.balance_of(&user, &token_id) >= 0,
-            "INVARIANT VIOLATION: Balance negative after mint"
-        );
-
-        client.burn(&user, &token_id, &100);
-        assert!(
-            client.balance_of(&user, &token_id) >= 0,
-            "INVARIANT VIOLATION: Balance negative after burn"
-        );
-    }
-
-    // =========================================================================
-    // INVARIANT 3: Conservation of Value in Transfer
-    // =========================================================================
-    /// In any transfer, the sum of sender and receiver balances before
-    /// must equal the sum after the transfer.
-    #[test]
-    fn invariant_transfer_value_conservation() {
-        let (env, client, _) = setup_fresh();
-        let alice = Address::generate(&env);
-        let bob = Address::generate(&env);
-        let token_id = 1u64;
-
-        client.mint(&alice, &token_id, &1000);
-
-        let alice_before = client.balance_of(&alice, &token_id);
-        let bob_before = client.balance_of(&bob, &token_id);
-        let sum_before = alice_before + bob_before;
-
-        client.transfer(&alice, &bob, &token_id, &400);
-
-        let alice_after = client.balance_of(&alice, &token_id);
-        let bob_after = client.balance_of(&bob, &token_id);
-        let sum_after = alice_after + bob_after;
-
-        // Invariant: total value is conserved
-        assert_eq!(
-            sum_before, sum_after,
-            "INVARIANT VIOLATION: Value not conserved in transfer"
-        );
-
-        // Additional checks: exact changes
-        assert_eq!(
-            alice_before - alice_after,
-            400,
-            "INVARIANT VIOLATION: Sender balance not reduced correctly"
-        );
-        assert_eq!(
-            bob_after - bob_before,
-            400,
-            "INVARIANT VIOLATION: Receiver balance not increased correctly"
-        );
-    }
-
-    // =========================================================================
-    // INVARIANT 4: Allowance Accounting
-    // =========================================================================
-    /// After transfer_from, the allowance must decrease by exactly the
-    /// transferred amount.
-    #[test]
-    fn invariant_allowance_decrease_on_transfer_from() {
-        let (env, client, _) = setup_fresh();
-        let owner = Address::generate(&env);
-        let spender = Address::generate(&env);
-        let recipient = Address::generate(&env);
-        let token_id = 1u64;
-
-        client.mint(&owner, &token_id, &1000);
-        client.approve(&owner, &spender, &token_id, &500);
-
-        let allowance_before = client.allowance(&owner, &spender, &token_id);
-
-        client.transfer_from(&spender, &owner, &recipient, &token_id, &200);
-
-        let allowance_after = client.allowance(&owner, &spender, &token_id);
-
-        // Invariant: allowance decreased by exactly the spent amount
-        assert_eq!(
-            allowance_before - allowance_after,
-            200,
-            "INVARIANT VIOLATION: Allowance not reduced correctly"
-        );
-    }
-
-    #[test]
-    #[should_panic]
-    fn invariant_allowance_cannot_exceed_approval() {
-        let (env, client, _) = setup_fresh();
-        let owner = Address::generate(&env);
-        let spender = Address::generate(&env);
-        let recipient = Address::generate(&env);
-        let token_id = 1u64;
-
-        client.mint(&owner, &token_id, &1000);
-        client.approve(&owner, &spender, &token_id, &100);
-
-        // Attempting to spend more than approved should fail
-        client.transfer_from(&spender, &owner, &recipient, &token_id, &150);
-    }
-
-    // =========================================================================
-    // INVARIANT 5: No Double Spend
-    // =========================================================================
-    /// A user cannot spend the same tokens twice (either directly or via approval).
-    #[test]
-    #[should_panic]
-    fn invariant_no_double_spend_direct() {
-        let (env, client, _) = setup_fresh();
-        let alice = Address::generate(&env);
-        let bob = Address::generate(&env);
-        let carol = Address::generate(&env);
-        let token_id = 1u64;
-
-        client.mint(&alice, &token_id, &100);
-
-        // First transfer succeeds
-        client.transfer(&alice, &bob, &token_id, &60);
-
-        // Alice now has 40, trying to spend 60 more should fail
-        client.transfer(&alice, &carol, &token_id, &60);
-    }
-
-    // =========================================================================
-    // INVARIANT 6: Total Supply Monotonicity
-    // =========================================================================
-    /// Total supply only increases via mint and only decreases via burn.
-    /// Transfers do not affect total supply.
-    #[test]
-    fn invariant_supply_only_changes_via_mint_burn() {
-        let (env, client, _) = setup_fresh();
-        let alice = Address::generate(&env);
-        let bob = Address::generate(&env);
-        let token_id = 1u64;
-
-        let initial_supply = client.total_supply(&token_id);
-        assert_eq!(initial_supply, 0);
-
-        // Mint increases supply
-        client.mint(&alice, &token_id, &500);
-        assert_eq!(client.total_supply(&token_id), 500);
-
-        // Transfer does not change supply
-        client.transfer(&alice, &bob, &token_id, &200);
-        assert_eq!(
-            client.total_supply(&token_id),
-            500,
-            "INVARIANT VIOLATION: Transfer changed total supply"
-        );
-
-        // Approve does not change supply
-        client.approve(&alice, &bob, &token_id, &100);
-        assert_eq!(
-            client.total_supply(&token_id),
-            500,
-            "INVARIANT VIOLATION: Approve changed total supply"
-        );
-
-        // Burn decreases supply
-        client.burn(&alice, &token_id, &100);
-        assert_eq!(client.total_supply(&token_id), 400);
-    }
-
-    // =========================================================================
-    // INVARIANT 7: Zero Address Handling
-    // =========================================================================
-    /// The contract should handle zero amounts appropriately.
-    #[test]
-    #[should_panic]
-    fn invariant_mint_zero_rejected() {
-        let (env, client, _) = setup_fresh();
-        let user = Address::generate(&env);
-        let token_id = 1u64;
-
-        client.mint(&user, &token_id, &0);
-    }
-
-    #[test]
-    #[should_panic]
-    fn invariant_burn_zero_rejected() {
-        let (env, client, _) = setup_fresh();
-        let user = Address::generate(&env);
-        let token_id = 1u64;
-
-        client.mint(&user, &token_id, &100);
-        client.burn(&user, &token_id, &0);
-    }
-
-    // =========================================================================
-    // INVARIANT 8: Idempotency Properties
-    // =========================================================================
-    /// Certain operations should have predictable idempotent-like behavior.
-    #[test]
-    fn invariant_approve_overwrites() {
-        let (env, client, _) = setup_fresh();
-        let owner = Address::generate(&env);
-        let spender = Address::generate(&env);
-        let token_id = 1u64;
-
-        client.approve(&owner, &spender, &token_id, &100);
-        assert_eq!(client.allowance(&owner, &spender, &token_id), 100);
-
-        // New approval should overwrite, not add
-        client.approve(&owner, &spender, &token_id, &200);
-        assert_eq!(
-            client.allowance(&owner, &spender, &token_id),
-            200,
-            "INVARIANT VIOLATION: Approve did not overwrite previous allowance"
-        );
-    }
-
-    // =========================================================================
-    // PROPERTY-BASED INVARIANT TESTS
-    // =========================================================================
-    /// These tests verify invariants across sequences of random-ish operations.
-
-    #[test]
-    fn property_sequence_invariant() {
-        let (env, client, _) = setup_fresh();
-        let alice = Address::generate(&env);
-        let bob = Address::generate(&env);
-        let carol = Address::generate(&env);
-        let token_id = 1u64;
-
-        // Sequence of operations that should maintain invariants
-        client.mint(&alice, &token_id, &1000); // Alice: 1000
-        client.mint(&bob, &token_id, &500); // Bob: 500
-        client.transfer(&alice, &bob, &token_id, &200); // Alice: 800, Bob: 700
-        client.approve(&bob, &carol, &token_id, &300);
-        client.transfer_from(&carol, &bob, &alice, &token_id, &150); // Alice: 950, Bob: 550
-        client.burn(&alice, &token_id, &100); // Total supply reduced by 100
-
-        // Verify final invariants
-        let total_balance = client.balance_of(&alice, &token_id)
-            + client.balance_of(&bob, &token_id)
-            + client.balance_of(&carol, &token_id);
-
-        assert_eq!(
-            client.total_supply(&token_id),
-            total_balance,
-            "PROPERTY VIOLATION: Supply invariant broken after operation sequence"
-        );
-
-        assert!(
-            client.balance_of(&alice, &token_id) >= 0
-                && client.balance_of(&bob, &token_id) >= 0
-                && client.balance_of(&carol, &token_id) >= 0,
-            "PROPERTY VIOLATION: Negative balance detected"
-        );
-    }
-
-    #[test]
-    fn property_mint_burn_symmetry() {
-        let (env, client, _) = setup_fresh();
-        let user = Address::generate(&env);
-        let token_id = 1u64;
-
-        // Mint then burn same amount should return to initial state
-        let initial_supply = client.total_supply(&token_id);
-        let initial_balance = client.balance_of(&user, &token_id);
-
-        client.mint(&user, &token_id, &500);
-        client.burn(&user, &token_id, &500);
-
-        assert_eq!(
-            client.total_supply(&token_id),
-            initial_supply,
-            "PROPERTY VIOLATION: Mint-burn symmetry broken for supply"
-        );
-        assert_eq!(
-            client.balance_of(&user, &token_id),
-            initial_balance,
-            "PROPERTY VIOLATION: Mint-burn symmetry broken for balance"
-        );
-    }
-
-    #[test]
-    fn property_transfer_reversibility_check() {
-        let (env, client, _) = setup_fresh();
-        let alice = Address::generate(&env);
-        let bob = Address::generate(&env);
-        let token_id = 1u64;
-
-        client.mint(&alice, &token_id, &1000);
-
-        let alice_initial = client.balance_of(&alice, &token_id);
-        let bob_initial = client.balance_of(&bob, &token_id);
-
-        // Transfer A -> B
-        client.transfer(&alice, &bob, &token_id, &300);
-
-        // Transfer B -> A (reverse)
-        client.transfer(&bob, &alice, &token_id, &300);
-
-        // After round-trip, balances should be back to original
-        assert_eq!(
-            client.balance_of(&alice, &token_id),
-            alice_initial,
-            "PROPERTY VIOLATION: Round-trip transfer didn't restore sender balance"
-        );
-        assert_eq!(
-            client.balance_of(&bob, &token_id),
-            bob_initial,
-            "PROPERTY VIOLATION: Round-trip transfer didn't restore receiver balance"
-        );
-    }
-}}
+}

--- a/src/upgradeable/lib.rs
+++ b/src/upgradeable/lib.rs
@@ -35,6 +35,7 @@ pub struct UpgradeProposal {
 #[contract]
 pub struct UpgradeableContract;
 
+#[allow(deprecated)]
 #[contractimpl]
 impl UpgradeableContract {
     pub fn set_security_registry(env: soroban_sdk::Env, registry: soroban_sdk::Address) {

--- a/src/utils/contract_metadata.rs
+++ b/src/utils/contract_metadata.rs
@@ -83,6 +83,7 @@ where
 /// * `description` – New description (pass current value to leave unchanged)
 /// * `icon_url`    – New icon URL
 /// * `website`     – New website URL
+#[allow(deprecated)]
 pub fn update<K>(
     env: &Env,
     key: &K,

--- a/src/utils/contract_metadata.rs
+++ b/src/utils/contract_metadata.rs
@@ -46,11 +46,14 @@ where
     K: IntoVal<Env, Val> + TryFromVal<Env, Val>,
 {
     if !env.storage().instance().has(key) {
-        env.storage().instance().set(key, &ContractMetadata {
-            description: String::from_str(env, ""),
-            icon_url: String::from_str(env, ""),
-            website: String::from_str(env, ""),
-        });
+        env.storage().instance().set(
+            key,
+            &ContractMetadata {
+                description: String::from_str(env, ""),
+                icon_url: String::from_str(env, ""),
+                website: String::from_str(env, ""),
+            },
+        );
     }
 }
 
@@ -92,7 +95,11 @@ pub fn update<K>(
 {
     admin.require_auth();
 
-    let meta = ContractMetadata { description, icon_url, website };
+    let meta = ContractMetadata {
+        description,
+        icon_url,
+        website,
+    };
     env.storage().instance().set(key, &meta);
 
     env.events().publish((symbol_short!("meta_upd"),), meta);

--- a/src/utils/events.rs
+++ b/src/utils/events.rs
@@ -102,6 +102,7 @@ pub trait EventEmitter {
 /// The payload is the structured `AnchorEvent` enum.
 /// The top-level topic is always `symbol_short!("anchor")` followed by the variant name,
 /// which allows indexers to filter globally for all AnchorPoint events.
+#[allow(deprecated)]
 pub fn emit_event(env: &Env, event: AnchorEvent) {
     let sub_topic = match &event {
         AnchorEvent::Deposit(_) => symbol_short!("deposit"),
@@ -122,8 +123,7 @@ pub fn emit_event(env: &Env, event: AnchorEvent) {
 mod tests {
     use super::*;
     use soroban_sdk::{
-        contract, contractimpl, testutils::Address as _, testutils::Events, vec, FromVal, IntoVal,
-        Val,
+        contract, contractimpl, testutils::Address as _, testutils::Events, vec, IntoVal,
     };
 
     #[contract]

--- a/src/vesting/lib.rs
+++ b/src/vesting/lib.rs
@@ -29,6 +29,8 @@ pub struct Grant {
 #[contract]
 pub struct VestingContract;
 
+#[allow(deprecated)]
+#[allow(clippy::too_many_arguments)]
 #[contractimpl]
 impl VestingContract {
     /// Initializes the contract with an admin.
@@ -53,6 +55,7 @@ impl VestingContract {
 
     /// Creates a new vesting grant.
     /// The admin must provide the tokens upfront.
+    #[allow(clippy::too_many_arguments)]
     pub fn create_grant(
         env: Env,
         beneficiary: Address,
@@ -76,7 +79,7 @@ impl VestingContract {
 
         // Deposit tokens into the contract
         let token_client = token::Client::new(&env, &token);
-        token_client.transfer(&admin, &env.current_contract_address(), &amount);
+        token_client.transfer(&admin, env.current_contract_address(), &amount);
 
         let id: u32 = env
             .storage()

--- a/src/yield_farming/Cargo.toml
+++ b/src/yield_farming/Cargo.toml
@@ -6,5 +6,8 @@ edition = "2021"
 [dependencies]
 soroban-sdk = "26.0.1"
 
+[dev-dependencies]
+soroban-sdk = { version = "26.0.1", features = ["testutils"] }
+
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/src/yield_farming/src/lib.rs
+++ b/src/yield_farming/src/lib.rs
@@ -170,10 +170,8 @@ impl YieldFarmingDistributor {
             .unwrap_or(0);
 
         if current_ledger > last_update && total_shares > 0 {
-            let ledgers_elapsed = (current_ledger - last_update) as i128;
-            let reward_delta = ledgers_elapsed
-                .checked_mul(reward_rate)
-                .expect("reward overflow")
+            let integrated_rewards = Self::calculate_rewards_for_period(reward_rate, last_update, current_ledger);
+            let reward_delta = integrated_rewards
                 .checked_mul(PRECISION)
                 .expect("reward overflow");
             let remainder: i128 = env
@@ -223,6 +221,46 @@ impl YieldFarmingDistributor {
 
     // ── Internal helpers ──────────────────────────────────────────────────────
 
+    /// Calculate the effective reward rate for a given ledger sequence.
+    /// Decays by 5% every 100,000 ledgers.
+    fn get_effective_reward_rate(initial_rate: i128, ledger_seq: u32) -> i128 {
+        let epoch = ledger_seq / 100_000;
+        let mut rate = initial_rate;
+        for _ in 0..epoch {
+            rate = rate.checked_mul(95).expect("reward overflow") / 100;
+        }
+        rate
+    }
+
+    /// Calculate the total integrated rewards emitted between two ledger sequences,
+    /// properly handling epoch boundaries where the rate decays.
+    fn calculate_rewards_for_period(initial_rate: i128, start_ledger: u32, end_ledger: u32) -> i128 {
+        if start_ledger >= end_ledger {
+            return 0;
+        }
+        let mut total_rewards = 0i128;
+        let mut current = start_ledger;
+        while current < end_ledger {
+            let current_epoch = current / 100_000;
+            let next_epoch_start = (current_epoch + 1) * 100_000;
+            let end = if next_epoch_start < end_ledger {
+                next_epoch_start
+            } else {
+                end_ledger
+            };
+            let ledgers_in_this_epoch = (end - current) as i128;
+            let effective_rate = Self::get_effective_reward_rate(initial_rate, current);
+            let epoch_rewards = ledgers_in_this_epoch
+                .checked_mul(effective_rate)
+                .expect("reward overflow");
+            total_rewards = total_rewards
+                .checked_add(epoch_rewards)
+                .expect("reward overflow");
+            current = end;
+        }
+        total_rewards
+    }
+
     /// Advance the global per-share accumulator to the current ledger.
     fn _update_global_reward(env: &Env) {
         let last_update: u32 = env
@@ -250,10 +288,8 @@ impl YieldFarmingDistributor {
                 .instance()
                 .get(&DataKey::RewardRate)
                 .unwrap_or(0);
-            let ledgers_elapsed = (current_ledger - last_update) as i128;
-            let reward_delta = ledgers_elapsed
-                .checked_mul(reward_rate)
-                .expect("reward overflow")
+            let integrated_rewards = Self::calculate_rewards_for_period(reward_rate, last_update, current_ledger);
+            let reward_delta = integrated_rewards
                 .checked_mul(PRECISION)
                 .expect("reward overflow");
             let remainder: i128 = env
@@ -503,7 +539,7 @@ mod tests {
         amm.set_shares(&user, &10_000); // 100% of pool
 
         // Advance 10 ledgers.
-        env.ledger().with_mut(|l| l.sequence_number += 10);
+        env.ledger().set_sequence_number(env.ledger().sequence() + 10);
 
         // Expected: 10 ledgers * 1000 rate * (10000/10000) = 10_000
         let pending = dist.pending_rewards(&user);
@@ -522,7 +558,7 @@ mod tests {
         amm.set_shares(&user_a, &7_500); // 75%
         amm.set_shares(&user_b, &2_500); // 25%
 
-        env.ledger().with_mut(|l| l.sequence_number += 10);
+        env.ledger().set_sequence_number(env.ledger().sequence() + 10);
 
         let pending_a = dist.pending_rewards(&user_a);
         let pending_b = dist.pending_rewards(&user_b);
@@ -543,7 +579,7 @@ mod tests {
         amm.set_total_shares(&10_000);
         amm.set_shares(&user, &10_000);
 
-        env.ledger().with_mut(|l| l.sequence_number += 5);
+        env.ledger().set_sequence_number(env.ledger().sequence() + 5);
 
         let claimed = dist.claim_rewards(&user);
         assert_eq!(claimed, 5_000); // 5 ledgers * 1000 rate
@@ -567,7 +603,7 @@ mod tests {
         amm.set_total_shares(&10_000);
         amm.set_shares(&user, &0);
 
-        env.ledger().with_mut(|l| l.sequence_number += 10);
+        env.ledger().set_sequence_number(env.ledger().sequence() + 10);
 
         let claimed = dist.claim_rewards(&user);
         assert_eq!(claimed, 0);
@@ -594,11 +630,11 @@ mod tests {
         amm.set_shares(&user, &1_000);
 
         // Advance 10 ledgers, claim, advance 10 more, check pending.
-        env.ledger().with_mut(|l| l.sequence_number += 10);
+        env.ledger().set_sequence_number(env.ledger().sequence() + 10);
         let first_claim = dist.claim_rewards(&user);
         assert_eq!(first_claim, 1_000); // 10 * 100
 
-        env.ledger().with_mut(|l| l.sequence_number += 10);
+        env.ledger().set_sequence_number(env.ledger().sequence() + 10);
         let pending = dist.pending_rewards(&user);
         assert_eq!(pending, 1_000); // another 10 * 100, not doubled
 
@@ -616,7 +652,7 @@ mod tests {
         amm.set_total_shares(&0); // empty pool
         amm.set_shares(&user, &0);
 
-        env.ledger().with_mut(|l| l.sequence_number += 100);
+        env.ledger().set_sequence_number(env.ledger().sequence() + 100);
 
         assert_eq!(dist.pending_rewards(&user), 0);
         assert_eq!(dist.claim_rewards(&user), 0);
@@ -632,10 +668,10 @@ mod tests {
         amm.set_total_shares(&3);
         amm.set_shares(&user, &1);
 
-        env.ledger().with_mut(|l| l.sequence_number += 1);
+        env.ledger().set_sequence_number(env.ledger().sequence() + 1);
         assert_eq!(dist.claim_rewards(&user), 0);
 
-        env.ledger().with_mut(|l| l.sequence_number += 2);
+        env.ledger().set_sequence_number(env.ledger().sequence() + 2);
         assert_eq!(dist.pending_rewards(&user), 1);
     }
 
@@ -650,7 +686,7 @@ mod tests {
         amm.set_total_shares(&-1);
         amm.set_shares(&user, &0);
 
-        env.ledger().with_mut(|l| l.sequence_number += 1);
+        env.ledger().set_sequence_number(env.ledger().sequence() + 1);
         let _ = dist.pending_rewards(&user);
     }
 
@@ -665,7 +701,40 @@ mod tests {
         amm.set_total_shares(&10);
         amm.set_shares(&user, &11);
 
-        env.ledger().with_mut(|l| l.sequence_number += 1);
+        env.ledger().set_sequence_number(env.ledger().sequence() + 1);
         let _ = dist.claim_rewards(&user);
+    }
+
+    #[test]
+    fn test_reward_rate_decay() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (dist, amm, _token, _dist_id, _admin) = setup(&env, 1_000);
+
+        let user = Address::generate(&env);
+        amm.set_total_shares(&10_000);
+        amm.set_shares(&user, &10_000);
+
+        // Epoch 0: ledgers 0 to 10
+        env.ledger().set_sequence_number(10);
+        assert_eq!(dist.pending_rewards(&user), 10_000); // 10 * 1000
+
+        // Epoch 1: jump to 100,010
+        // ledgers 0 -> 100_000 (100,000 * 1000 = 100,000,000)
+        // ledgers 100_000 -> 100_010 (10 * 950 = 9,500)
+        // Total = 100,009,500
+        env.ledger().set_sequence_number(100_010);
+        assert_eq!(dist.pending_rewards(&user), 100_009_500);
+
+        let claimed = dist.claim_rewards(&user);
+        assert_eq!(claimed, 100_009_500);
+
+        // Epoch 2: jump to 200,010
+        // ledgers 100,010 -> 200_000 (99,990 * 950 = 94,990,500)
+        // ledgers 200_000 -> 200_010 (10 * 902 = 9,020)
+        // Total = 94,999,520
+        env.ledger().set_sequence_number(200_010);
+        let claimed2 = dist.claim_rewards(&user);
+        assert_eq!(claimed2, 94_999_520);
     }
 }

--- a/src/yield_farming/src/lib.rs
+++ b/src/yield_farming/src/lib.rs
@@ -170,7 +170,8 @@ impl YieldFarmingDistributor {
             .unwrap_or(0);
 
         if current_ledger > last_update && total_shares > 0 {
-            let integrated_rewards = Self::calculate_rewards_for_period(reward_rate, last_update, current_ledger);
+            let integrated_rewards =
+                Self::calculate_rewards_for_period(reward_rate, last_update, current_ledger);
             let reward_delta = integrated_rewards
                 .checked_mul(PRECISION)
                 .expect("reward overflow");
@@ -234,7 +235,11 @@ impl YieldFarmingDistributor {
 
     /// Calculate the total integrated rewards emitted between two ledger sequences,
     /// properly handling epoch boundaries where the rate decays.
-    fn calculate_rewards_for_period(initial_rate: i128, start_ledger: u32, end_ledger: u32) -> i128 {
+    fn calculate_rewards_for_period(
+        initial_rate: i128,
+        start_ledger: u32,
+        end_ledger: u32,
+    ) -> i128 {
         if start_ledger >= end_ledger {
             return 0;
         }
@@ -288,7 +293,8 @@ impl YieldFarmingDistributor {
                 .instance()
                 .get(&DataKey::RewardRate)
                 .unwrap_or(0);
-            let integrated_rewards = Self::calculate_rewards_for_period(reward_rate, last_update, current_ledger);
+            let integrated_rewards =
+                Self::calculate_rewards_for_period(reward_rate, last_update, current_ledger);
             let reward_delta = integrated_rewards
                 .checked_mul(PRECISION)
                 .expect("reward overflow");
@@ -539,7 +545,8 @@ mod tests {
         amm.set_shares(&user, &10_000); // 100% of pool
 
         // Advance 10 ledgers.
-        env.ledger().set_sequence_number(env.ledger().sequence() + 10);
+        env.ledger()
+            .set_sequence_number(env.ledger().sequence() + 10);
 
         // Expected: 10 ledgers * 1000 rate * (10000/10000) = 10_000
         let pending = dist.pending_rewards(&user);
@@ -558,7 +565,8 @@ mod tests {
         amm.set_shares(&user_a, &7_500); // 75%
         amm.set_shares(&user_b, &2_500); // 25%
 
-        env.ledger().set_sequence_number(env.ledger().sequence() + 10);
+        env.ledger()
+            .set_sequence_number(env.ledger().sequence() + 10);
 
         let pending_a = dist.pending_rewards(&user_a);
         let pending_b = dist.pending_rewards(&user_b);
@@ -579,7 +587,8 @@ mod tests {
         amm.set_total_shares(&10_000);
         amm.set_shares(&user, &10_000);
 
-        env.ledger().set_sequence_number(env.ledger().sequence() + 5);
+        env.ledger()
+            .set_sequence_number(env.ledger().sequence() + 5);
 
         let claimed = dist.claim_rewards(&user);
         assert_eq!(claimed, 5_000); // 5 ledgers * 1000 rate
@@ -603,7 +612,8 @@ mod tests {
         amm.set_total_shares(&10_000);
         amm.set_shares(&user, &0);
 
-        env.ledger().set_sequence_number(env.ledger().sequence() + 10);
+        env.ledger()
+            .set_sequence_number(env.ledger().sequence() + 10);
 
         let claimed = dist.claim_rewards(&user);
         assert_eq!(claimed, 0);
@@ -630,11 +640,13 @@ mod tests {
         amm.set_shares(&user, &1_000);
 
         // Advance 10 ledgers, claim, advance 10 more, check pending.
-        env.ledger().set_sequence_number(env.ledger().sequence() + 10);
+        env.ledger()
+            .set_sequence_number(env.ledger().sequence() + 10);
         let first_claim = dist.claim_rewards(&user);
         assert_eq!(first_claim, 1_000); // 10 * 100
 
-        env.ledger().set_sequence_number(env.ledger().sequence() + 10);
+        env.ledger()
+            .set_sequence_number(env.ledger().sequence() + 10);
         let pending = dist.pending_rewards(&user);
         assert_eq!(pending, 1_000); // another 10 * 100, not doubled
 
@@ -652,7 +664,8 @@ mod tests {
         amm.set_total_shares(&0); // empty pool
         amm.set_shares(&user, &0);
 
-        env.ledger().set_sequence_number(env.ledger().sequence() + 100);
+        env.ledger()
+            .set_sequence_number(env.ledger().sequence() + 100);
 
         assert_eq!(dist.pending_rewards(&user), 0);
         assert_eq!(dist.claim_rewards(&user), 0);
@@ -668,10 +681,12 @@ mod tests {
         amm.set_total_shares(&3);
         amm.set_shares(&user, &1);
 
-        env.ledger().set_sequence_number(env.ledger().sequence() + 1);
+        env.ledger()
+            .set_sequence_number(env.ledger().sequence() + 1);
         assert_eq!(dist.claim_rewards(&user), 0);
 
-        env.ledger().set_sequence_number(env.ledger().sequence() + 2);
+        env.ledger()
+            .set_sequence_number(env.ledger().sequence() + 2);
         assert_eq!(dist.pending_rewards(&user), 1);
     }
 
@@ -686,7 +701,8 @@ mod tests {
         amm.set_total_shares(&-1);
         amm.set_shares(&user, &0);
 
-        env.ledger().set_sequence_number(env.ledger().sequence() + 1);
+        env.ledger()
+            .set_sequence_number(env.ledger().sequence() + 1);
         let _ = dist.pending_rewards(&user);
     }
 
@@ -701,7 +717,8 @@ mod tests {
         amm.set_total_shares(&10);
         amm.set_shares(&user, &11);
 
-        env.ledger().set_sequence_number(env.ledger().sequence() + 1);
+        env.ledger()
+            .set_sequence_number(env.ledger().sequence() + 1);
         let _ = dist.claim_rewards(&user);
     }
 

--- a/src/yield_farming/src/lib.rs
+++ b/src/yield_farming/src/lib.rs
@@ -90,6 +90,7 @@ impl YieldFarmingDistributor {
     ///
     /// Flushes the global accumulator before changing the rate so that
     /// previously accrued rewards are calculated at the old rate.
+    #[allow(deprecated)]
     pub fn set_reward_rate(env: Env, rate: i128) {
         assert!(rate >= 0, "reward rate must be non-negative");
         let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
@@ -103,6 +104,7 @@ impl YieldFarmingDistributor {
     /// Claim all pending rewards for `user`.
     ///
     /// Returns the amount of reward tokens transferred.
+    #[allow(deprecated)]
     pub fn claim_rewards(env: Env, user: Address) -> i128 {
         user.require_auth();
         Self::_update_user_reward(&env, &user);


### PR DESCRIPTION
closes #800 

# Summary
- Adds a 5% reward decay every 100,000 ledgers in the yield farming contract.
- Updates reward integration logic to handle epoch boundary splits precisely.
- Fixes the yield farming test harness for the pinned Soroban SDK version.
- Adds/updates tests covering the decay behavior and existing reward flows.

# Reason
- This reduces long-term emissions and prevents token hyperinflation while preserving accurate reward accounting over time.

