### PR TITLE
feat(contracts): add cross-contract call interface for bridge stub co…

### DIFF
--- a/contracts/bridge_stub/src/lib.rs
+++ b/contracts/bridge_stub/src/lib.rs
@@ -1,7 +1,8 @@
 #![no_std]
 
 use soroban_sdk::{
-    contract, contractimpl, contracttype, symbol_short, token, xdr::ToXdr, Address, BytesN, Env, IntoVal, Vec,
+    contract, contractimpl, contracttype, symbol_short, token, xdr::ToXdr, Address, BytesN, Env,
+    IntoVal, Vec,
 };
 
 #[contracttype]
@@ -10,6 +11,57 @@ pub enum DataKey {
     BridgeToken,
     Relayer,
     Processed(BytesN<32>),
+}
+
+/// Client for cross-contract invocation of the Bridge Stub contract.
+///
+/// Other contracts can instantiate this client and call `burn` or `mint`
+/// without needing to use `invoke_contract` directly.
+pub struct BridgeContractClient<'a> {
+    env: &'a Env,
+    contract_id: &'a Address,
+}
+
+impl<'a> BridgeContractClient<'a> {
+    pub fn new(env: &'a Env, contract_id: &'a Address) -> Self {
+        Self { env, contract_id }
+    }
+
+    pub fn burn(
+        &self,
+        user: &Address,
+        amount: &i128,
+        dest_chain: &u32,
+        dest_recipient: &BytesN<32>,
+    ) {
+        self.env.invoke_contract::<()>(
+            self.contract_id,
+            &symbol_short!("burn"),
+            (user.clone(), *amount, *dest_chain, dest_recipient.clone()).into_val(self.env),
+        );
+    }
+
+    pub fn mint(
+        &self,
+        relayer: &Address,
+        recipient: &Address,
+        amount: &i128,
+        source_chain: &u32,
+        nonce: &u64,
+    ) {
+        self.env.invoke_contract::<()>(
+            self.contract_id,
+            &symbol_short!("mint"),
+            (
+                relayer.clone(),
+                recipient.clone(),
+                *amount,
+                *source_chain,
+                *nonce,
+            )
+                .into_val(self.env),
+        );
+    }
 }
 
 #[contract]
@@ -23,7 +75,9 @@ impl BridgeStub {
             panic!("already initialized");
         }
         env.storage().instance().set(&DataKey::Admin, &admin);
-        env.storage().instance().set(&DataKey::BridgeToken, &bridge_token);
+        env.storage()
+            .instance()
+            .set(&DataKey::BridgeToken, &bridge_token);
         env.storage().instance().set(&DataKey::Relayer, &relayer);
     }
 
@@ -39,8 +93,12 @@ impl BridgeStub {
         user.require_auth();
         assert!(amount > 0, "amount must be positive");
 
-        let bridge_token: Address = env.storage().instance().get(&DataKey::BridgeToken).unwrap();
-        
+        let bridge_token: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::BridgeToken)
+            .unwrap();
+
         token::Client::new(&env, &bridge_token).transfer(
             &user,
             &env.current_contract_address(),
@@ -48,10 +106,8 @@ impl BridgeStub {
         );
 
         // Emit event following strict indexed schema
-        env.events().publish(
-            (symbol_short!("br_burn"), user, amount, dest_chain),
-            dest_recipient,
-        );
+        env.events()
+            .publish((symbol_short!("br_burn"), user, amount, dest_chain), dest_recipient);
     }
 
     /// Mints tokens on this chain based on a verified message from another chain.
@@ -65,8 +121,12 @@ impl BridgeStub {
         nonce: u64,
     ) {
         relayer.require_auth();
-        
-        let authorized_relayer: Address = env.storage().instance().get(&DataKey::Relayer).unwrap();
+
+        let authorized_relayer: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Relayer)
+            .unwrap();
         if relayer != authorized_relayer {
             panic!("not authorized relayer");
         }
@@ -77,10 +137,9 @@ impl BridgeStub {
         msg_data.push_back(amount.into_val(&env));
         msg_data.push_back(source_chain.into_val(&env));
         msg_data.push_back(nonce.into_val(&env));
-        
-        // In Soroban 22, we can use the env.crypto().sha256 on serialized data
+
         // For this stub, we'll use a simpler unique key
-        let msg_hash = env.crypto().sha256(&recipient.clone().to_xdr(&env)); // Simplified hash for stub
+        let msg_hash = env.crypto().sha256(&recipient.clone().to_xdr(&env));
 
         // Replay protection
         let processed_key = DataKey::Processed(msg_hash.clone().into());
@@ -92,7 +151,11 @@ impl BridgeStub {
         env.storage().persistent().set(&processed_key, &true);
 
         // Mint/Transfer tokens
-        let bridge_token: Address = env.storage().instance().get(&DataKey::BridgeToken).unwrap();
+        let bridge_token: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::BridgeToken)
+            .unwrap();
         token::Client::new(&env, &bridge_token).transfer(
             &env.current_contract_address(),
             &recipient,
@@ -100,27 +163,34 @@ impl BridgeStub {
         );
 
         // Emit event
-        env.events().publish(
-            (symbol_short!("br_mint"), recipient, amount, source_chain),
-            nonce,
-        );
+        env.events()
+            .publish((symbol_short!("br_mint"), recipient, amount, source_chain), nonce);
     }
 
     /// Update relayer address (admin only)
     pub fn set_relayer(env: Env, admin: Address, new_relayer: Address) {
         admin.require_auth();
-        let current_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        let current_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .unwrap();
         assert_eq!(admin, current_admin, "not authorized");
-        
-        env.storage().instance().set(&DataKey::Relayer, &new_relayer);
+
+        env.storage()
+            .instance()
+            .set(&DataKey::Relayer, &new_relayer);
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use soroban_sdk::testutils::{Address as _};
-    use soroban_sdk::{token, Address, BytesN, Env};
+    use soroban_sdk::{
+        testutils::{Address as _},
+        token,
+        Address, BytesN, Env,
+    };
 
     fn setup() -> (Env, Address, Address, Address, Address, Address) {
         let env = Env::default();
@@ -129,7 +199,7 @@ mod tests {
         let admin = Address::generate(&env);
         let user = Address::generate(&env);
         let relayer = Address::generate(&env);
-        
+
         // Setup a mock token
         let token_admin = Address::generate(&env);
         let token_id = env.register_stellar_asset_contract_v2(token_admin.clone());
@@ -139,18 +209,55 @@ mod tests {
         let bridge_id = env.register_contract(None, BridgeStub);
         let bridge_client = BridgeStubClient::new(&env, &bridge_id);
         bridge_client.initialize(&admin, &token_id.address(), &relayer);
-        
+
         // Give bridge contract some tokens to "mint"
         token_client.mint(&bridge_id, &10000);
 
         (env, bridge_id, admin, user, token_id.address(), relayer)
     }
 
+    /// A mock contract that uses BridgeContractClient to call the bridge.
+    ///
+    /// In a real-world scenario the calling contract would first authenticate
+    /// the user/relayer before invoking the bridge (as demonstrated below).
+    #[contract]
+    pub struct MockCaller;
+
+    #[contractimpl]
+    impl MockCaller {
+        pub fn call_bridge_burn(
+            env: Env,
+            bridge_id: Address,
+            user: Address,
+            amount: i128,
+            dest_chain: u32,
+            dest_recipient: BytesN<32>,
+        ) {
+            user.require_auth();
+            let bridge = BridgeContractClient::new(&env, &bridge_id);
+            bridge.burn(&user, &amount, &dest_chain, &dest_recipient);
+        }
+
+        pub fn call_bridge_mint(
+            env: Env,
+            bridge_id: Address,
+            relayer: Address,
+            recipient: Address,
+            amount: i128,
+            source_chain: u32,
+            nonce: u64,
+        ) {
+            relayer.require_auth();
+            let bridge = BridgeContractClient::new(&env, &bridge_id);
+            bridge.mint(&relayer, &recipient, &amount, &source_chain, &nonce);
+        }
+    }
+
     #[test]
     fn test_burn_event() {
         let (env, bridge_id, _, user, _, _) = setup();
         let bridge_client = BridgeStubClient::new(&env, &bridge_id);
-        
+
         let dest_recipient = BytesN::from_array(&env, &[7u8; 32]);
         bridge_client.burn(&user, &100, &2, &dest_recipient);
     }
@@ -159,11 +266,32 @@ mod tests {
     fn test_mint_authorized() {
         let (env, bridge_id, _, user, _, relayer) = setup();
         let bridge_client = BridgeStubClient::new(&env, &bridge_id);
-        
+
         let amount = 50i128;
         let source_chain = 1u32;
         let nonce = 123u64;
 
         bridge_client.mint(&relayer, &user, &amount, &source_chain, &nonce);
+    }
+
+    #[test]
+    fn test_cross_contract_burn_via_bridge_client() {
+        let (env, bridge_id, _admin, user, _token_addr, _relayer) = setup();
+
+        let caller_id = env.register_contract(None, MockCaller);
+        let caller = MockCallerClient::new(&env, &caller_id);
+
+        let dest_recipient = BytesN::from_array(&env, &[7u8; 32]);
+        caller.call_bridge_burn(&bridge_id, &user, &100, &2, &dest_recipient);
+    }
+
+    #[test]
+    fn test_cross_contract_mint_via_bridge_client() {
+        let (env, bridge_id, _admin, user, _token_addr, relayer) = setup();
+
+        let caller_id = env.register_contract(None, MockCaller);
+        let caller = MockCallerClient::new(&env, &caller_id);
+
+        caller.call_bridge_mint(&bridge_id, &relayer, &user, &50, &1, &123);
     }
 }


### PR DESCRIPTION
1. BridgeContractClient struct — clean cross-contract invocation wrapper with new, burn, and mint methods. Uses invoke_contract internally with .into_val(self.env) for SDK 22 tuple → Vec<Val> conversion.
2. MockCaller contract (in tests) — demonstrates a calling contract that:
- Authenticates the user/relayer (require_auth()) before bridge calls
- Uses BridgeContractClient::new(&env, &bridge_id) to invoke burn and mint on the bridge
3. 4 tests (all passing):
- test_burn_event — existing, direct bridge call
- test_mint_authorized — existing, direct bridge call
- test_cross_contract_burn_via_bridge_client — MockCaller uses BridgeContractClient to call bridge's burn
- test_cross_contract_mint_via_bridge_client — MockCaller uses BridgeContractClient to call bridge's mint

closes #795 