### PR TITLE
feat:  Fix dashboard state

### DIFF
--- a/backend/src/index.test.ts
+++ b/backend/src/index.test.ts
@@ -2,6 +2,12 @@ import request from 'supertest';
 import prisma from './lib/prisma';
 import { redis } from './lib/redis';
 
+if (!process.env.PRODUCTION_CORS_ORIGINS) {
+  process.env.PRODUCTION_CORS_ORIGINS = 'http://localhost:3000,https://allowed.example.com';
+}
+
+const mockedPublicLimiter = jest.fn((req: any, res: any, next: any) => next());
+
 jest.mock('./lib/prisma', () => ({
   __esModule: true,
   default: {
@@ -18,7 +24,7 @@ jest.mock('./api/middleware/rate-limit.middleware', () => ({
   apiLimiter: (req: any, res: any, next: any) => next(),
   authLimiter: (req: any, res: any, next: any) => next(),
   sensitiveApiLimiter: (req: any, res: any, next: any) => next(),
-  publicLimiter: (req: any, res: any, next: any) => next(),
+  publicLimiter: mockedPublicLimiter,
 }));
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -66,5 +72,39 @@ describe('Backend API', () => {
     const res = await request(app).get('/');
     expect(res.statusCode).toEqual(200);
     expect(res.text).toContain('AnchorPoint Backend API is running.');
+  });
+
+  it('should include CORS header for allowed origin', async () => {
+    const res = await request(app)
+      .get('/')
+      .set('Origin', 'http://localhost:3000');
+
+    expect(res.statusCode).toEqual(200);
+    expect(res.headers['access-control-allow-origin']).toEqual('http://localhost:3000');
+  });
+
+  it('should not include CORS header for blocked origin', async () => {
+    const res = await request(app)
+      .get('/')
+      .set('Origin', 'https://blocked.example.com');
+
+    expect(res.statusCode).toEqual(200);
+    expect(res.headers['access-control-allow-origin']).toBeUndefined();
+  });
+
+  it('should mount each public route exactly once with publicLimiter', () => {
+    const publicPaths = ['/sep31', '/sep38', '/info', '/sep24', '/sep6', '/metrics'];
+    const stack = (app as any)._router?.stack ?? [];
+
+    for (const path of publicPaths) {
+      const matchingLayers = stack.filter((layer: any) => (
+        layer?.regexp instanceof RegExp && layer.regexp.test(path)
+      ));
+      const limiterLayers = matchingLayers.filter((layer: any) => layer.handle === mockedPublicLimiter);
+      const routerLayers = matchingLayers.filter((layer: any) => layer.name === 'router');
+
+      expect(limiterLayers).toHaveLength(1);
+      expect(routerLayers).toHaveLength(1);
+    }
   });
 });

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -47,8 +47,32 @@ app.disable('x-powered-by');
 app.use(securityHeadersMiddleware);
 const PORT = config.PORT;
 
+const configuredOrigins = process.env.PRODUCTION_CORS_ORIGINS ?? '';
+const allowedOrigins = configuredOrigins
+  .split(',')
+  .map((origin) => origin.trim())
+  .filter((origin) => origin.length > 0);
+
+if (process.env.NODE_ENV === 'production' && allowedOrigins.length === 0) {
+  throw new Error('PRODUCTION_CORS_ORIGINS must be configured in production.');
+}
+
+const fallbackLocalOrigins = ['http://localhost:3000', 'http://127.0.0.1:3000'];
+const effectiveAllowedOrigins = allowedOrigins.length > 0 ? allowedOrigins : fallbackLocalOrigins;
+
 const corsOptions = {
-  origin: process.env.PRODUCTION_CORS_ORIGINS ? process.env.PRODUCTION_CORS_ORIGINS.split(',') : [],
+  origin: (origin: string | undefined, callback: (err: Error | null, allow?: boolean) => void) => {
+    if (!origin) {
+      return callback(null, true);
+    }
+
+    if (effectiveAllowedOrigins.includes(origin)) {
+      return callback(null, true);
+    }
+
+    logger.warn(`Blocked CORS origin: ${origin}`);
+    return callback(null, false);
+  },
   credentials: true,
   methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
   allowedHeaders: ['Content-Type', 'Authorization'],
@@ -223,13 +247,19 @@ app.use('/sep10', authLimiter, authRouter);
 // SEP-12 KYC routes
 app.use('/sep12', sep12Router);
 
-// Public endpoints — shared Redis-backed rate limit state
-app.use('/sep31', publicLimiter, sep31Router);
-app.use('/sep38', publicLimiter, sep38Router);
-app.use('/info', publicLimiter, infoRouter);
-app.use('/sep24', publicLimiter, sep24Router);
-app.use('/sep6', publicLimiter, sep6Router);
-app.use('/metrics', publicLimiter, metricsRouter);
+// Public endpoints — mounted once with shared Redis-backed rate limiting
+const publicRoutes: Array<[string, express.Router]> = [
+  ['/sep31', sep31Router],
+  ['/sep38', sep38Router],
+  ['/info', infoRouter],
+  ['/sep24', sep24Router],
+  ['/sep6', sep6Router],
+  ['/metrics', metricsRouter],
+];
+
+publicRoutes.forEach(([path, router]) => {
+  app.use(path, publicLimiter, router);
+});
 
 app.use('/api/recurring-payments', recurringPaymentsRouter);
 

--- a/dashboard/src/App.test.tsx
+++ b/dashboard/src/App.test.tsx
@@ -1,0 +1,92 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import App from './App';
+
+const connectMock = vi.fn();
+const disconnectMock = vi.fn();
+
+vi.mock('./lib/wallet/FreighterAdapter', () => {
+  class MockFreighterAdapter {
+    connect = connectMock;
+    disconnect = disconnectMock;
+  }
+
+  return { FreighterAdapter: MockFreighterAdapter };
+});
+
+vi.mock('./components/NotificationBell', () => ({
+  NotificationBell: () => <div data-testid="notification-bell" />,
+}));
+
+vi.mock('./components/CopyablePublicKey', () => ({
+  CopyablePublicKey: ({ publicKey }: { publicKey: string }) => <div>Connected wallet: {publicKey}</div>,
+}));
+
+vi.mock('./components/UserAvatarDropdown', () => ({
+  UserAvatarDropdown: ({ onSignOut }: { onSignOut?: () => void }) => (
+    <button type="button" onClick={onSignOut}>
+      Sign Out
+    </button>
+  ),
+}));
+
+vi.mock('./components/DashboardOverview', () => ({ default: () => <div>Dashboard Overview</div> }));
+vi.mock('./components/TransactionHistory', () => ({ default: () => <div>Transaction History</div> }));
+vi.mock('./components/SEP24Flow', () => ({ default: () => <div>SEP24</div> }));
+vi.mock('./components/KycStatusView', () => ({ default: () => <div>KYC</div> }));
+vi.mock('./components/NotificationCenter', () => ({ default: () => <div>Notifications</div> }));
+vi.mock('./components/NotificationPreferences', () => ({ default: () => <div>Notification Preferences</div> }));
+vi.mock('./components/Sep38QuotePanel', () => ({ default: () => <div>Sep38 Quote</div> }));
+vi.mock('./components/ServiceStatusPanel', () => ({ default: () => <div>Service Status</div> }));
+vi.mock('./components/SettingsView', () => ({ default: () => <div>Settings</div> }));
+
+describe('App wallet disconnect handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    connectMock.mockResolvedValue({ publicKey: 'GTESTPUBLICKEY123', network: 'testnet' });
+    disconnectMock.mockResolvedValue(undefined);
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: null }),
+      }),
+    );
+
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  it('resets wallet/session state and clears token/cache stores on sign out', async () => {
+    localStorage.setItem('authToken', 'token-123');
+    localStorage.setItem('transactionCache', 'cached-transactions');
+    localStorage.setItem('balanceStore', 'cached-balance');
+    localStorage.setItem('themePreference', 'dark');
+    sessionStorage.setItem('sessionToken', 'session-token');
+    sessionStorage.setItem('miscData', 'should-stay');
+
+    render(<App />);
+
+    fireEvent.click(screen.getByRole('button', { name: /connect wallet/i }));
+    await waitFor(() => expect(connectMock).toHaveBeenCalledTimes(1));
+    await screen.findByText(/Connected wallet:/i);
+
+    fireEvent.click(screen.getByRole('button', { name: 'History' }));
+    expect(screen.getByRole('heading', { name: 'History' })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Sign Out' }));
+    await waitFor(() => expect(disconnectMock).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(screen.getByRole('button', { name: /connect wallet/i })).toBeTruthy());
+
+    expect(screen.queryByText(/Connected wallet:/i)).toBeNull();
+    expect(screen.getByRole('heading', { name: 'Overview' })).toBeTruthy();
+
+    expect(localStorage.getItem('authToken')).toBeNull();
+    expect(localStorage.getItem('transactionCache')).toBeNull();
+    expect(localStorage.getItem('balanceStore')).toBeNull();
+    expect(localStorage.getItem('themePreference')).toEqual('dark');
+    expect(sessionStorage.getItem('sessionToken')).toBeNull();
+    expect(sessionStorage.getItem('miscData')).toEqual('should-stay');
+  });
+});

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { lazy, Suspense, useEffect, useMemo, useState } from 'react';
+import React, { lazy, Suspense, useCallback, useEffect, useMemo, useState } from 'react';
 import {
   LayoutDashboard,
   ArrowUpRight,
@@ -137,7 +137,43 @@ const App = () => {
   const [wallet, setWallet] = useState<{ publicKey: string; network: string } | null>(null);
   const [walletStatus, setWalletStatus] = useState<'idle' | 'connecting' | 'error'>('idle');
   const [walletError, setWalletError] = useState('');
+  const [walletSessionResetCounter, setWalletSessionResetCounter] = useState(0);
   const walletAdapter = useMemo(() => new FreighterAdapter(), []);
+
+  const clearClientSessionState = useCallback(() => {
+    const shouldClearKey = (key: string) => /token|session|wallet|transaction|balance/i.test(key);
+
+    for (let index = localStorage.length - 1; index >= 0; index -= 1) {
+      const key = localStorage.key(index);
+      if (key && shouldClearKey(key)) {
+        localStorage.removeItem(key);
+      }
+    }
+
+    for (let index = sessionStorage.length - 1; index >= 0; index -= 1) {
+      const key = sessionStorage.key(index);
+      if (key && shouldClearKey(key)) {
+        sessionStorage.removeItem(key);
+      }
+    }
+  }, []);
+
+  const handleWalletDisconnect = useCallback(async (skipAdapterDisconnect = false) => {
+    if (!skipAdapterDisconnect) {
+      try {
+        await walletAdapter.disconnect();
+      } catch (error) {
+        console.warn('Wallet disconnect cleanup failed:', error);
+      }
+    }
+
+    clearClientSessionState();
+    setWallet(null);
+    setWalletStatus('idle');
+    setWalletError('');
+    setActiveTab('dashboard');
+    setWalletSessionResetCounter((previous) => previous + 1);
+  }, [clearClientSessionState, walletAdapter]);
 
   useEffect(() => {
     let ignore = false;
@@ -170,6 +206,17 @@ const App = () => {
       ignore = true;
     };
   }, []);
+
+  useEffect(() => {
+    const handleExternalDisconnect = () => {
+      void handleWalletDisconnect(true);
+    };
+
+    window.addEventListener('freighter:disconnect', handleExternalDisconnect);
+    return () => {
+      window.removeEventListener('freighter:disconnect', handleExternalDisconnect);
+    };
+  }, [handleWalletDisconnect]);
 
   useEffect(() => {
     const mediaQuery = window.matchMedia('(min-width: 1024px)');
@@ -357,6 +404,9 @@ const App = () => {
             <UserAvatarDropdown
               onSettings={() => setActiveTab('settings')}
               onNotifications={() => setActiveTab('notifications')}
+              onSignOut={() => {
+                void handleWalletDisconnect();
+              }}
             />
           </div>
         </header>
@@ -399,7 +449,7 @@ const App = () => {
           <AnimatePresence mode="wait">
             <motion.div
               data-testid="active-view"
-              key={activeTab}
+              key={`${activeTab}:${walletSessionResetCounter}`}
               initial={{ opacity: 0, y: 10 }}
               animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0, y: -10 }}


### PR DESCRIPTION
closes #810
closes #812
closes #815
closes #819


## Summary
This PR addresses backend routing/CORS stability and dashboard wallet disconnect cleanup.

## What Changed

### Backend (`backend/src/index.ts`)
- Consolidated public route mounts so each endpoint is mounted exactly once:
  - `/sep31`
  - `/sep38`
  - `/info`
  - `/sep24`
  - `/sep6`
  - `/metrics`
- Applied `publicLimiter` uniformly via a single `publicRoutes` definition loop.
- Hardened CORS behavior:
  - Parse and trim `PRODUCTION_CORS_ORIGINS` into an explicit whitelist.
  - In `production`, fail startup when no allowed origins are configured.
  - In non-production, use strict localhost fallback only:
    - `http://localhost:3000`
    - `http://127.0.0.1:3000`
  - Explicitly validate incoming `Origin` against whitelist.
  - Block non-whitelisted origins (no CORS allow-origin response).

### Backend Tests (`backend/src/index.test.ts`)
- Added regression test ensuring each public route is mounted exactly once and includes `publicLimiter`.
- Added CORS header tests:
  - Allowed origin receives `access-control-allow-origin`.
  - Blocked origin does not receive `access-control-allow-origin`.

---

### Dashboard (`dashboard/src/App.tsx`)
- Added centralized wallet disconnect/reset flow:
  - Disconnect Freighter adapter.
  - Clear wallet auth/UI state (`wallet`, status, errors).
  - Reset active tab to unauthenticated default (`dashboard`).
  - Force view remount to clear child transactional state immediately.
- Added client storage cleanup on disconnect:
  - Remove storage keys matching: `token|session|wallet|transaction|balance` (case-insensitive).
  - Applied to both `localStorage` and `sessionStorage`.
- Wired cleanup to:
  - User avatar **Sign Out** action.
  - External wallet disconnect event: `freighter:disconnect`.

### Dashboard Tests (`dashboard/src/App.test.tsx`)
- Added unit test verifying sign-out:
  - Clears wallet/session transaction/balance/token caches.
  - Preserves unrelated storage keys.
  - Immediately resets UI to unauthenticated state (Connect Wallet visible, Overview active).

## Files Changed
- `backend/src/index.ts`
- `backend/src/index.test.ts`
- `dashboard/src/App.tsx`
- `dashboard/src/App.test.tsx`

