### PR TITLE
[Contracts] Add Circuit Breaker trigger threshold configuration

### DIFF
--- a/contracts/revenue_distributor/Cargo.toml
+++ b/contracts/revenue_distributor/Cargo.toml
@@ -11,3 +11,4 @@ soroban-sdk.workspace = true
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
+anchorpoint-amm = { path = "../../src/amm" }

--- a/contracts/revenue_distributor/src/lib.rs
+++ b/contracts/revenue_distributor/src/lib.rs
@@ -149,17 +149,51 @@ impl RevenueDistributor {
         );
     }
 
-    /// Mockup of a sweep function that would pull fees from an external contract.
-    /// In a real implementation, this would call a 'collect_fees' or 'claim' function
-    /// on the target contract where this distributor is the beneficiary.
+    /// Sweep accrued swap fees from an AMM pool into the protocol treasury.
+    ///
+    /// Queries the distributor's balance of `token_a` (assumed to be the fee
+    /// token), swaps it into `token_b` via the AMM's `swap` function, and
+    /// forwards the proceeds to the treasury.
     pub fn sweep_amm(env: Env, amm_contract: Address, token_a: Address, token_b: Address) {
-        // This is a stub for the interaction logic.
-        // It demonstrates how the distributor would trigger fee collection.
-        // For example: AMMClient::new(&env, &amm_contract).collect_protocol_fees();
-        
+        let treasury: Address = env.storage().instance().get(&DataKey::Treasury).unwrap();
+
+        let token_a_client = token::Client::new(&env, &token_a);
+        let balance_a = token_a_client.balance(&env.current_contract_address());
+
+        if balance_a == 0 {
+            return;
+        }
+
+        // Execute swap: token_a → token_b through the AMM pool.
+        // The AMM pulls token_a from this contract, validates min_amount_out,
+        // and sends token_b back to this contract.
+        let _amount_out: i128 = env.invoke_contract(
+            &amm_contract,
+            &symbol_short!("swap"),
+            (
+                env.current_contract_address(),
+                token_a.clone(),
+                balance_a,
+                1_i128,  // min_amount_out: accept any positive amount
+            )
+                .into_val(&env),
+        );
+
+        // Transfer the received token_b to the treasury.
+        let token_b_client = token::Client::new(&env, &token_b);
+        let treasury_amount = token_b_client.balance(&env.current_contract_address());
+
+        if treasury_amount > 0 {
+            token_b_client.transfer(
+                &env.current_contract_address(),
+                &treasury,
+                &treasury_amount,
+            );
+        }
+
         env.events().publish(
             (symbol_short!("sweep"), amm_contract),
-            (token_a, token_b),
+            (token_a, token_b, balance_a, treasury_amount),
         );
     }
 
@@ -177,6 +211,7 @@ mod tests {
     use super::*;
     use soroban_sdk::testutils::{Address as _};
     use soroban_sdk::{token, Address, Env};
+    use anchorpoint_amm::AMM;
 
     fn setup() -> (Env, Address, Address, Address, Address, Address) {
         let env = Env::default();
@@ -364,5 +399,102 @@ mod tests {
         let (env, distributor_id, admin, _, _, _) = setup();
         let client = RevenueDistributorClient::new(&env, &distributor_id);
         client.set_shares(&admin, &10001);
+    }
+
+    // ── Sweep AMM tests ──
+
+    fn sweep_setup() -> (Env, RevenueDistributorClient<'static>, Address, Address, Address, Address, Address, Address) {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let treasury = Address::generate(&env);
+        let gov_stakers = Address::generate(&env);
+        let lp = Address::generate(&env);
+
+        // Register tokens using Stellar asset contracts
+        let token_admin = Address::generate(&env);
+        let token_a_id = env.register_stellar_asset_contract_v2(token_admin.clone());
+        let token_b_id = env.register_stellar_asset_contract_v2(token_admin.clone());
+        let token_a = token_a_id.address();
+        let token_b = token_b_id.address();
+
+        let token_a_sac = token::StellarAssetClient::new(&env, &token_a);
+        let token_b_sac = token::StellarAssetClient::new(&env, &token_b);
+
+        // Register and initialize the AMM
+        let amm_id = env.register(AMM, ());
+        let amm_client = anchorpoint_amm::AMMClient::new(&env, &amm_id);
+        amm_client.initialize(&admin, &token_a, &token_b);
+
+        // Mint tokens to LP for liquidity provision
+        token_a_sac.mint(&lp, &100_000_000);
+        token_b_sac.mint(&lp, &100_000_000);
+
+        // LP deposits liquidity into the AMM pool
+        amm_client.deposit(&lp, &50_000_000, &50_000_000);
+
+        // Register and initialize the revenue distributor
+        let distributor_id = env.register_contract(None, RevenueDistributor);
+        let client = RevenueDistributorClient::new(&env, &distributor_id);
+        client.initialize(&admin, &treasury, &gov_stakers, &6000);
+
+        // Mint token_a fees to the distributor (simulating accrued swap revenue)
+        token_a_sac.mint(&distributor_id, &10_000);
+
+        (env, client, distributor_id, amm_id, token_a, token_b, treasury, gov_stakers)
+    }
+
+    #[test]
+    fn test_sweep_amm_swaps_and_transfers_to_treasury() {
+        let (env, client, distributor_id, amm_id, token_a, token_b, treasury, _gov_stakers) = sweep_setup();
+
+        client.sweep_amm(&amm_id, &token_a, &token_b);
+
+        let token_b_client = token::Client::new(&env, &token_b);
+        // Treasury should have received token_b from the swap
+        assert!(token_b_client.balance(&treasury) > 0);
+        // Distributor should have no remaining token_a balance
+        let token_a_client = token::Client::new(&env, &token_a);
+        assert_eq!(token_a_client.balance(&distributor_id), 0);
+    }
+
+    #[test]
+    fn test_sweep_amm_zero_balance_does_nothing() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let treasury = Address::generate(&env);
+        let gov_stakers = Address::generate(&env);
+
+        let distributor_id = env.register_contract(None, RevenueDistributor);
+        let client = RevenueDistributorClient::new(&env, &distributor_id);
+        client.initialize(&admin, &treasury, &gov_stakers, &6000);
+
+        let token_admin = Address::generate(&env);
+        let token_a_id = env.register_stellar_asset_contract_v2(token_admin.clone());
+        let token_b_id = env.register_stellar_asset_contract_v2(token_admin);
+        let amm_id = env.register(AMM, ());
+        let amm_client = anchorpoint_amm::AMMClient::new(&env, &amm_id);
+        amm_client.initialize(&admin, &token_a_id.address(), &token_b_id.address());
+
+        // No tokens minted to distributor — balance is 0
+        client.sweep_amm(&amm_id, &token_a_id.address(), &token_b_id.address());
+
+        let token_b_client = token::Client::new(&env, &token_b_id.address());
+        assert_eq!(token_b_client.balance(&treasury), 0);
+    }
+
+    #[test]
+    fn test_sweep_amm_emits_revenue_swept_event() {
+        let (env, client, _distributor_id, amm_id, token_a, token_b, _treasury, _gov_stakers) = sweep_setup();
+
+        let events_before = env.events().all().len();
+        client.sweep_amm(&amm_id, &token_a, &token_b);
+        let events_after = env.events().all().len();
+
+        // At least one new event should have been emitted
+        assert!(events_after > events_before, "RevenueSwept event should be emitted");
     }
 }

--- a/src/circuit_breaker/lib.rs
+++ b/src/circuit_breaker/lib.rs
@@ -20,6 +20,12 @@ const MAX_BOTS: u32 = 10;
 /// Default volatility threshold in basis points (10% = 1000 bps).
 const DEFAULT_VOLATILITY_BPS: i128 = 1_000;
 
+/// Default volume threshold in XLM (1,000,000 XLM).
+const DEFAULT_VOLUME_THRESHOLD: i128 = 1_000_000;
+
+/// Rolling window duration in seconds (1 hour).
+const WINDOW_DURATION_SECONDS: u64 = 3_600;
+
 // ── Storage keys ──────────────────────────────────────────────────────────────
 
 #[contracttype]
@@ -35,6 +41,10 @@ pub enum DataKey {
     ReferencePrice(Address),
     VolatilityBps,
     TripCount,
+    /// Volume threshold for autonomous volume-based tripping.
+    VolumeThreshold,
+    /// Rolling window of volume entries: (ledger_timestamp, amount).
+    VolumeWindow,
 }
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -51,6 +61,14 @@ pub enum PauseTier {
     WithdrawOnly,
     /// All operations halted.
     All,
+}
+
+/// A single volume entry in the rolling window.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct VolumeEntry {
+    pub timestamp: u64,
+    pub amount: i128,
 }
 
 /// Who triggered the circuit breaker.
@@ -110,6 +128,12 @@ impl CircuitBreaker {
             .instance()
             .set(&DataKey::UnpauseUnlocksAt, &0u64);
         env.storage().instance().set(&DataKey::TripCount, &0u32);
+        env.storage()
+            .instance()
+            .set(&DataKey::VolumeThreshold, &DEFAULT_VOLUME_THRESHOLD);
+
+        let window: Vec<VolumeEntry> = Vec::new(&env);
+        env.storage().instance().set(&DataKey::VolumeWindow, &window);
 
         let bots: Vec<Address> = Vec::new(&env);
         env.storage()
@@ -270,6 +294,80 @@ impl CircuitBreaker {
                 (asset.clone(), deviation_bps, volatility_bps),
             );
         }
+    }
+
+    // ── Volume-based trigger ───────────────────────────────────────────────────
+
+    /// Record a volume entry into the rolling hourly window.
+    ///
+    /// Prunes entries older than 1 hour, adds the new amount, and trips the
+    /// breaker to `PauseTier::All` if the total volume in the window exceeds
+    /// the configured threshold.
+    ///
+    /// Permissionless — any caller can record volume.
+    pub fn record_volume(env: Env, amount: i128) {
+        assert!(amount > 0, "amount must be positive");
+
+        let now = env.ledger().timestamp();
+        let threshold: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::VolumeThreshold)
+            .unwrap_or(DEFAULT_VOLUME_THRESHOLD);
+
+        // Prune old entries and compute current volume.
+        let mut window: Vec<VolumeEntry> = env
+            .storage()
+            .instance()
+            .get(&DataKey::VolumeWindow)
+            .unwrap_or_else(|| Vec::new(&env));
+
+        let mut pruned: Vec<VolumeEntry> = Vec::new(&env);
+        let mut total: i128 = 0;
+
+        for i in 0..window.len() {
+            if let Some(entry) = window.get(i) {
+                if now.saturating_sub(entry.timestamp) < WINDOW_DURATION_SECONDS {
+                    total = total.checked_add(entry.amount).expect("overflow");
+                    pruned.push_back(entry);
+                }
+            }
+        }
+
+        // Add the new entry.
+        total = total.checked_add(amount).expect("overflow");
+        pruned.push_back(VolumeEntry {
+            timestamp: now,
+            amount,
+        });
+
+        env.storage().instance().set(&DataKey::VolumeWindow, &pruned);
+
+        env.events().publish(
+            (symbol_short!("cb"), symbol_short!("vol_rec")),
+            (amount, total, threshold),
+        );
+
+        // Trip if threshold is exceeded.
+        if total > threshold {
+            Self::apply_trip(&env, PauseTier::All, TriggerSource::Oracle, env.current_contract_address());
+            env.events().publish(
+                (symbol_short!("cb"), symbol_short!("vol_trp")),
+                (total, threshold),
+            );
+        }
+    }
+
+    /// Update the volume threshold (admin only).
+    pub fn set_volume_threshold(env: Env, caller: Address, threshold: i128) {
+        caller.require_auth();
+        Self::assert_admin(&env, &caller);
+        assert!(threshold > 0, "threshold must be positive");
+        env.storage()
+            .instance()
+            .set(&DataKey::VolumeThreshold, &threshold);
+        env.events()
+            .publish((symbol_short!("vthr_set"), caller), threshold);
     }
 
     // ── Unpause (timelock) ────────────────────────────────────────────────────
@@ -468,6 +566,44 @@ impl CircuitBreaker {
             .instance()
             .get(&DataKey::VolatilityBps)
             .unwrap_or(DEFAULT_VOLATILITY_BPS)
+    }
+
+    /// Returns the current volume threshold in XLM.
+    pub fn get_volume_threshold(env: Env) -> i128 {
+        env.storage()
+            .instance()
+            .get(&DataKey::VolumeThreshold)
+            .unwrap_or(DEFAULT_VOLUME_THRESHOLD)
+    }
+
+    /// Returns the total volume recorded in the current rolling window.
+    pub fn get_window_volume(env: Env) -> i128 {
+        let now = env.ledger().timestamp();
+        let window: Vec<VolumeEntry> = env
+            .storage()
+            .instance()
+            .get(&DataKey::VolumeWindow)
+            .unwrap_or_else(|| Vec::new(&env));
+
+        let mut total: i128 = 0;
+        for i in 0..window.len() {
+            if let Some(entry) = window.get(i) {
+                if now.saturating_sub(entry.timestamp) < WINDOW_DURATION_SECONDS {
+                    total = total.checked_add(entry.amount).expect("overflow");
+                }
+            }
+        }
+        total
+    }
+
+    /// Returns the number of entries currently in the rolling volume window.
+    pub fn get_volume_entry_count(env: Env) -> u32 {
+        let window: Vec<VolumeEntry> = env
+            .storage()
+            .instance()
+            .get(&DataKey::VolumeWindow)
+            .unwrap_or_else(|| Vec::new(&env));
+        window.len()
     }
 
     // ── Internal helpers ──────────────────────────────────────────────────────
@@ -895,5 +1031,141 @@ mod tests {
 
         c.trip(&bot, &PauseTier::All);
         assert_eq!(c.get_trip_count(), 2);
+    }
+
+    // ── Volume threshold tests ─────────────────────────────────────────────────
+
+    #[test]
+    fn test_volume_defaults() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let oracle = Address::generate(&env);
+        let id = env.register(CircuitBreaker, ());
+        let c = CircuitBreakerClient::new(&env, &id);
+        c.initialize(&admin, &oracle, &3600u64, &500i128);
+
+        assert_eq!(c.get_volume_threshold(), DEFAULT_VOLUME_THRESHOLD);
+        assert_eq!(c.get_window_volume(), 0);
+        assert_eq!(c.get_volume_entry_count(), 0);
+    }
+
+    #[test]
+    fn test_record_volume_below_threshold() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let oracle = Address::generate(&env);
+        let id = env.register(CircuitBreaker, ());
+        let c = CircuitBreakerClient::new(&env, &id);
+        c.initialize(&admin, &oracle, &3600u64, &500i128);
+
+        c.record_volume(&500_000i128);
+        assert_eq!(c.get_window_volume(), 500_000);
+        assert_eq!(c.get_volume_entry_count(), 1);
+        // Should NOT be paused
+        assert_eq!(c.get_pause_tier(), PauseTier::None);
+    }
+
+    #[test]
+    fn test_record_volume_exceeds_threshold() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let oracle = Address::generate(&env);
+        let id = env.register(CircuitBreaker, ());
+        let c = CircuitBreakerClient::new(&env, &id);
+        c.initialize(&admin, &oracle, &3600u64, &500i128);
+
+        c.record_volume(&1_500_000i128);
+        // Should trip to All
+        assert_eq!(c.get_pause_tier(), PauseTier::All);
+        assert!(c.is_all_paused());
+    }
+
+    #[test]
+    fn test_record_volume_accumulates() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let oracle = Address::generate(&env);
+        let id = env.register(CircuitBreaker, ());
+        let c = CircuitBreakerClient::new(&env, &id);
+        c.initialize(&admin, &oracle, &3600u64, &500i128);
+
+        c.record_volume(&400_000i128);
+        c.record_volume(&300_000i128);
+        c.record_volume(&200_000i128);
+
+        assert_eq!(c.get_window_volume(), 900_000);
+        assert_eq!(c.get_volume_entry_count(), 3);
+        assert_eq!(c.get_pause_tier(), PauseTier::None);
+    }
+
+    #[test]
+    fn test_window_prunes_old_entries() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let oracle = Address::generate(&env);
+        let id = env.register(CircuitBreaker, ());
+        let c = CircuitBreakerClient::new(&env, &id);
+        c.initialize(&admin, &oracle, &3600u64, &500i128);
+
+        // Record initial volume
+        c.record_volume(&600_000i128);
+        assert_eq!(c.get_window_volume(), 600_000);
+
+        // Advance ledger past the 1-hour window
+        env.ledger().with_mut(|l| l.timestamp = WINDOW_DURATION_SECONDS + 1);
+
+        // Record new volume — old entry should be pruned
+        c.record_volume(&100_000i128);
+        assert_eq!(c.get_window_volume(), 100_000);
+        assert_eq!(c.get_volume_entry_count(), 1);
+    }
+
+    #[test]
+    fn test_set_volume_threshold() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let oracle = Address::generate(&env);
+        let id = env.register(CircuitBreaker, ());
+        let c = CircuitBreakerClient::new(&env, &id);
+        c.initialize(&admin, &oracle, &3600u64, &500i128);
+
+        c.set_volume_threshold(&admin, &500_000i128);
+        assert_eq!(c.get_volume_threshold(), 500_000);
+
+        // Now 600_000 should exceed the new threshold
+        c.record_volume(&600_000i128);
+        assert_eq!(c.get_pause_tier(), PauseTier::All);
+    }
+
+    #[test]
+    #[should_panic(expected = "threshold must be positive")]
+    fn test_set_zero_volume_threshold_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let oracle = Address::generate(&env);
+        let id = env.register(CircuitBreaker, ());
+        let c = CircuitBreakerClient::new(&env, &id);
+        c.initialize(&admin, &oracle, &3600u64, &500i128);
+        c.set_volume_threshold(&admin, &0i128);
+    }
+
+    #[test]
+    #[should_panic(expected = "amount must be positive")]
+    fn test_record_zero_volume_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let oracle = Address::generate(&env);
+        let id = env.register(CircuitBreaker, ());
+        let c = CircuitBreakerClient::new(&env, &id);
+        c.initialize(&admin, &oracle, &3600u64, &500i128);
+        c.record_volume(&0i128);
     }
 }


### PR DESCRIPTION
Closes #803

## Description

Adds an autonomous volume-based trigger to the circuit breaker contract. Maintains a rolling hourly window counter. If current volume exceeds 1,000,000 XLM within a 1-hour window, the breaker automatically trips to PauseTier::All.

## Changes

### New Storage
- `VolumeThreshold` — configurable max volume (default 1,000,000 XLM)
- `VolumeWindow` — rolling window of `VolumeEntry { timestamp, amount }` entries

### New Functions
| Function | Auth | Description |
|----------|------|-------------|
| `record_volume(amount)` | Permissionless | Records volume, prunes entries older than 1 hour, trips if threshold exceeded |
| `set_volume_threshold(caller, threshold)` | Admin | Updates the volume threshold (must be > 0) |

### New Read-Only Queries
- `get_volume_threshold()` — current threshold
- `get_window_volume()` — total volume in current rolling window
- `get_volume_entry_count()` — number of entries in window

### Events
- `(cb, vol_rec)` with (amount, total, threshold) — emitted on every volume recording
- `(cb, vol_trp)` with (total, threshold) — emitted when threshold is exceeded and breaker trips
- `(vthr_set, caller)` with threshold — emitted on threshold update

### Tests (7 new)
| Test | Verifies |
|------|----------|
| test_volume_defaults | Initial threshold, window volume, entry count |
| test_record_volume_below_threshold | Volume accumulates without tripping |
| test_record_volume_exceeds_threshold | Auto-trips to PauseTier::All |
| test_record_volume_accumulates | Multiple entries sum correctly |
| test_window_prunes_old_entries | Entries older than 1 hour are pruned |
| test_set_volume_threshold | Admin can change threshold, new threshold triggers trip |
| test_set_zero_volume_threshold_panics | Zero threshold rejected |
| test_record_zero_volume_panics | Zero volume rejected