### PR TITLE
[DevOps] [DevOps] Add Docker Compose production configuration with SSL termination

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,130 @@
+x-backend-common: &backend-common
+  build:
+    context: ./backend
+    dockerfile: Dockerfile
+  environment:
+    - NODE_ENV=production
+    - PORT=3002
+    - DATABASE_URL=postgresql://${POSTGRES_USER:-anchorpoint}:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in your production environment}@postgres:5432/${POSTGRES_DB:-anchorpoint}
+    - REDIS_URL=redis://:${REDIS_PASSWORD:?Set REDIS_PASSWORD in your production environment}@redis:6379
+    - JAEGER_ENDPOINT=http://jaeger:14268/api/traces
+    - PROMETHEUS_METRICS_PORT=9464
+    - OTEL_SERVICE_NAME=anchorpoint-backend
+    - OTEL_RESOURCE_ATTRIBUTES=service.name=anchorpoint-backend,service.version=1.0.0
+  depends_on:
+    postgres:
+      condition: service_healthy
+    redis:
+      condition: service_healthy
+  healthcheck:
+    test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3002/health"]
+    interval: 30s
+    timeout: 3s
+    retries: 3
+    start_period: 10s
+  restart: unless-stopped
+  networks:
+    - anchorpoint-production-network
+
+services:
+  proxy:
+    image: nginx:1.27-alpine
+    container_name: anchorpoint-proxy
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./infra/nginx/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./infra/nginx/certs:/etc/nginx/certs:ro
+    depends_on:
+      dashboard:
+        condition: service_healthy
+      backend-1:
+        condition: service_healthy
+      backend-2:
+        condition: service_healthy
+      backend-3:
+        condition: service_healthy
+    restart: unless-stopped
+    networks:
+      - anchorpoint-production-network
+
+  dashboard:
+    build:
+      context: .
+      dockerfile: dashboard/Dockerfile
+    environment:
+      - NODE_ENV=production
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:80/health"]
+      interval: 30s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+    restart: unless-stopped
+    networks:
+      - anchorpoint-production-network
+
+  backend-1:
+    <<: *backend-common
+
+  backend-2:
+    <<: *backend-common
+
+  backend-3:
+    <<: *backend-common
+
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      - POSTGRES_USER=${POSTGRES_USER:-anchorpoint}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in your production environment}
+      - POSTGRES_DB=${POSTGRES_DB:-anchorpoint}
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-anchorpoint}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    restart: unless-stopped
+    networks:
+      - anchorpoint-production-network
+
+  redis:
+    image: redis:7-alpine
+    command: redis-server --requirepass ${REDIS_PASSWORD:?Set REDIS_PASSWORD in your production environment}
+    environment:
+      - REDIS_PASSWORD=${REDIS_PASSWORD:?Set REDIS_PASSWORD in your production environment}
+    volumes:
+      - redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD}", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+    restart: unless-stopped
+    networks:
+      - anchorpoint-production-network
+
+  jaeger:
+    image: jaegertracing/all-in-one:latest
+    profiles:
+      - monitoring
+    environment:
+      - COLLECTOR_OTLP_ENABLED=true
+    restart: unless-stopped
+    networks:
+      - anchorpoint-production-network
+
+volumes:
+  postgres-data:
+    driver: local
+  redis-data:
+    driver: local
+
+networks:
+  anchorpoint-production-network:
+    driver: bridge

--- a/infra/nginx/nginx.conf
+++ b/infra/nginx/nginx.conf
@@ -1,0 +1,80 @@
+resolver 127.0.0.11 ipv6=off valid=30s;
+
+upstream anchorpoint_dashboard {
+    zone anchorpoint_dashboard 64k;
+    server dashboard:80 resolve;
+    keepalive 16;
+}
+
+upstream anchorpoint_backend {
+    zone anchorpoint_backend 64k;
+    least_conn;
+    server backend-1:3002 resolve max_fails=3 fail_timeout=30s;
+    server backend-2:3002 resolve max_fails=3 fail_timeout=30s;
+    server backend-3:3002 resolve max_fails=3 fail_timeout=30s;
+    keepalive 32;
+}
+
+server {
+    listen 80;
+    server_name _;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    http2 on;
+    server_name _;
+
+    ssl_certificate /etc/nginx/certs/fullchain.pem;
+    ssl_certificate_key /etc/nginx/certs/privkey.pem;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers on;
+    ssl_session_cache shared:SSL:10m;
+    ssl_session_timeout 10m;
+
+    server_tokens off;
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript image/svg+xml;
+    gzip_min_length 256;
+    gzip_vary on;
+
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Host $host;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header Connection "";
+
+    location = /api {
+        return 301 /api/;
+    }
+
+    location /api/ {
+        proxy_pass http://anchorpoint_backend/;
+        proxy_connect_timeout 5s;
+        proxy_read_timeout 60s;
+        proxy_send_timeout 60s;
+        proxy_buffering off;
+    }
+
+    location = /health {
+        proxy_pass http://anchorpoint_backend/health;
+        proxy_connect_timeout 5s;
+        proxy_read_timeout 10s;
+    }
+
+    location / {
+        proxy_pass http://anchorpoint_dashboard;
+        proxy_connect_timeout 5s;
+        proxy_read_timeout 60s;
+        proxy_send_timeout 60s;
+    }
+}


### PR DESCRIPTION
## Summary
- Added `docker-compose.prod.yml` for production with NGINX SSL termination and a backend replica pool.
- Added `infra/nginx/nginx.conf` with HTTP→HTTPS redirect, TLS termination, and proxy routing for dashboard and API traffic.
- Mounted certificate files from `infra/nginx/certs/`.

## Testing
- `POSTGRES_PASSWORD=dummy REDIS_PASSWORD=dummy docker compose -f docker-compose.prod.yml config`
- `docker run --rm -v "$PWD/infra/nginx/nginx.conf:/etc/nginx/conf.d/default.conf:ro" -v "$PWD/infra/nginx/certs:/etc/nginx/certs:ro" nginx:1.27-alpine nginx -t`

Closes ceejaylaboratory/AnchorPoint#826