### PR TITLE
fix(backend): harden Redis connection error handling

### DIFF
--- a/backend/src/lib/redis.test.ts
+++ b/backend/src/lib/redis.test.ts
@@ -1,0 +1,85 @@
+import { EventEmitter } from 'events';
+
+const mockLogger = {
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+};
+
+class MockRedisClient extends EventEmitter {
+  public get = jest.fn();
+  public set = jest.fn();
+  public del = jest.fn();
+  public publish = jest.fn();
+  public ping = jest.fn();
+  public call = jest.fn();
+  public exists = jest.fn();
+  public duplicate: jest.Mock;
+
+  constructor() {
+    super();
+    this.duplicate = jest.fn(() => {
+      const duplicate = new MockRedisClient();
+      mockRedisInstances.push(duplicate);
+      return duplicate;
+    });
+  }
+}
+
+const mockRedisInstances: MockRedisClient[] = [];
+const mockRedisConstructor = jest.fn(() => {
+  const client = new MockRedisClient();
+  mockRedisInstances.push(client);
+  return client;
+});
+
+jest.mock('ioredis', () => ({
+  __esModule: true,
+  default: mockRedisConstructor,
+}));
+
+jest.mock('../utils/logger', () => ({
+  __esModule: true,
+  default: mockLogger,
+}));
+
+describe('Redis client error handling', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  const loadRedisModule = () => {
+    let moduleRef: typeof import('./redis');
+
+    jest.isolateModules(() => {
+      moduleRef = require('./redis');
+    });
+
+    return moduleRef!;
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRedisInstances.length = 0;
+    process.env.NODE_ENV = 'production';
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+  });
+
+  it('logs Redis connection errors without throwing for the primary client', () => {
+    const { redis } = loadRedisModule();
+    const error = new Error('ECONNREFUSED');
+
+    expect(() => (redis as MockRedisClient).emit('error', error)).not.toThrow();
+    expect(mockLogger.error).toHaveBeenCalledWith('Redis connection error:', error);
+  });
+
+  it('logs Redis connection errors without throwing for duplicated clients', () => {
+    const { redis } = loadRedisModule();
+    const duplicate = (redis as MockRedisClient).duplicate() as MockRedisClient;
+    const error = new Error('READONLY');
+
+    expect(() => duplicate.emit('error', error)).not.toThrow();
+    expect(mockLogger.error).toHaveBeenCalledWith('Redis connection error:', error);
+  });
+});

--- a/backend/src/lib/redis.ts
+++ b/backend/src/lib/redis.ts
@@ -5,51 +5,84 @@ const redisUrl = process.env.REDIS_URL || 'redis://localhost:6379';
 
 const isTest = process.env.NODE_ENV === 'test';
 
-const createNoop = <T extends (...args: any[]) => any>(result?: ReturnType<T>) => {
-  return (..._args: Parameters<T>) => result;
+type RedisClientLike = {
+  on: (event: string, handler: (...args: unknown[]) => void) => void;
+  duplicate: (...args: unknown[]) => RedisClientLike;
 };
 
-export const redis = isTest 
-  ? ({
-      duplicate: () => ({
-        subscribe: createNoop<(channel: string, callback?: (err: Error | null) => void) => void>(undefined),
-        on: createNoop<(event: string, handler: (...args: any[]) => void) => void>(undefined),
-      }),
-      call: (command: string, ...args: any[]) => {
-        const cmd = command.toLowerCase();
-        if (cmd === 'eval' || cmd === 'evalsha') {
-          return [1, 60];
-        }
-        if (cmd === 'script' && args[0]?.toLowerCase() === 'load') {
-          return 'mock-sha-1234567890';
-        }
-        return 1;
-      },
-      on: createNoop<(event: string, handler: (...args: any[]) => void) => void>(undefined),
-      get: createNoop<(key: string) => Promise<string | null>>(Promise.resolve(null)),
-      set: createNoop<(key: string, value: string) => Promise<'OK'>>(Promise.resolve('OK')),
-      del: createNoop<(key: string) => Promise<number>>(Promise.resolve(1)),
-      publish: createNoop<(channel: string, message: string) => Promise<number>>(Promise.resolve(1)),
-      ping: createNoop<() => Promise<string>>(Promise.resolve('PONG')),
-    } as any)
+type RedisTestClient = RedisClientLike & {
+  subscribe: (channel: string, callback?: (err: Error | null) => void) => void;
+  call: (command: string, ...args: unknown[]) => number | string | [number, number];
+  get: (key: string) => Promise<string | null>;
+  set: (key: string, value: string) => Promise<'OK'>;
+  del: (key: string) => Promise<number>;
+  publish: (channel: string, message: string) => Promise<number>;
+  ping: () => Promise<string>;
+};
 
-
-
-  : new Redis(redisUrl, {
-      maxRetriesPerRequest: 3,
-      retryStrategy: (times: number) => {
-        const delay = Math.min(times * 50, 2000);
-        return delay;
-      },
-    });
-
-if (!isTest) {
-  redis.on('connect', () => {
+const attachRedisEventHandlers = <T extends RedisClientLike>(client: T) => {
+  client.on('connect', () => {
     logger.info('Redis connected successfully');
   });
 
-  redis.on('error', (err: Error) => {
-    logger.error('Redis connection error:', err);
+  client.on('error', (err: unknown) => {
+    logger.error('Redis connection error:', err instanceof Error ? err : new Error(String(err)));
   });
-}
 
+  client.on('close', () => {
+    logger.warn('Redis connection closed');
+  });
+
+  client.on('reconnecting', (delay: unknown) => {
+    logger.warn(`Redis reconnecting in ${typeof delay === 'number' ? delay : 0}ms`);
+  });
+
+  return client;
+};
+
+const decorateDuplicateMethod = <T extends RedisClientLike>(client: T): T => {
+  const originalDuplicate = client.duplicate.bind(client);
+
+  client.duplicate = ((...args: unknown[]) => {
+    return decorateDuplicateMethod(attachRedisEventHandlers(originalDuplicate(...args) as T));
+  }) as T['duplicate'];
+
+  return client;
+};
+
+const createRedisClient = () => {
+  const client = new Redis(redisUrl, {
+    maxRetriesPerRequest: 3,
+    retryStrategy: (times: number) => {
+      const delay = Math.min(times * 50, 2000);
+      return delay;
+    },
+  }) as RedisClientLike;
+
+  return decorateDuplicateMethod(attachRedisEventHandlers(client));
+};
+
+const createTestRedisClient = (): RedisTestClient => ({
+  duplicate: () => createTestRedisClient(),
+  subscribe: () => undefined,
+  on: () => undefined,
+  call: (command: string, ...args: unknown[]) => {
+    const cmd = command.toLowerCase();
+    if (cmd === 'eval' || cmd === 'evalsha') {
+      return [1, 60];
+    }
+    if (cmd === 'script' && typeof args[0] === 'string' && args[0].toLowerCase() === 'load') {
+      return 'mock-sha-1234567890';
+    }
+    return 1;
+  },
+  get: async () => null,
+  set: async () => 'OK',
+  del: async () => 1,
+  publish: async () => 1,
+  ping: async () => 'PONG',
+});
+
+export const redis = isTest 
+  ? createTestRedisClient()
+  : createRedisClient();


### PR DESCRIPTION
## Summary
- Attach Redis connection lifecycle handlers to the primary client and all duplicates.
- Log Redis connection errors without letting them surface as unhandled events.

## Testing
- npx eslint backend/src/lib/redis.ts backend/src/lib/redis.test.ts
- npm test -- --runInBand --coverage=false src/lib/redis.test.ts

Closes ceejaylaboratory/AnchorPoint#813.