### PR TITLE
feat(contracts): add comprehensive panic message error enums for anch…

### DIFF
--- a/contracts/anchorpoint/src/admin.rs
+++ b/contracts/anchorpoint/src/admin.rs
@@ -2,6 +2,7 @@
 //! Rationale: In an admin context, separating cooldowns ensures emergency functions remain available even if regular maintenance functions were just called.
 
 use crate::rate_limit::{ActionType, RateLimiter, RateLimitError};
+use crate::Error;
 use soroban_sdk::{Env, Address};
 
 /// Admin module wrapper.
@@ -9,23 +10,25 @@ use soroban_sdk::{Env, Address};
 pub struct Admin;
 
 impl Admin {
-    pub fn update_oracle(env: Env, admin: Address, _feed_id: u32, _price: i128) -> Result<(), RateLimitError> {
+    pub fn update_oracle(env: Env, admin: Address, _feed_id: u32, _price: i128) -> Result<(), Error> {
         admin.require_auth();
         
         // Security: Admin key compromise during lockout
         // If the cooldown is active and the admin key is compromised, the attacker must still wait out 
         // the cooldown. This provides an essential time window to intervene.
-        RateLimiter::check_and_update(&env, ActionType::UpdateOracle)?;
+        RateLimiter::check_and_update(&env, ActionType::UpdateOracle)
+            .map_err(|_: RateLimitError| Error::Unauthorized)?;
         
         // ... oracle updating logic ...
         Ok(())
     }
 
-    pub fn set_fee(env: Env, admin: Address, _new_fee: u32) -> Result<(), RateLimitError> {
+    pub fn set_fee(env: Env, admin: Address, _new_fee: u32) -> Result<(), Error> {
         admin.require_auth();
         
         // Independent action cooldown allows setting fees even if the oracle was just updated.
-        RateLimiter::check_and_update(&env, ActionType::SetFee)?;
+        RateLimiter::check_and_update(&env, ActionType::SetFee)
+            .map_err(|_: RateLimitError| Error::Unauthorized)?;
         
         // ... fee setting logic ...
         Ok(())

--- a/contracts/anchorpoint/src/lib.rs
+++ b/contracts/anchorpoint/src/lib.rs
@@ -7,5 +7,38 @@ pub mod storage_keys;
 #[cfg(test)]
 mod tests;
 
+use soroban_sdk::contracterror;
+
+/// Explicit error codes replacing generic panics across AnchorPoint contracts.
+///
+/// Using `#[contracterror]` ensures every error surface is machine-readable
+/// (u32 code) and observable in transaction results without parsing raw panic
+/// strings.
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum Error {
+    /// Caller is not the authorised admin.
+    Unauthorized = 1,
+    /// Contract has already been initialised.
+    AlreadyInitialized = 2,
+    /// The supplied amount is zero or negative.
+    InvalidAmount = 3,
+    /// The caller's balance is too low for the requested operation.
+    InsufficientBalance = 4,
+    /// The caller's allowance is too low for the requested operation.
+    InsufficientAllowance = 5,
+    /// The deposit would push total supply past the configured cap.
+    SupplyCapExceeded = 6,
+    /// The requested operation is blocked while the contract is paused.
+    ContractPaused = 7,
+    /// A required storage entry was not found.
+    NotInitialized = 8,
+    /// The provided batch exceeds the maximum allowed size.
+    BatchTooLarge = 9,
+    /// The provided batch is empty.
+    EmptyBatch = 10,
+}
+
 #[soroban_sdk::contract]
 pub struct AnchorPointContract;

--- a/contracts/anchorpoint/src/tests/admin_tests.rs
+++ b/contracts/anchorpoint/src/tests/admin_tests.rs
@@ -4,6 +4,7 @@
 
 use crate::admin::Admin;
 use crate::rate_limit::{ActionType, RateLimiter, RateLimitError};
+use crate::Error;
 use soroban_sdk::{testutils::Address as _, testutils::Ledger, Address, Env};
 
 #[test]
@@ -123,5 +124,43 @@ fn test_set_fee_cooldown_independent_of_add_asset() {
 
         assert_eq!(RateLimiter::check_and_update(&env, ActionType::AddAsset), Ok(()));
         assert_eq!(RateLimiter::check_and_update(&env, ActionType::SetFee), Ok(()));
+    });
+}
+
+// -------------------------------------------------------------------------
+// Error enum tests (#808)
+// -------------------------------------------------------------------------
+
+#[test]
+fn test_error_codes_are_distinct_u32() {
+    // Each variant must map to a unique non-zero u32.
+    assert_eq!(Error::Unauthorized as u32, 1);
+    assert_eq!(Error::AlreadyInitialized as u32, 2);
+    assert_eq!(Error::InvalidAmount as u32, 3);
+    assert_eq!(Error::InsufficientBalance as u32, 4);
+    assert_eq!(Error::InsufficientAllowance as u32, 5);
+    assert_eq!(Error::SupplyCapExceeded as u32, 6);
+    assert_eq!(Error::ContractPaused as u32, 7);
+    assert_eq!(Error::NotInitialized as u32, 8);
+    assert_eq!(Error::BatchTooLarge as u32, 9);
+    assert_eq!(Error::EmptyBatch as u32, 10);
+}
+
+#[test]
+fn test_admin_rate_limit_returns_error_enum() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+
+    let contract_id = env.register(crate::AnchorPointContract, ());
+    env.as_contract(&contract_id, || {
+        env.ledger().set_timestamp(1000);
+        // First call succeeds → Ok(())
+        assert_eq!(Admin::update_oracle(env.clone(), admin.clone(), 0, 100), Ok(()));
+        // Second call within cooldown → Err(Error::Unauthorized)
+        assert_eq!(
+            Admin::update_oracle(env.clone(), admin.clone(), 0, 200),
+            Err(Error::Unauthorized),
+        );
     });
 }


### PR DESCRIPTION
…orpoint core - Define #[contracterror] #[repr(u32)] enum Error with 10 explicit codes (Unauthorized=1, AlreadyInitialized=2, InvalidAmount=3, InsufficientBalance=4, InsufficientAllowance=5, SupplyCapExceeded=6, ContractPaused=7, NotInitialized=8, BatchTooLarge=9, EmptyBatch=10) - Replace RateLimitError returns in admin.rs with Err(Error::Unauthorized) - Add test_error_codes_are_distinct_u32 verifying all u32 codes - Add test_admin_rate_limit_returns_error_enum verifying Err(Error::Unauthorized) on cooldown Closes #808