### PR TITLE
[Contracts] Implement security registry contract pause status query

### DIFF
--- a/src/security_registry/lib.rs
+++ b/src/security_registry/lib.rs
@@ -7,6 +7,8 @@ use soroban_sdk::{contract, contractimpl, contracttype, Address, Env};
 pub enum DataKey {
     SuperAdmin,
     IsPaused,
+    /// Pause status per individual registered contract
+    ContractPaused(Address),
 }
 
 #[contract]
@@ -54,6 +56,50 @@ impl SecurityRegistry {
             .get(&DataKey::IsPaused)
             .unwrap_or(false)
     }
+
+    // -------------------------------------------------------------------------
+    // Per-contract pause registry
+    // -------------------------------------------------------------------------
+
+    /// Pause a specific registered contract.
+    pub fn pause_contract(env: Env, admin: Address, contract_id: Address) {
+        admin.require_auth();
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::SuperAdmin)
+            .expect("not initialized");
+        if admin != stored_admin {
+            panic!("not super admin");
+        }
+        env.storage()
+            .persistent()
+            .set(&DataKey::ContractPaused(contract_id), &true);
+    }
+
+    /// Unpause a specific registered contract.
+    pub fn unpause_contract(env: Env, admin: Address, contract_id: Address) {
+        admin.require_auth();
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::SuperAdmin)
+            .expect("not initialized");
+        if admin != stored_admin {
+            panic!("not super admin");
+        }
+        env.storage()
+            .persistent()
+            .set(&DataKey::ContractPaused(contract_id), &false);
+    }
+
+    /// Read-only query returning whether a specific contract is paused.
+    pub fn is_contract_paused(env: Env, contract_id: Address) -> bool {
+        env.storage()
+            .persistent()
+            .get(&DataKey::ContractPaused(contract_id))
+            .unwrap_or(false)
+    }
 }
 
 #[cfg(test)]
@@ -77,5 +123,41 @@ mod tests {
 
         client.unpause(&admin);
         assert_eq!(client.is_paused(), false);
+    }
+
+    #[test]
+    fn test_is_contract_paused_default_false() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let registry_id = env.register(SecurityRegistry, ());
+        let client = SecurityRegistryClient::new(&env, &registry_id);
+        client.initialize(&admin);
+
+        let some_contract = Address::generate(&env);
+        assert_eq!(client.is_contract_paused(&some_contract), false);
+    }
+
+    #[test]
+    fn test_pause_and_query_specific_contract() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let registry_id = env.register(SecurityRegistry, ());
+        let client = SecurityRegistryClient::new(&env, &registry_id);
+        client.initialize(&admin);
+
+        let target = Address::generate(&env);
+        let other = Address::generate(&env);
+
+        assert_eq!(client.is_contract_paused(&target), false);
+
+        client.pause_contract(&admin, &target);
+        assert_eq!(client.is_contract_paused(&target), true);
+        // Other contract must remain unaffected
+        assert_eq!(client.is_contract_paused(&other), false);
+
+        client.unpause_contract(&admin, &target);
+        assert_eq!(client.is_contract_paused(&target), false);
     }
 }


### PR DESCRIPTION
## Summary

Provides a lightweight read-only method returning pause status for individual registered contracts in the Security Registry.

## Changes

- Added `ContractPaused(Address)` variant to `DataKey` enum
- Added `pause_contract(admin, contract_id)` admin method
- Added `unpause_contract(admin, contract_id)` admin method
- Added `is_contract_paused(contract_id) -> bool` read-only query

## Tests

- `test_is_contract_paused_default_false`
- `test_pause_and_query_specific_contract` (also verifies isolation between contracts)

Closes #806
