### PR TITLE
[Backend] Add TTL expiry scheduler for temporary document uploads

### DIFF
--- a/backend/prisma/migrations/20260728000000_add_upload_record_expiry/migration.sql
+++ b/backend/prisma/migrations/20260728000000_add_upload_record_expiry/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable: add isTemporary flag to support TTL expiry scheduler
+ALTER TABLE "UploadRecord" ADD COLUMN "isTemporary" BOOLEAN NOT NULL DEFAULT true;
+
+-- CreateIndex: composite index for efficient expiry queries
+CREATE INDEX "UploadRecord_isTemporary_status_createdAt_idx" ON "UploadRecord"("isTemporary", "status", "createdAt");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -427,3 +427,16 @@ model CrawlJobRecord {
   nonCompliantCount Int
   suspiciousCount   Int
 }
+
+model UploadRecord {
+  id          String   @id @default(uuid())
+  key         String   @unique
+  contentType String
+  status      String   @default("PENDING")
+  isTemporary Boolean  @default(true)
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  @@index([status])
+  @@index([isTemporary, status, createdAt])
+}

--- a/backend/src/services/storage-provider.service.ts
+++ b/backend/src/services/storage-provider.service.ts
@@ -9,6 +9,8 @@ export interface StorageProvider {
   generatePresignedPutUrl(key: string, contentType: string, expiresInSeconds: number): Promise<string>;
   /** Return true when the object at `key` exists in the bucket. */
   objectExists(key: string): Promise<boolean>;
+  /** Permanently delete the object at `key` from the bucket. */
+  deleteObject(key: string): Promise<void>;
 }
 
 export type StorageProviderKind = 'mock' | 's3' | 'gcs';
@@ -78,6 +80,10 @@ export class MockStorageProvider implements StorageProvider {
     return this.uploadedKeys.has(key);
   }
 
+  async deleteObject(key: string): Promise<void> {
+    this.uploadedKeys.delete(key);
+  }
+
   /** Test helper: simulate a completed upload for a key. */
   _markUploaded(key: string): void {
     this.uploadedKeys.add(key);
@@ -105,6 +111,10 @@ export class S3StorageProvider implements StorageProvider {
   async objectExists(_key: string): Promise<boolean> {
     return false;
   }
+
+  async deleteObject(_key: string): Promise<void> {
+    // S3 stub: real deletion would use DeleteObjectCommand
+  }
 }
 
 /** Google Cloud Storage implementation of StorageProvider. */
@@ -125,6 +135,10 @@ export class GcsStorageProvider implements StorageProvider {
 
   async objectExists(_key: string): Promise<boolean> {
     return false;
+  }
+
+  async deleteObject(_key: string): Promise<void> {
+    // GCS stub: real deletion would use storage.bucket().file(key).delete()
   }
 }
 

--- a/backend/src/services/upload-store.service.ts
+++ b/backend/src/services/upload-store.service.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'crypto';
 import { generateStorageKey } from '../utils/storage-key';
 
-export type UploadStatus = 'PENDING' | 'COMPLETED' | 'EXPIRED';
+export type UploadStatus = 'PENDING' | 'COMPLETED' | 'EXPIRED' | 'EXPIRED_DELETED';
 
 export interface UploadRecord {
   uploadId: string;

--- a/backend/src/workers/upload-expiry.scheduler.ts
+++ b/backend/src/workers/upload-expiry.scheduler.ts
@@ -1,20 +1,31 @@
 import cron, { ScheduledTask } from 'node-cron';
 import { uploadStore } from '../services/upload-store.service';
+import { storageProvider } from '../services/storage-provider.service';
+import prisma from '../lib/prisma';
 import logger from '../utils/logger';
+
+const TTL_DAYS = 30;
 
 export class UploadExpiryScheduler {
   private task: ScheduledTask | null = null;
 
   start(): void {
     // Run every minute to expire stale uploads
-    this.task = cron.schedule('* * * * *', () => {
+    this.task = cron.schedule('* * * * *', async () => {
       try {
+        // In-memory fallback expiry
         const expiredCount = uploadStore.expireStale();
         if (expiredCount > 0) {
-          logger.info(`Expired ${expiredCount} stale KYC upload records`);
+          logger.info(`Expired ${expiredCount} stale KYC upload records (in-memory)`);
         }
       } catch (error) {
-        logger.error('Failed to run upload expiry task', { error });
+        logger.error('Failed to run in-memory upload expiry task', { error });
+      }
+
+      try {
+        await this.expireDbUploads();
+      } catch (error) {
+        logger.error('Failed to run DB upload expiry task', { error });
       }
     });
 
@@ -27,6 +38,43 @@ export class UploadExpiryScheduler {
       this.task = null;
     }
     logger.info('Upload expiry scheduler stopped');
+  }
+
+  /** Query DB for temporary uploads older than TTL_DAYS and delete them from storage. */
+  async expireDbUploads(): Promise<number> {
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - TTL_DAYS);
+
+    const records = await (prisma as any).uploadRecord.findMany({
+      where: {
+        isTemporary: true,
+        status: { not: 'EXPIRED_DELETED' },
+        createdAt: { lt: cutoff },
+      },
+      select: { id: true, key: true },
+    });
+
+    if (records.length === 0) return 0;
+
+    let deleted = 0;
+    for (const record of records) {
+      try {
+        await storageProvider.deleteObject(record.key);
+        await (prisma as any).uploadRecord.update({
+          where: { id: record.id },
+          data: { status: 'EXPIRED_DELETED' },
+        });
+        deleted++;
+      } catch (error) {
+        logger.error('Failed to expire upload record', { id: record.id, key: record.key, error });
+      }
+    }
+
+    if (deleted > 0) {
+      logger.info(`Expired and deleted ${deleted} temporary upload records from storage`);
+    }
+
+    return deleted;
   }
 }
 


### PR DESCRIPTION
## Summary

Enhances the upload expiry scheduler to query the database for temporary KYC uploads older than 30 days, delete their objects from storage, and mark records as `EXPIRED_DELETED`.

## Changes

- `prisma/schema.prisma` — added `isTemporary` flag and composite index on UploadRecord
- `prisma/migrations/` — migration adding the column and index
- `upload-store.service.ts` — added `'EXPIRED_DELETED'` to `UploadStatus`
- `storage-provider.service.ts` — added `deleteObject(key)` to interface + Mock/S3/GCS implementations
- `upload-expiry.scheduler.ts` — added DB-backed `expireDbUploads()`; keeps in-memory fallback

Closes #740