### PR TITLE
[Backend] Add WebSocket server for real-time transaction status updates

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -71,6 +71,7 @@
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1",
     "uuid": "^9.0.0",
+    "socket.io": "^4.8.1",
     "vite": "^6.4.3",
     "winston": "^3.19.0",
     "zod": "^4.3.6"

--- a/backend/src/api/routes/transactions.route.ts
+++ b/backend/src/api/routes/transactions.route.ts
@@ -5,6 +5,7 @@ import { authMiddleware, AuthRequest } from '../middleware/auth.middleware';
 import { validate } from '../middleware/validate.middleware';
 import { stellarService } from '../../services/stellar.service';
 import { submissionLimiter } from '../middleware/rate-limit.middleware';
+import { emitTxUpdated } from '../../lib/socket';
 
 
 const router = Router();
@@ -270,6 +271,76 @@ router.post('/submit', authMiddleware, submissionLimiter, validate({ body: submi
       status: 'error',
       message: error.message,
     });
+  }
+});
+
+const statusUpdateSchema = z.object({
+  status: z.enum(['PENDING', 'COMPLETED', 'FAILED']),
+});
+
+/**
+ * @swagger
+ * /api/transactions/{id}/status:
+ *   patch:
+ *     summary: Update transaction status
+ *     description: Updates the status of a transaction and emits a real-time WebSocket event.
+ *     tags: [Transactions]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Transaction ID
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - status
+ *             properties:
+ *               status:
+ *                 type: string
+ *                 enum: [PENDING, COMPLETED, FAILED]
+ *     responses:
+ *       200:
+ *         description: Transaction status updated successfully
+ *       401:
+ *         description: Unauthorized
+ *       404:
+ *         description: Transaction not found
+ */
+router.patch('/:id/status', authMiddleware, validate({ body: statusUpdateSchema }), async (req: AuthRequest, res: Response) => {
+  const { id } = req.params;
+  const { status } = req.body as { status: string };
+  const publicKey = req.user!.publicKey;
+
+  try {
+    const user = await prisma.user.findUnique({ where: { publicKey } });
+    if (!user) {
+      return res.status(404).json({ status: 'error', message: 'User not found' });
+    }
+
+    const existing = await prisma.transaction.findFirst({ where: { id, userId: user.id } });
+    if (!existing) {
+      return res.status(404).json({ status: 'error', message: 'Transaction not found' });
+    }
+
+    const tx = await prisma.transaction.update({
+      where: { id },
+      data: { status },
+    });
+
+    emitTxUpdated({ id: tx.id, status: tx.status, assetCode: tx.assetCode, amount: tx.amount, type: tx.type });
+
+    return res.json({ status: 'success', data: tx });
+  } catch (error) {
+    console.error('Error updating transaction status:', error);
+    return res.status(500).json({ status: 'error', message: 'Failed to update transaction status' });
   }
 });
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,3 +1,4 @@
+import http from 'http';
 import express, { Request, Response } from 'express';
 import cors from 'cors';
 import swaggerUi from 'swagger-ui-express';
@@ -36,6 +37,7 @@ import prisma from './lib/prisma';
 import { redis } from './lib/redis';
 import { validateStorageConfigOnStartup } from './services/storage-provider.service';
 import { uploadExpiryScheduler } from './workers/upload-expiry.scheduler';
+import { initSocket } from './lib/socket';
 
 // Initialize Notification Engine
 notificationService.registerProvider(NotificationType.EMAIL, createEmailProvider());
@@ -43,6 +45,7 @@ notificationService.registerProvider(NotificationType.SMS, new ConsoleSmsProvide
 notificationService.registerProvider(NotificationType.PUSH, new ConsolePushProvider());
 
 const app = express();
+const httpServer = http.createServer(app);
 app.disable('x-powered-by');
 app.use(securityHeadersMiddleware);
 const PORT = config.PORT;
@@ -279,7 +282,8 @@ if (process.env.NODE_ENV !== 'test') {
       logger.error('Failed to initialize config service:', error);
     })
     .finally(() => {
-      app.listen(PORT, () => {
+      initSocket(httpServer);
+      httpServer.listen(PORT, () => {
         logger.info(`Backend service listening at http://localhost:${PORT}`);
         logger.info(`API Documentation available at http://localhost:${PORT}/api-docs`);
         feeReportScheduler.start();

--- a/backend/src/lib/socket.ts
+++ b/backend/src/lib/socket.ts
@@ -1,0 +1,39 @@
+import { Server as HttpServer } from 'http';
+import { Server as SocketServer, Socket } from 'socket.io';
+import { verifyToken } from '../services/auth.service';
+import logger from '../utils/logger';
+
+let io: SocketServer | null = null;
+
+export function initSocket(httpServer: HttpServer): SocketServer {
+  io = new SocketServer(httpServer, {
+    cors: { origin: '*', methods: ['GET', 'POST'] },
+  });
+
+  io.use((socket, next) => {
+    const token = socket.handshake.auth?.token;
+    if (!token) return next(new Error('Authentication required'));
+    try {
+      const user = verifyToken(token);
+      (socket as any).user = user;
+      next();
+    } catch {
+      next(new Error('Invalid token'));
+    }
+  });
+
+  io.on('connection', (socket: Socket) => {
+    logger.info('WebSocket client connected', { id: socket.id });
+    socket.on('disconnect', () => logger.info('WebSocket client disconnected', { id: socket.id }));
+  });
+
+  return io;
+}
+
+export function emitTxUpdated(payload: { id: string; status: string; [key: string]: unknown }): void {
+  io?.emit('tx_updated', payload);
+}
+
+export function getIo(): SocketServer | null {
+  return io;
+}


### PR DESCRIPTION
## Summary

Integrates Socket.io to push `tx_updated` events to connected dashboards whenever a transaction status changes.

## Changes

- `backend/src/lib/socket.ts` (new) — `initSocket(httpServer)`, `emitTxUpdated(payload)`, JWT auth middleware on connection
- `backend/src/index.ts` — wraps Express in `http.createServer`, calls `initSocket`, listens on `httpServer`
- `backend/src/api/routes/transactions.route.ts` — new `PATCH /api/transactions/:id/status` endpoint that updates DB and emits `tx_updated`
- `backend/package.json` — added `socket.io ^4.8.1` (run `npm install` after merging)

Closes #747