### PR TITLE
[Backend] Stellar Wave — upload expiry, MIME validation, WebSocket tx status, migration rollback

### DIFF
--- a/backend/docs/MIGRATION_INTEGRITY.md
+++ b/backend/docs/MIGRATION_INTEGRITY.md
@@ -294,6 +294,98 @@ Before deploying migrations to production:
 - [ ] Monitoring alerts configured
 - [ ] Maintenance window scheduled (if needed)
 
+## Rollback Verification Procedure
+
+### Overview
+
+`backend/scripts/rollback.ts` is a dedicated rollback verification script that checks **foreign key integrity before applying a rollback**. It is distinct from `generate-rollback.ts` (which only generates the SQL file) — this script validates, reports, and then applies the rollback.
+
+### How It Works
+
+1. **Locate rollback SQL** — finds `rollback.sql` in the target migration directory. If it does not exist, it auto-generates one using `RollbackGenerator`.
+2. **Parse DROP TABLE statements** — extracts tables that would be removed by the rollback.
+3. **FK impact analysis** — for every table referencing a to-be-dropped table, counts rows that would become orphaned:
+   - Uses `PRAGMA foreign_key_list(table)` to discover FK relationships.
+   - Uses `PRAGMA foreign_key_check` to surface any pre-existing violations.
+4. **Print integrity report** — categorises each FK reference as **safe** (0 referencing rows) or **blocking** (≥1 orphaned rows).
+5. **Confirm before applying** — prompts for `y/N` unless `--force` is passed.
+6. **Apply rollback** — executes each SQL statement via Prisma's `$executeRawUnsafe`.
+
+### Usage
+
+```bash
+# Rollback the latest migration (interactive confirmation)
+npm run migrate:rollback:verify
+
+# Rollback a specific migration
+npm run migrate:rollback:verify -- 20240101_add_user_table
+
+# Dry-run: check FKs but do NOT apply
+npm run migrate:rollback:verify -- --dry-run
+
+# Skip confirmation prompt (CI / emergency)
+npm run migrate:rollback:verify -- --force
+```
+
+### Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| `0`  | Rollback applied (or dry-run passed) |
+| `1`  | FK violations found and `--force` not set, or rollback SQL execution failed |
+
+### Example Output
+
+```
+🔍 Migration Rollback Verifier
+============================================================
+
+📁 Target migration: 20240101000000_add_orders
+📄 Rollback SQL: prisma/migrations/20240101000000_add_orders/rollback.sql
+🗑  Tables to be dropped: Order
+
+🔎 Checking foreign key integrity...
+
+============================================================
+  Foreign Key Integrity Report
+============================================================
+
+✅ No pre-existing FK violations in current database state.
+
+❌ FK violations that WILL occur after rollback (1):
+   • OrderItem.orderId → Order.id (42 referencing rows)
+
+   ⚠️  These rows will have dangling foreign key references after the rollback.
+   ⚠️  Consider cleaning up referencing rows before rolling back,
+       or use --force to apply anyway (NOT recommended for production).
+============================================================
+
+❌ FK violations detected. Use --force to apply anyway (may break referential integrity).
+```
+
+### CD Pipeline Integration
+
+Add rollback verification as a pre-gate in your CD pipeline:
+
+```yaml
+# .github/workflows/cd.yml
+- name: Verify rollback safety
+  run: npm run migrate:rollback:verify -- --dry-run
+  working-directory: backend
+  env:
+    DATABASE_URL: ${{ secrets.DATABASE_URL }}
+```
+
+Use `--dry-run` in CI so the step reports FK risk without mutating the database. Treat exit code `1` as a deployment blocker until the team reviews and resolves the FK dependencies.
+
+### Relationship Between Migration Scripts
+
+| Script | npm command | Purpose |
+|--------|-------------|---------|
+| `generate-rollback.ts` | `migrate:rollback` | Generate `rollback.sql` from forward migration SQL |
+| `rollback.ts` | `migrate:rollback:verify` | Verify FK integrity **and** apply rollback |
+| `migration-integrity-checker.ts` | `migrate:check` | Full pre-deploy integrity suite |
+
 ## Support
 
 For issues or questions:

--- a/backend/package.json
+++ b/backend/package.json
@@ -26,6 +26,7 @@
     "migrate:verify": "ts-node scripts/verify-migrations.ts",
     "migrate:check": "ts-node scripts/migration-integrity-checker.ts",
     "migrate:rollback": "ts-node scripts/generate-rollback.ts",
+    "migrate:rollback:verify": "ts-node scripts/rollback.ts",
     "migrate:status": "prisma migrate status",
     "migrate:validate-env": "node scripts/validate-migration-env.js",
     "migrate:bootstrap": "bash scripts/bootstrap-db.sh",

--- a/backend/package.json
+++ b/backend/package.json
@@ -71,6 +71,7 @@
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1",
     "uuid": "^9.0.0",
+    "socket.io": "^4.8.1",
     "vite": "^6.4.3",
     "winston": "^3.19.0",
     "zod": "^4.3.6"

--- a/backend/prisma/migrations/20260728000000_add_upload_record_expiry/migration.sql
+++ b/backend/prisma/migrations/20260728000000_add_upload_record_expiry/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable: add isTemporary flag to support TTL expiry scheduler
+ALTER TABLE "UploadRecord" ADD COLUMN "isTemporary" BOOLEAN NOT NULL DEFAULT true;
+
+-- CreateIndex: composite index for efficient expiry queries
+CREATE INDEX "UploadRecord_isTemporary_status_createdAt_idx" ON "UploadRecord"("isTemporary", "status", "createdAt");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -427,3 +427,16 @@ model CrawlJobRecord {
   nonCompliantCount Int
   suspiciousCount   Int
 }
+
+model UploadRecord {
+  id          String   @id @default(uuid())
+  key         String   @unique
+  contentType String
+  status      String   @default("PENDING")
+  isTemporary Boolean  @default(true)
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  @@index([status])
+  @@index([isTemporary, status, createdAt])
+}

--- a/backend/scripts/rollback.ts
+++ b/backend/scripts/rollback.ts
@@ -1,0 +1,356 @@
+#!/usr/bin/env ts-node
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as readline from 'readline';
+import { PrismaClient } from '@prisma/client';
+import RollbackGenerator from './generate-rollback';
+
+/**
+ * Rollback Verification Script
+ *
+ * Checks foreign key integrity BEFORE applying a rollback SQL file.
+ * Usage:
+ *   ts-node scripts/rollback.ts [migration_name] [--force] [--dry-run]
+ *
+ * Options:
+ *   migration_name  Target migration directory name (defaults to latest)
+ *   --force         Skip confirmation prompt and apply even with FK violations
+ *   --dry-run       Report FK check results without applying the rollback
+ */
+
+interface FKViolation {
+  referencingTable: string;
+  referencingColumn: string;
+  referencedTable: string;
+  referencedColumn: string;
+  affectedRowCount: number;
+}
+
+interface FKRow {
+  id: number;
+  seq: number;
+  table: string;
+  from: string;
+  to: string;
+  on_update: string;
+  on_delete: string;
+  match: string;
+}
+
+interface TableRow {
+  name: string;
+}
+
+interface CountRow {
+  count: number;
+}
+
+class RollbackVerifier {
+  private prisma: PrismaClient;
+  private migrationsDir: string;
+
+  constructor() {
+    this.prisma = new PrismaClient();
+    this.migrationsDir = path.join(__dirname, '../prisma/migrations');
+  }
+
+  async run(migrationName?: string, force = false, dryRun = false): Promise<void> {
+    console.log('🔍 Migration Rollback Verifier\n' + '='.repeat(60));
+
+    try {
+      // 1. Resolve migration and locate/generate rollback.sql
+      const resolvedMigration = this.resolveMigration(migrationName);
+      if (!resolvedMigration) {
+        console.error('❌ No migrations found.');
+        process.exit(1);
+      }
+
+      console.log(`\n📁 Target migration: ${resolvedMigration}`);
+      const rollbackSqlPath = await this.ensureRollbackSql(resolvedMigration);
+
+      const rollbackSql = fs.readFileSync(rollbackSqlPath, 'utf-8');
+      console.log(`📄 Rollback SQL: ${rollbackSqlPath}`);
+
+      // 2. Parse which tables will be dropped/altered by the rollback
+      const droppedTables = this.extractDroppedTables(rollbackSql);
+      if (droppedTables.length > 0) {
+        console.log(`\n🗑  Tables to be dropped: ${droppedTables.join(', ')}`);
+      }
+
+      // 3. Check FK integrity
+      console.log('\n🔎 Checking foreign key integrity...');
+      const violations = await this.checkForeignKeyViolations(droppedTables);
+      const existingViolations = await this.checkExistingFKViolations();
+
+      this.printIntegrityReport(violations, existingViolations, droppedTables);
+
+      const hasBlockingViolations = violations.some(v => v.affectedRowCount > 0);
+
+      if (dryRun) {
+        console.log('\n🧪 Dry-run mode — rollback SQL was NOT applied.');
+        process.exit(hasBlockingViolations ? 1 : 0);
+      }
+
+      // 4. Confirm before applying
+      if (hasBlockingViolations && !force) {
+        console.log('\n❌ FK violations detected. Use --force to apply anyway (may break referential integrity).');
+        process.exit(1);
+      }
+
+      if (!force) {
+        const confirmed = await this.confirm(
+          `\n⚠️  Apply rollback for migration "${resolvedMigration}"? [y/N] `
+        );
+        if (!confirmed) {
+          console.log('Aborted.');
+          process.exit(0);
+        }
+      } else {
+        console.log('\n⚡ --force flag set — skipping confirmation prompt.');
+      }
+
+      // 5. Apply rollback SQL
+      await this.applyRollback(rollbackSql);
+      console.log('\n✅ Rollback applied successfully.');
+    } finally {
+      await this.prisma.$disconnect();
+    }
+  }
+
+  /**
+   * Resolve the target migration name (latest if not specified).
+   */
+  private resolveMigration(name?: string): string | null {
+    if (!fs.existsSync(this.migrationsDir)) return null;
+
+    const migrations = fs
+      .readdirSync(this.migrationsDir)
+      .filter(f => {
+        const full = path.join(this.migrationsDir, f);
+        return fs.statSync(full).isDirectory() && f !== 'migration_lock.toml';
+      })
+      .sort();
+
+    if (migrations.length === 0) return null;
+
+    if (name) {
+      if (!migrations.includes(name)) {
+        console.error(`❌ Migration not found: ${name}`);
+        console.error(`   Available: ${migrations.slice(-5).join(', ')}`);
+        process.exit(1);
+      }
+      return name;
+    }
+
+    return migrations[migrations.length - 1];
+  }
+
+  /**
+   * Ensure rollback.sql exists for the target migration, generating it if missing.
+   */
+  private async ensureRollbackSql(migrationName: string): Promise<string> {
+    const migrationPath = path.join(this.migrationsDir, migrationName);
+    const rollbackPath = path.join(migrationPath, 'rollback.sql');
+
+    if (!fs.existsSync(rollbackPath)) {
+      console.log('⚙️  rollback.sql not found — generating it now...');
+      const generator = new RollbackGenerator();
+      generator.generateRollback(migrationName);
+
+      if (!fs.existsSync(rollbackPath)) {
+        console.error('❌ Failed to generate rollback.sql');
+        process.exit(1);
+      }
+    }
+
+    return rollbackPath;
+  }
+
+  /**
+   * Extract table names that will be dropped by the rollback SQL.
+   */
+  private extractDroppedTables(sql: string): string[] {
+    const dropped = new Set<string>();
+    const pattern = /DROP\s+TABLE\s+(?:IF\s+EXISTS\s+)?["'`]?(\w+)["'`]?/gi;
+    let m: RegExpExecArray | null;
+    while ((m = pattern.exec(sql)) !== null) {
+      dropped.add(m[1]);
+    }
+    return Array.from(dropped);
+  }
+
+  /**
+   * Check which FK references would break if the given tables are dropped.
+   * Returns violations grouped by (referencingTable, referencedTable).
+   */
+  private async checkForeignKeyViolations(droppedTables: string[]): Promise<FKViolation[]> {
+    if (droppedTables.length === 0) return [];
+
+    // Get all user tables
+    const tables = await this.prisma.$queryRawUnsafe<TableRow[]>(
+      `SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' AND name NOT LIKE '_prisma_%'`
+    );
+
+    const violations: FKViolation[] = [];
+
+    for (const { name: tableName } of tables) {
+      // Get FK list for this table
+      const fks = await this.prisma.$queryRawUnsafe<FKRow[]>(
+        `PRAGMA foreign_key_list("${tableName}")`
+      );
+
+      for (const fk of fks) {
+        if (!droppedTables.includes(fk.table)) continue;
+
+        // Count rows in this table that reference the to-be-dropped table
+        const countResult = await this.prisma.$queryRawUnsafe<CountRow[]>(
+          `SELECT COUNT(*) AS count FROM "${tableName}" WHERE "${fk.from}" IS NOT NULL`
+        );
+        const affectedRowCount = Number(countResult[0]?.count ?? 0);
+
+        violations.push({
+          referencingTable: tableName,
+          referencingColumn: fk.from,
+          referencedTable: fk.table,
+          referencedColumn: fk.to ?? 'id',
+          affectedRowCount,
+        });
+      }
+    }
+
+    return violations;
+  }
+
+  /**
+   * Check for FK violations already present in the database (pre-rollback state).
+   */
+  private async checkExistingFKViolations(): Promise<string[]> {
+    try {
+      const rows = await this.prisma.$queryRawUnsafe<Record<string, unknown>[]>(
+        `PRAGMA foreign_key_check`
+      );
+      return rows.map(r => `${r['table']}(rowid=${r['rowid']}): FK → ${r['parent']}`);
+    } catch {
+      return [];
+    }
+  }
+
+  /**
+   * Print the FK integrity report.
+   */
+  private printIntegrityReport(
+    violations: FKViolation[],
+    existingViolations: string[],
+    droppedTables: string[]
+  ): void {
+    console.log('\n' + '='.repeat(60));
+    console.log('  Foreign Key Integrity Report');
+    console.log('='.repeat(60));
+
+    if (existingViolations.length > 0) {
+      console.log(`\n⚠️  Pre-existing FK violations in database (${existingViolations.length}):`);
+      existingViolations.forEach(v => console.log(`   • ${v}`));
+    } else {
+      console.log('\n✅ No pre-existing FK violations in current database state.');
+    }
+
+    if (droppedTables.length === 0) {
+      console.log('\n✅ No DROP TABLE statements in rollback — no FK impact analysis needed.');
+      console.log('='.repeat(60) + '\n');
+      return;
+    }
+
+    const blocking = violations.filter(v => v.affectedRowCount > 0);
+    const safe = violations.filter(v => v.affectedRowCount === 0);
+
+    if (safe.length > 0) {
+      console.log(`\n✅ Safe FK references (0 referencing rows, no impact):`);
+      safe.forEach(v =>
+        console.log(
+          `   • ${v.referencingTable}.${v.referencingColumn} → ${v.referencedTable}.${v.referencedColumn}`
+        )
+      );
+    }
+
+    if (blocking.length > 0) {
+      console.log(`\n❌ FK violations that WILL occur after rollback (${blocking.length}):`);
+      blocking.forEach(v =>
+        console.log(
+          `   • ${v.referencingTable}.${v.referencingColumn} → ${v.referencedTable}.${v.referencedColumn}` +
+            ` (${v.affectedRowCount} referencing row${v.affectedRowCount !== 1 ? 's' : ''})`
+        )
+      );
+      console.log('\n   ⚠️  These rows will have dangling foreign key references after the rollback.');
+      console.log('   ⚠️  Consider cleaning up referencing rows before rolling back,');
+      console.log('       or use --force to apply anyway (NOT recommended for production).');
+    } else if (violations.length > 0) {
+      console.log('\n✅ All FK references are safe — no rows would be orphaned.');
+    }
+
+    console.log('='.repeat(60) + '\n');
+  }
+
+  /**
+   * Apply rollback SQL statements one by one.
+   */
+  private async applyRollback(sql: string): Promise<void> {
+    console.log('\n🚀 Applying rollback SQL...');
+
+    const statements = sql
+      .split(';')
+      .map(s => s.trim())
+      .filter(s => s.length > 0 && !s.startsWith('--'));
+
+    let applied = 0;
+    for (const stmt of statements) {
+      // Skip pure-comment blocks
+      const nonComment = stmt
+        .split('\n')
+        .filter(l => !l.trim().startsWith('--'))
+        .join('\n')
+        .trim();
+      if (!nonComment) continue;
+
+      try {
+        await this.prisma.$executeRawUnsafe(nonComment);
+        applied++;
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error(`\n❌ Failed to execute statement:\n   ${nonComment}\n   Error: ${msg}`);
+        throw err;
+      }
+    }
+
+    console.log(`   Applied ${applied} statement${applied !== 1 ? 's' : ''}.`);
+  }
+
+  /**
+   * Prompt the user for a yes/no confirmation.
+   */
+  private confirm(prompt: string): Promise<boolean> {
+    return new Promise(resolve => {
+      const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+      rl.question(prompt, answer => {
+        rl.close();
+        resolve(answer.toLowerCase() === 'y' || answer.toLowerCase() === 'yes');
+      });
+    });
+  }
+}
+
+// CLI entry point
+if (require.main === module) {
+  const args = process.argv.slice(2);
+  const force = args.includes('--force');
+  const dryRun = args.includes('--dry-run');
+  const migrationName = args.find(a => !a.startsWith('--'));
+
+  const verifier = new RollbackVerifier();
+  verifier.run(migrationName, force, dryRun).catch(err => {
+    console.error('Fatal error:', err);
+    process.exit(1);
+  });
+}
+
+export default RollbackVerifier;

--- a/backend/src/api/routes/transactions.route.ts
+++ b/backend/src/api/routes/transactions.route.ts
@@ -5,6 +5,7 @@ import { authMiddleware, AuthRequest } from '../middleware/auth.middleware';
 import { validate } from '../middleware/validate.middleware';
 import { stellarService } from '../../services/stellar.service';
 import { submissionLimiter } from '../middleware/rate-limit.middleware';
+import { emitTxUpdated } from '../../lib/socket';
 
 
 const router = Router();
@@ -270,6 +271,76 @@ router.post('/submit', authMiddleware, submissionLimiter, validate({ body: submi
       status: 'error',
       message: error.message,
     });
+  }
+});
+
+const statusUpdateSchema = z.object({
+  status: z.enum(['PENDING', 'COMPLETED', 'FAILED']),
+});
+
+/**
+ * @swagger
+ * /api/transactions/{id}/status:
+ *   patch:
+ *     summary: Update transaction status
+ *     description: Updates the status of a transaction and emits a real-time WebSocket event.
+ *     tags: [Transactions]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Transaction ID
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - status
+ *             properties:
+ *               status:
+ *                 type: string
+ *                 enum: [PENDING, COMPLETED, FAILED]
+ *     responses:
+ *       200:
+ *         description: Transaction status updated successfully
+ *       401:
+ *         description: Unauthorized
+ *       404:
+ *         description: Transaction not found
+ */
+router.patch('/:id/status', authMiddleware, validate({ body: statusUpdateSchema }), async (req: AuthRequest, res: Response) => {
+  const { id } = req.params;
+  const { status } = req.body as { status: string };
+  const publicKey = req.user!.publicKey;
+
+  try {
+    const user = await prisma.user.findUnique({ where: { publicKey } });
+    if (!user) {
+      return res.status(404).json({ status: 'error', message: 'User not found' });
+    }
+
+    const existing = await prisma.transaction.findFirst({ where: { id, userId: user.id } });
+    if (!existing) {
+      return res.status(404).json({ status: 'error', message: 'Transaction not found' });
+    }
+
+    const tx = await prisma.transaction.update({
+      where: { id },
+      data: { status },
+    });
+
+    emitTxUpdated({ id: tx.id, status: tx.status, assetCode: tx.assetCode, amount: tx.amount, type: tx.type });
+
+    return res.json({ status: 'success', data: tx });
+  } catch (error) {
+    console.error('Error updating transaction status:', error);
+    return res.status(500).json({ status: 'error', message: 'Failed to update transaction status' });
   }
 });
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,3 +1,4 @@
+import http from 'http';
 import express, { Request, Response } from 'express';
 import cors from 'cors';
 import swaggerUi from 'swagger-ui-express';
@@ -36,6 +37,7 @@ import prisma from './lib/prisma';
 import { redis } from './lib/redis';
 import { validateStorageConfigOnStartup } from './services/storage-provider.service';
 import { uploadExpiryScheduler } from './workers/upload-expiry.scheduler';
+import { initSocket } from './lib/socket';
 
 // Initialize Notification Engine
 notificationService.registerProvider(NotificationType.EMAIL, createEmailProvider());
@@ -43,6 +45,7 @@ notificationService.registerProvider(NotificationType.SMS, new ConsoleSmsProvide
 notificationService.registerProvider(NotificationType.PUSH, new ConsolePushProvider());
 
 const app = express();
+const httpServer = http.createServer(app);
 app.disable('x-powered-by');
 app.use(securityHeadersMiddleware);
 const PORT = config.PORT;
@@ -279,7 +282,8 @@ if (process.env.NODE_ENV !== 'test') {
       logger.error('Failed to initialize config service:', error);
     })
     .finally(() => {
-      app.listen(PORT, () => {
+      initSocket(httpServer);
+      httpServer.listen(PORT, () => {
         logger.info(`Backend service listening at http://localhost:${PORT}`);
         logger.info(`API Documentation available at http://localhost:${PORT}/api-docs`);
         feeReportScheduler.start();

--- a/backend/src/lib/socket.ts
+++ b/backend/src/lib/socket.ts
@@ -1,0 +1,39 @@
+import { Server as HttpServer } from 'http';
+import { Server as SocketServer, Socket } from 'socket.io';
+import { verifyToken } from '../services/auth.service';
+import logger from '../utils/logger';
+
+let io: SocketServer | null = null;
+
+export function initSocket(httpServer: HttpServer): SocketServer {
+  io = new SocketServer(httpServer, {
+    cors: { origin: '*', methods: ['GET', 'POST'] },
+  });
+
+  io.use((socket, next) => {
+    const token = socket.handshake.auth?.token;
+    if (!token) return next(new Error('Authentication required'));
+    try {
+      const user = verifyToken(token);
+      (socket as any).user = user;
+      next();
+    } catch {
+      next(new Error('Invalid token'));
+    }
+  });
+
+  io.on('connection', (socket: Socket) => {
+    logger.info('WebSocket client connected', { id: socket.id });
+    socket.on('disconnect', () => logger.info('WebSocket client disconnected', { id: socket.id }));
+  });
+
+  return io;
+}
+
+export function emitTxUpdated(payload: { id: string; status: string; [key: string]: unknown }): void {
+  io?.emit('tx_updated', payload);
+}
+
+export function getIo(): SocketServer | null {
+  return io;
+}

--- a/backend/src/services/storage-provider.service.test.ts
+++ b/backend/src/services/storage-provider.service.test.ts
@@ -1,12 +1,15 @@
 import {
   createStorageProvider,
   GcsStorageProvider,
+  MAX_UPLOAD_SIZE_BYTES,
   MockStorageProvider,
   S3StorageProvider,
   StorageProviderError,
   storageConfigFromEnv,
+  validateKycUpload,
   validateStorageProviderConfig,
   validateStorageConfigOnStartup,
+  validateUploadSize,
 } from './storage-provider.service';
 import logger from '../utils/logger';
 
@@ -221,5 +224,61 @@ describe('StorageProvider initialization', () => {
     it('rejects empty bucket at construction', () => {
       expect(() => new MockStorageProvider('')).toThrow('STORAGE_BUCKET is required');
     });
+  });
+});
+
+describe('validateUploadSize', () => {
+  it('accepts files at exactly the 10 MB limit', () => {
+    expect(() => validateUploadSize(MAX_UPLOAD_SIZE_BYTES)).not.toThrow();
+  });
+
+  it('accepts files smaller than 10 MB', () => {
+    expect(() => validateUploadSize(5 * 1024 * 1024)).not.toThrow();
+  });
+
+  it('rejects files larger than 10 MB', () => {
+    expect(() => validateUploadSize(MAX_UPLOAD_SIZE_BYTES + 1)).toThrow(StorageProviderError);
+    expect(() => validateUploadSize(MAX_UPLOAD_SIZE_BYTES + 1)).toThrow('exceeds the maximum allowed size');
+  });
+});
+
+describe('validateKycUpload', () => {
+  const jpeg = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]);
+  const png  = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a]);
+  const pdf  = Buffer.from([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31]); // %PDF-1
+
+  it('accepts a valid JPEG buffer declared as image/jpeg', () => {
+    expect(() => validateKycUpload(jpeg, 'image/jpeg')).not.toThrow();
+  });
+
+  it('accepts a valid PNG buffer declared as image/png', () => {
+    expect(() => validateKycUpload(png, 'image/png')).not.toThrow();
+  });
+
+  it('accepts a valid PDF buffer declared as application/pdf', () => {
+    expect(() => validateKycUpload(pdf, 'application/pdf')).not.toThrow();
+  });
+
+  it('rejects a PDF buffer declared as image/jpeg', () => {
+    expect(() => validateKycUpload(pdf, 'image/jpeg')).toThrow(StorageProviderError);
+    expect(() => validateKycUpload(pdf, 'image/jpeg')).toThrow('magic bytes do not match');
+  });
+
+  it('rejects a JPEG buffer declared as image/png', () => {
+    expect(() => validateKycUpload(jpeg, 'image/png')).toThrow(StorageProviderError);
+  });
+
+  it('rejects a JPEG buffer declared as application/pdf', () => {
+    expect(() => validateKycUpload(jpeg, 'application/pdf')).toThrow(StorageProviderError);
+  });
+
+  it('rejects an unsupported MIME type', () => {
+    expect(() => validateKycUpload(jpeg, 'image/gif')).toThrow(StorageProviderError);
+    expect(() => validateKycUpload(jpeg, 'image/gif')).toThrow('Unsupported MIME type');
+  });
+
+  it('rejects a buffer too small to determine type', () => {
+    expect(() => validateKycUpload(Buffer.from([0xff]), 'image/jpeg')).toThrow(StorageProviderError);
+    expect(() => validateKycUpload(Buffer.from([0xff]), 'image/jpeg')).toThrow('too small');
   });
 });

--- a/backend/src/services/storage-provider.service.ts
+++ b/backend/src/services/storage-provider.service.ts
@@ -9,6 +9,8 @@ export interface StorageProvider {
   generatePresignedPutUrl(key: string, contentType: string, expiresInSeconds: number): Promise<string>;
   /** Return true when the object at `key` exists in the bucket. */
   objectExists(key: string): Promise<boolean>;
+  /** Permanently delete the object at `key` from the bucket. */
+  deleteObject(key: string): Promise<void>;
 }
 
 export type StorageProviderKind = 'mock' | 's3' | 'gcs';
@@ -78,6 +80,10 @@ export class MockStorageProvider implements StorageProvider {
     return this.uploadedKeys.has(key);
   }
 
+  async deleteObject(key: string): Promise<void> {
+    this.uploadedKeys.delete(key);
+  }
+
   /** Test helper: simulate a completed upload for a key. */
   _markUploaded(key: string): void {
     this.uploadedKeys.add(key);
@@ -105,6 +111,10 @@ export class S3StorageProvider implements StorageProvider {
   async objectExists(_key: string): Promise<boolean> {
     return false;
   }
+
+  async deleteObject(_key: string): Promise<void> {
+    // S3 stub: real deletion would use DeleteObjectCommand
+  }
 }
 
 /** Google Cloud Storage implementation of StorageProvider. */
@@ -125,6 +135,10 @@ export class GcsStorageProvider implements StorageProvider {
 
   async objectExists(_key: string): Promise<boolean> {
     return false;
+  }
+
+  async deleteObject(_key: string): Promise<void> {
+    // GCS stub: real deletion would use storage.bucket().file(key).delete()
   }
 }
 

--- a/backend/src/services/storage-provider.service.ts
+++ b/backend/src/services/storage-provider.service.ts
@@ -1,5 +1,48 @@
 import logger from '../utils/logger';
 
+export const MAX_UPLOAD_SIZE_BYTES = 10 * 1024 * 1024; // 10 MB
+
+const MAGIC_BYTES: Record<string, { bytes: number[]; offset?: number }> = {
+  'image/jpeg': { bytes: [0xff, 0xd8, 0xff] },
+  'image/png':  { bytes: [0x89, 0x50, 0x4e, 0x47] },
+  'application/pdf': { bytes: [0x25, 0x50, 0x44, 0x46] }, // %PDF
+};
+
+/**
+ * Throws a StorageProviderError when `size` exceeds MAX_UPLOAD_SIZE_BYTES.
+ */
+export function validateUploadSize(size: number): void {
+  if (size > MAX_UPLOAD_SIZE_BYTES) {
+    throw new StorageProviderError(
+      `File size ${size} bytes exceeds the maximum allowed size of ${MAX_UPLOAD_SIZE_BYTES} bytes (10 MB)`
+    );
+  }
+}
+
+/**
+ * Verifies that `buffer`'s magic bytes match `declaredMimeType`.
+ * Throws a StorageProviderError for unsupported or mismatched MIME types.
+ */
+export function validateKycUpload(buffer: Buffer, declaredMimeType: string): void {
+  const expected = MAGIC_BYTES[declaredMimeType];
+  if (!expected) {
+    throw new StorageProviderError(
+      `Unsupported MIME type: ${declaredMimeType}. Allowed: ${Object.keys(MAGIC_BYTES).join(', ')}`
+    );
+  }
+  if (buffer.length < expected.bytes.length) {
+    throw new StorageProviderError(
+      `File too small to determine type for declared MIME type: ${declaredMimeType}`
+    );
+  }
+  const matches = expected.bytes.every((byte, i) => buffer[i] === byte);
+  if (!matches) {
+    throw new StorageProviderError(
+      `File magic bytes do not match declared MIME type: ${declaredMimeType}. The file may be masquerading as a different type.`
+    );
+  }
+}
+
 /**
  * Provider-agnostic interface for cloud object storage.
  * Implementations exist for S3 and GCS; the mock is used in development/test.

--- a/backend/src/services/upload-store.service.ts
+++ b/backend/src/services/upload-store.service.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'crypto';
 import { generateStorageKey } from '../utils/storage-key';
 
-export type UploadStatus = 'PENDING' | 'COMPLETED' | 'EXPIRED';
+export type UploadStatus = 'PENDING' | 'COMPLETED' | 'EXPIRED' | 'EXPIRED_DELETED';
 
 export interface UploadRecord {
   uploadId: string;

--- a/backend/src/workers/upload-expiry.scheduler.ts
+++ b/backend/src/workers/upload-expiry.scheduler.ts
@@ -1,20 +1,31 @@
 import cron, { ScheduledTask } from 'node-cron';
 import { uploadStore } from '../services/upload-store.service';
+import { storageProvider } from '../services/storage-provider.service';
+import prisma from '../lib/prisma';
 import logger from '../utils/logger';
+
+const TTL_DAYS = 30;
 
 export class UploadExpiryScheduler {
   private task: ScheduledTask | null = null;
 
   start(): void {
     // Run every minute to expire stale uploads
-    this.task = cron.schedule('* * * * *', () => {
+    this.task = cron.schedule('* * * * *', async () => {
       try {
+        // In-memory fallback expiry
         const expiredCount = uploadStore.expireStale();
         if (expiredCount > 0) {
-          logger.info(`Expired ${expiredCount} stale KYC upload records`);
+          logger.info(`Expired ${expiredCount} stale KYC upload records (in-memory)`);
         }
       } catch (error) {
-        logger.error('Failed to run upload expiry task', { error });
+        logger.error('Failed to run in-memory upload expiry task', { error });
+      }
+
+      try {
+        await this.expireDbUploads();
+      } catch (error) {
+        logger.error('Failed to run DB upload expiry task', { error });
       }
     });
 
@@ -27,6 +38,43 @@ export class UploadExpiryScheduler {
       this.task = null;
     }
     logger.info('Upload expiry scheduler stopped');
+  }
+
+  /** Query DB for temporary uploads older than TTL_DAYS and delete them from storage. */
+  async expireDbUploads(): Promise<number> {
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - TTL_DAYS);
+
+    const records = await (prisma as any).uploadRecord.findMany({
+      where: {
+        isTemporary: true,
+        status: { not: 'EXPIRED_DELETED' },
+        createdAt: { lt: cutoff },
+      },
+      select: { id: true, key: true },
+    });
+
+    if (records.length === 0) return 0;
+
+    let deleted = 0;
+    for (const record of records) {
+      try {
+        await storageProvider.deleteObject(record.key);
+        await (prisma as any).uploadRecord.update({
+          where: { id: record.id },
+          data: { status: 'EXPIRED_DELETED' },
+        });
+        deleted++;
+      } catch (error) {
+        logger.error('Failed to expire upload record', { id: record.id, key: record.key, error });
+      }
+    }
+
+    if (deleted > 0) {
+      logger.info(`Expired and deleted ${deleted} temporary upload records from storage`);
+    }
+
+    return deleted;
   }
 }
 


### PR DESCRIPTION
## Summary

Covers four Stellar Wave backend issues.

---

### #740 — TTL expiry scheduler for temporary document uploads

- `storage-provider.service.ts`: added `deleteObject(key)` to interface + Mock/S3/GCS implementations
- `upload-store.service.ts`: added `EXPIRED_DELETED` status
- `upload-expiry.scheduler.ts`: added `expireDbUploads()` — queries DB for `isTemporary=true` records >30 days old, deletes from storage, marks `EXPIRED_DELETED`; keeps in-memory fallback
- `prisma/schema.prisma`: added `isTemporary` flag and composite index
- Migration SQL included

Closes #740

---

### #746 — Strict MIME-type validation for KYC uploads

- `storage-provider.service.ts`: `MAX_UPLOAD_SIZE_BYTES`, `validateUploadSize(size)`, `validateKycUpload(buffer, declaredMimeType)` — checks magic bytes (JPEG `ff d8 ff`, PNG `89 50 4e 47`, PDF `%PDF`)
- 11 new tests covering valid types, mismatched MIME, unsupported types, size limits

Closes #746

---

### #747 — WebSocket server for real-time transaction status

- `backend/src/lib/socket.ts` (new): `initSocket(httpServer)`, `emitTxUpdated(payload)`, JWT auth middleware
- `backend/src/index.ts`: wraps Express in `http.createServer`, calls `initSocket`, listens on `httpServer`
- `backend/src/api/routes/transactions.route.ts`: `PATCH /api/transactions/:id/status` updates DB and emits `tx_updated`
- `package.json`: added `socket.io ^4.8.1` (run `npm install` after merging)

Closes #747

---

### #749 — Migration rollback with FK integrity verification

- `backend/scripts/rollback.ts` (new): `RollbackVerifier` — checks FK violations via `PRAGMA foreign_key_check`, prints report, applies rollback; supports `--force` and `--dry-run`
- `package.json`: added `migrate:rollback:verify` script
- `docs/MIGRATION_INTEGRITY.md`: added Rollback Verification Procedure section

Closes #749