### PR TITLE
Fix 4 dashboard UX gaps (upload retry, copy buttons, error boundary, exporter)

### DIFF
--- a/dashboard/src/components/Common/CopyButton.tsx
+++ b/dashboard/src/components/Common/CopyButton.tsx
@@ -1,0 +1,61 @@
+import { useEffect, useState } from 'react';
+import { Check, Copy } from 'lucide-react';
+
+interface CopyButtonProps {
+  value: string;
+  label: string;
+  className?: string;
+}
+
+const COPY_RESET_MS = 2000;
+
+export const CopyButton = ({ value, label, className = '' }: CopyButtonProps) => {
+  const [copyState, setCopyState] = useState<'idle' | 'copied' | 'failed'>('idle');
+
+  useEffect(() => {
+    if (copyState === 'idle') return undefined;
+
+    const timeoutId = window.setTimeout(() => setCopyState('idle'), COPY_RESET_MS);
+    return () => window.clearTimeout(timeoutId);
+  }, [copyState]);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopyState('copied');
+    } catch {
+      setCopyState('failed');
+    }
+  };
+
+  return (
+    <span className="relative inline-flex items-center">
+      <button
+        type="button"
+        onClick={handleCopy}
+        aria-label={`Copy ${label.toLowerCase()}`}
+        className={`shrink-0 rounded-md p-1 text-slate-400 transition-colors hover:bg-slate-800 hover:text-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 ${className}`}
+      >
+        {copyState === 'copied' ? (
+          <Check size={14} className="text-emerald-400" aria-hidden="true" />
+        ) : (
+          <Copy size={14} aria-hidden="true" />
+        )}
+      </button>
+      {copyState === 'copied' && (
+        <span
+          role="status"
+          className="absolute -top-8 left-1/2 -translate-x-1/2 whitespace-nowrap rounded-md border border-slate-700 bg-slate-900 px-2 py-1 text-[10px] font-medium text-emerald-400 shadow-lg"
+        >
+          Copied!
+        </span>
+      )}
+      <span className="sr-only" aria-live="polite">
+        {copyState === 'copied' ? `${label} copied to clipboard.` : ''}
+        {copyState === 'failed' ? `Unable to copy ${label.toLowerCase()}.` : ''}
+      </span>
+    </span>
+  );
+};
+
+export default CopyButton;

--- a/dashboard/src/components/GlobalErrorBoundary.tsx
+++ b/dashboard/src/components/GlobalErrorBoundary.tsx
@@ -1,5 +1,5 @@
 import React, { Component, ReactNode, ErrorInfo } from 'react';
-import { AlertTriangle, RefreshCcw } from 'lucide-react';
+import { AlertTriangle, RefreshCcw, Copy, Check } from 'lucide-react';
 
 interface Props {
   children?: ReactNode;
@@ -8,24 +8,44 @@ interface Props {
 interface State {
   hasError: boolean;
   error: Error | null;
+  errorInfo: ErrorInfo | null;
+  copied: boolean;
 }
 
 export class GlobalErrorBoundary extends Component<Props, State> {
   public state: State = {
     hasError: false,
     error: null,
+    errorInfo: null,
+    copied: false,
   };
 
-  public static getDerivedStateFromError(error: Error): State {
+  public static getDerivedStateFromError(error: Error): Partial<State> {
     return { hasError: true, error };
   }
 
   public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     console.error('Uncaught error:', error, errorInfo);
+    this.setState({ errorInfo });
   }
 
   private handleReload = () => {
     window.location.reload();
+  };
+
+  private handleCopyStackTrace = async () => {
+    const { error, errorInfo } = this.state;
+    const stackTrace = [error?.stack ?? error?.toString(), errorInfo?.componentStack]
+      .filter(Boolean)
+      .join('\n\nComponent Stack:');
+
+    try {
+      await navigator.clipboard.writeText(stackTrace);
+      this.setState({ copied: true });
+      window.setTimeout(() => this.setState({ copied: false }), 2000);
+    } catch {
+      /* clipboard not available */
+    }
   };
 
   public render() {
@@ -52,13 +72,22 @@ export class GlobalErrorBoundary extends Component<Props, State> {
               </div>
             )}
             
-            <button
-              onClick={this.handleReload}
-              className="action-button mt-6 flex items-center justify-center gap-2 bg-blue-600 text-white px-6 py-2.5 rounded-lg font-medium hover:bg-blue-500 hover:shadow-lg hover:shadow-blue-500/20 w-full sm:w-auto border border-blue-500"
-            >
-              <RefreshCcw size={18} />
-              Reload Application
-            </button>
+            <div className="mt-6 flex w-full flex-col gap-3 sm:w-auto sm:flex-row">
+              <button
+                onClick={this.handleReload}
+                className="action-button flex items-center justify-center gap-2 bg-blue-600 text-white px-6 py-2.5 rounded-lg font-medium hover:bg-blue-500 hover:shadow-lg hover:shadow-blue-500/20 w-full sm:w-auto border border-blue-500"
+              >
+                <RefreshCcw size={18} />
+                Reload Application
+              </button>
+              <button
+                onClick={this.handleCopyStackTrace}
+                className="action-button flex items-center justify-center gap-2 bg-slate-800 text-slate-200 px-6 py-2.5 rounded-lg font-medium hover:bg-slate-700 w-full sm:w-auto border border-slate-600"
+              >
+                {this.state.copied ? <Check size={18} className="text-emerald-400" /> : <Copy size={18} />}
+                {this.state.copied ? 'Copied!' : 'Copy Error Details'}
+              </button>
+            </div>
           </div>
         </div>
       );

--- a/dashboard/src/components/KycDocumentUpload.tsx
+++ b/dashboard/src/components/KycDocumentUpload.tsx
@@ -116,7 +116,11 @@ export const KycDocumentUpload = ({ apiBaseUrl, account, fields, onComplete }: K
                 accept={field.accept ?? 'image/jpeg,image/png,application/pdf'}
                 className="sr-only"
                 disabled={state.status === 'uploading'}
-                onChange={(e) => handleFileChange(field, e.target.files?.[0])}
+                onChange={(e) => {
+                  const file = e.target.files?.[0];
+                  e.target.value = '';
+                  handleFileChange(field, file);
+                }}
               />
               {state.status === 'complete' && (
                 <CheckCircle2 size={18} className="text-emerald-400" aria-label="Upload complete" />

--- a/dashboard/src/components/TransactionExporter.tsx
+++ b/dashboard/src/components/TransactionExporter.tsx
@@ -1,0 +1,94 @@
+import { Download } from 'lucide-react';
+
+interface ExportableTransaction {
+  id: string;
+  type: string;
+  asset: string;
+  amount: number;
+  status: string;
+  date: string;
+  reference: string;
+}
+
+interface TransactionExporterProps {
+  transactions: ExportableTransaction[];
+  totalCount: number;
+  filters: Record<string, string>;
+}
+
+const CSV_COLUMNS: (keyof ExportableTransaction)[] = ['id', 'type', 'asset', 'amount', 'status', 'date', 'reference'];
+
+const csvEscape = (value: string | number) => {
+  const str = String(value);
+  return /[",\n]/.test(str) ? `"${str.replace(/"/g, '""')}"` : str;
+};
+
+const todayStamp = () => new Date().toISOString().split('T')[0];
+
+const triggerDownload = (content: string, mimeType: string, extension: string) => {
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = `AnchorPoint_Transactions_${todayStamp()}.${extension}`;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+};
+
+const buildMetadataLines = (totalCount: number, filters: Record<string, string>, prefix: string) => {
+  const activeFilters = Object.entries(filters)
+    .filter(([, value]) => value)
+    .map(([key, value]) => `${key}=${value}`)
+    .join('; ');
+
+  return [
+    `${prefix}Exported: ${new Date().toISOString()}`,
+    `${prefix}Total records: ${totalCount}`,
+    `${prefix}Filters: ${activeFilters || 'none'}`,
+  ];
+};
+
+export const TransactionExporter = ({ transactions, totalCount, filters }: TransactionExporterProps) => {
+  const handleExportCsv = () => {
+    const metadata = buildMetadataLines(totalCount, filters, '# ');
+    const header = CSV_COLUMNS.join(',');
+    const rows = transactions.map((tx) => CSV_COLUMNS.map((col) => csvEscape(tx[col])).join(','));
+    const csv = [...metadata, header, ...rows].join('\n');
+    triggerDownload(csv, 'text/csv;charset=utf-8', 'csv');
+  };
+
+  const handleExportJson = () => {
+    const payload = {
+      exportedAt: new Date().toISOString(),
+      totalCount,
+      filters,
+      transactions,
+    };
+    triggerDownload(JSON.stringify(payload, null, 2), 'application/json', 'json');
+  };
+
+  return (
+    <div className="flex items-center gap-2">
+      <button
+        type="button"
+        onClick={handleExportCsv}
+        className="flex items-center gap-1.5 rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-300 transition hover:border-primary/50 hover:text-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
+      >
+        <Download size={14} aria-hidden="true" />
+        CSV
+      </button>
+      <button
+        type="button"
+        onClick={handleExportJson}
+        className="flex items-center gap-1.5 rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-300 transition hover:border-primary/50 hover:text-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
+      >
+        <Download size={14} aria-hidden="true" />
+        JSON
+      </button>
+    </div>
+  );
+};
+
+export default TransactionExporter;

--- a/dashboard/src/components/TransactionHistory.tsx
+++ b/dashboard/src/components/TransactionHistory.tsx
@@ -11,6 +11,7 @@ import {
 } from 'lucide-react';
 import { TransactionStatusBadge } from './TransactionStatusBadge';
 import type { TransactionStatus } from './TransactionStatusBadge';
+import { CopyButton } from './Common/CopyButton';
 
 type TransactionType = 'Deposit' | 'Withdrawal';
 type SortKey = 'type' | 'asset' | 'amount' | 'status' | 'date';
@@ -296,7 +297,12 @@ export const TransactionHistory = () => {
                   <td className="p-4 text-sm text-slate-400" data-label="Date">
                     <time dateTime={tx.date}>{tx.date}</time>
                   </td>
-                  <td className="p-4 font-mono text-xs text-slate-500" data-label="Reference">{tx.reference}</td>
+                  <td className="p-4 font-mono text-xs text-slate-500" data-label="Reference">
+                    <span className="inline-flex items-center gap-1.5">
+                      {tx.reference}
+                      <CopyButton value={tx.reference} label="Transaction reference" />
+                    </span>
+                  </td>
                 </tr>
               ))
             )}

--- a/dashboard/src/components/TransactionHistory.tsx
+++ b/dashboard/src/components/TransactionHistory.tsx
@@ -12,6 +12,7 @@ import {
 import { TransactionStatusBadge } from './TransactionStatusBadge';
 import type { TransactionStatus } from './TransactionStatusBadge';
 import { CopyButton } from './Common/CopyButton';
+import { TransactionExporter } from './TransactionExporter';
 
 type TransactionType = 'Deposit' | 'Withdrawal';
 type SortKey = 'type' | 'asset' | 'amount' | 'status' | 'date';
@@ -216,6 +217,14 @@ export const TransactionHistory = () => {
             ))}
           </select>
         </div>
+      </div>
+
+      <div className="flex justify-end">
+        <TransactionExporter
+          transactions={sorted}
+          totalCount={sorted.length}
+          filters={{ query, status: statusFilter, dateFrom, dateTo }}
+        />
       </div>
 
       <div className="glass-card overflow-x-auto">


### PR DESCRIPTION
Fixes for four dashboard issues from the current batch.

- #583: The KYC upload input already integrated with `/sep12/customer/upload-url` and `/sep12/customer/upload-confirm`, but the file input never cleared its value after a selection, so retrying a failed upload with the same file wouldn't re-trigger the change handler. Reset the input value on selection.
- #756: Added a reusable `CopyButton` component and applied it to transaction references in the history table, which previously had no copy affordance (public keys already had one via `CopyablePublicKey`).
- #757: The `GlobalErrorBoundary` fallback (already wrapping the app in `main.tsx`) was missing the copy-error-details action called for in the issue. Added a button that copies the error message plus component stack to the clipboard.
- #758: Added a `TransactionExporter` component that exports the currently filtered/sorted transaction table as CSV or JSON, including a metadata header with export time, total count, and active filters, and wired it into the transaction history view.

Sanity-checked by reading the affected code paths and tracing data flow manually; this repo's dashboard test suite was not run as part of this change.

Closes #583
Closes #756
Closes #757
Closes #758
