### PR TITLE
[Backend] Add Postgres database connection pooling and SSL configuration

### DIFF
--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -14,6 +14,20 @@ const envSchema = z.object({
     .transform((val: string) => parseInt(val, 10))
     .pipe(z.number().positive()),
   DATABASE_URL: z.string().min(1, 'DATABASE_URL is required').default('file:./prisma/dev.db'),
+  // PostgreSQL connection pool configuration for production high-concurrency workloads.
+  DB_CONNECTION_LIMIT: z
+    .string()
+    .default('20')
+    .transform((val: string) => parseInt(val, 10))
+    .pipe(z.number().int().min(1).max(100)),
+  DB_POOL_TIMEOUT: z
+    .string()
+    .default('10')
+    .transform((val: string) => parseInt(val, 10))
+    .pipe(z.number().int().min(1).max(60)),
+  // SSL mode for PostgreSQL connections. Defaults to 'disable' for safe local
+  // development. Set to 'require' (or stricter) for production deployments.
+  DB_SSL_MODE: z.enum(['require', 'disable', 'allow', 'prefer', 'verify-ca', 'verify-full']).default('disable'),
   JWT_SECRET: z.string().min(8, 'JWT_SECRET must be at least 8 characters').default('stellar-anchor-secret'),
   SEP24_INTERACTIVE_URL_JWT_SECRET: z
     .string()

--- a/backend/src/lib/prisma.ts
+++ b/backend/src/lib/prisma.ts
@@ -6,18 +6,100 @@ if (!process.env.DATABASE_URL) {
 
 import { PrismaClient } from '@prisma/client';
 import { metricsService } from '../services/metrics.service';
+import { config } from '../config/env';
 
 declare global {
   // eslint-disable-next-line no-var
   var __prisma: PrismaClient | undefined;
 }
 
-const prisma = global.__prisma ?? new PrismaClient();
+// ── Connection pool & SSL configuration ──────────────────────────────
+// Append PostgreSQL connection-pool and SSL parameters to DATABASE_URL
+// when running against a PostgreSQL datasource. SQLite URLs are left
+// untouched.
+function buildDatabaseUrl(): string {
+  let url = process.env.DATABASE_URL!;
+
+  // Only decorate PostgreSQL connection strings.
+  if (!url.startsWith('postgresql://') && !url.startsWith('postgres://')) {
+    return url;
+  }
+
+  const params = new URLSearchParams();
+
+  // Connection pool limits (Prisma-level; use pgBouncer / Pgpool for
+  // external pooling in very high-concurrency deployments).
+  params.set('connection_limit', String(config.DB_CONNECTION_LIMIT));
+  params.set('pool_timeout', String(config.DB_POOL_TIMEOUT));
+
+  // SSL mode – configurable per environment. Set to 'require' or stricter
+  // for production deployments.
+  params.set('sslmode', config.DB_SSL_MODE);
+
+  // Merge with any existing query-string params, giving our explicit params
+  // precedence.
+  const urlParts = url.split('?');
+  const baseUrl = urlParts[0];
+  if (urlParts[1]) {
+    const existing = new URLSearchParams(urlParts[1]);
+    for (const [key, value] of existing.entries()) {
+      if (!params.has(key)) {
+        params.set(key, value);
+      }
+    }
+  }
+
+  return `${baseUrl}?${params.toString()}`;
+}
+
+// ── Retry helper ──────────────────────────────────────────────────────
+const MAX_CONNECT_RETRIES = 5;
+const CONNECT_RETRY_BASE_MS = 2_000;
+
+async function connectWithRetry(client: PrismaClient): Promise<void> {
+  for (let attempt = 1; attempt <= MAX_CONNECT_RETRIES; attempt++) {
+    try {
+      await client.$connect();
+      console.log('[Prisma] Successfully connected to database');
+      return;
+    } catch (error) {
+      if (attempt === MAX_CONNECT_RETRIES) {
+        const errMsg =
+          error instanceof Error
+            ? `${error.name}: ${error.message}`
+            : String(error);
+        console.error(
+          `[Prisma] Failed to connect after ${MAX_CONNECT_RETRIES} attempts: ${errMsg}`,
+        );
+        throw error;
+      }
+      // Exponential backoff with jitter.
+      const delay = CONNECT_RETRY_BASE_MS * Math.pow(2, attempt - 1) * (0.5 + Math.random() * 0.5);
+      console.warn(
+        `[Prisma] Connection attempt ${attempt}/${MAX_CONNECT_RETRIES} failed. ` +
+          `Retrying in ${Math.round(delay)}ms...`,
+      );
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
+  }
+}
+
+// ── Client instantiation ──────────────────────────────────────────────
+const databaseUrl = buildDatabaseUrl();
+
+const prismaClientOptions = databaseUrl !== process.env.DATABASE_URL
+  ? { datasources: { db: { url: databaseUrl } } }
+  : {};
+
+const prisma =
+  global.__prisma ??
+  new PrismaClient(prismaClientOptions);
 
 if (process.env.NODE_ENV !== 'production') {
   global.__prisma = prisma;
 }
 
+// ── Metrics middleware ────────────────────────────────────────────────
 type PrismaMiddlewareParams = {
   model?: string;
   action: string;
@@ -38,6 +120,16 @@ if (typeof prismaAny.$use === 'function') {
       const queryType = `${params.model ?? 'raw'}.${params.action}`;
       metricsService.observeDbQuery(queryType, seconds);
     }
+  });
+}
+
+// ── Startup connection retry (production only) ────────────────────────
+// Eagerly verify the database connection on startup so the process fails
+// fast rather than throwing on the first HTTP request.
+if (process.env.NODE_ENV === 'production') {
+  connectWithRetry(prisma).catch((error) => {
+    console.error('[Prisma] Fatal: could not establish database connection', error);
+    process.exit(1);
   });
 }
 


### PR DESCRIPTION
## Summary

Prepares the backend Prisma configuration for high-concurrency production PostgreSQL deployments by adding connection pooling, SSL mode toggles, and startup retry logic.

## Changes

### 1. `backend/src/config/env.ts` — New environment variables

| Variable | Type | Default | Description |
|---|---|---|---|
| `DB_CONNECTION_LIMIT` | int (1–100) | `20` | Max concurrent connections in the Prisma connection pool |
| `DB_POOL_TIMEOUT` | int (1–60) | `10` | Max seconds to wait for a connection from the pool |
| `DB_SSL_MODE` | enum | `disable` | PostgreSQL SSL mode. Set to `require` for production TLS |

### 2. `backend/src/lib/prisma.ts` — Connection pool & retry logic

- **`buildDatabaseUrl()`**: Constructs the final `DATABASE_URL` by appending `connection_limit`, `pool_timeout`, and `sslmode` query parameters when the datasource is PostgreSQL. Existing query params are preserved and our explicit params take precedence. SQLite URLs (`file:`) are passed through unchanged.
- **`connectWithRetry()`**: On production startup, the Prisma client eagerly connects with up to **5 retries** using **exponential backoff with jitter** (base 2s). If all retries fail, the process exits with a clear error message including the error name and message for easier debugging.
- The build output is compared against the original `DATABASE_URL`; the custom datasource URL is only passed to `PrismaClient` when the URL was actually decorated (i.e., PostgreSQL is in use).

## How to Test

1. **Local dev (SQLite)**: No changes — the existing `file:./prisma/dev.db` default continues to work.
2. **PostgreSQL production simulation**: Set `DATABASE_URL=postgresql://user:pass@host:5432/db` and the pool/SSL params are automatically appended.
3. **Connection retry**: Start the backend with an invalid PostgreSQL URL — observe the retry attempts and eventual `process.exit(1)` with a descriptive error.

Closes #718
